### PR TITLE
Snapshots

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -123,6 +123,8 @@ routes = [
     webapp2.Route(_format(r'/api/snapshots/<cont_name:{cont_name_re}>/<cid:{cid_re}>'),                             snapshothandler.SnapshotHandler, name='snap_get', methods=['GET']),
     webapp2.Route(_format(r'/api/snapshots/<par_cont_name:projects>/<par_id:{cid_re}>/<cont_name:sessions>'),       snapshothandler.SnapshotHandler, name='snap_proj_ses', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/snapshots/<par_cont_name:sessions>/<par_id:{cid_re}>/<cont_name:acquisitions>'),   snapshothandler.SnapshotHandler, name='snap_ses_acq', handler_method='get_all', methods=['GET']),
+    webapp2.Route(_format(r'/api/projects/<cid:{cid_re}>/snapshots'),                                               snapshothandler.SnapshotHandler, name='snap_for_proj', handler_method='get_all_for_project', methods=['GET']),
+
 ]
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -124,6 +124,8 @@ routes = [
     webapp2.Route(_format(r'/api/snapshots/<par_cont_name:projects>/<par_id:{cid_re}>/<cont_name:sessions>'),       snapshothandler.SnapshotHandler, name='snap_proj_ses', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/snapshots/<par_cont_name:sessions>/<par_id:{cid_re}>/<cont_name:acquisitions>'),   snapshothandler.SnapshotHandler, name='snap_ses_acq', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/projects/<cid:{cid_re}>/snapshots'),                                               snapshothandler.SnapshotHandler, name='snap_for_proj', handler_method='get_all_for_project', methods=['GET']),
+    webapp2.Route(_format(r'/api/snapshots/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:files>/<name:{filename_re}>'),
+                                                                                                                    snapshothandler.SnapshotFileListHandler, name='snap_files', methods=['GET']),
 
 ]
 

--- a/api/api.py
+++ b/api/api.py
@@ -127,6 +127,8 @@ routes = [
     webapp2.Route(_format(r'/api/snapshots/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:files>/<name:{filename_re}>'),
                                                                                                                     snapshothandler.SnapshotFileListHandler, name='snap_files', methods=['GET']),
 
+    webapp2.Route(r'/api/snapshots/download',         core.Core, handler_method='download_snapshot', methods=['GET', 'POST'], name='download_snapshot'),
+
 ]
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -119,7 +119,7 @@ routes = [
     webapp2.Route(_format(r'/api/snapshots'),                                                                       snapshothandler.SnapshotHandler, name='snap_post', handler_method='create', methods=['POST']),
     webapp2.Route(_format(r'/api/snapshots/<cont_name:projects>'),                                                  snapshothandler.SnapshotHandler, name='snap_proj', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/snapshots/<cont_name:projects>/<cid:{cid_re}>'),                                   snapshothandler.SnapshotHandler, name='snap_delete', handler_method='remove', methods=['DELETE']),
-    webapp2.Route(_format(r'/api/snapshots/<cont_name:projects>/<cid:{cid_re}>/publish'),                           snapshothandler.SnapshotHandler, name='snap_publish', handler_method='publish', methods=['PUT']),
+    webapp2.Route(_format(r'/api/snapshots/<cont_name:projects>/<cid:{cid_re}>/public'),                            snapshothandler.SnapshotHandler, name='snap_publish', handler_method='publish', methods=['PUT']),
     webapp2.Route(_format(r'/api/snapshots/<cont_name:{cont_name_re}>/<cid:{cid_re}>'),                             snapshothandler.SnapshotHandler, name='snap_get', methods=['GET']),
     webapp2.Route(_format(r'/api/snapshots/<par_cont_name:projects>/<par_id:{cid_re}>/<cont_name:sessions>'),       snapshothandler.SnapshotHandler, name='snap_proj_ses', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/snapshots/<par_cont_name:sessions>/<par_id:{cid_re}>/<cont_name:acquisitions>'),   snapshothandler.SnapshotHandler, name='snap_ses_acq', handler_method='get_all', methods=['GET']),

--- a/api/api.py
+++ b/api/api.py
@@ -12,6 +12,7 @@ from handlers import userhandler
 from handlers import grouphandler
 from handlers import containerhandler
 from handlers import collectionshandler
+from handlers import snapshothandler
 
 log = config.log
 
@@ -114,6 +115,14 @@ routes = [
 
     webapp2.Route(_format(r'/api/<par_cont_name:groups>/<par_id:{group_id_re}>/<cont_name:projects>'),          containerhandler.ContainerHandler, name='cont_sublist_groups', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/<par_cont_name:{cont_name_re}>/<par_id:{cid_re}>/<cont_name:{cont_name_re}>'), containerhandler.ContainerHandler, name='cont_sublist', handler_method='get_all', methods=['GET']),
+
+    webapp2.Route(_format(r'/api/snapshots'),                                                                       snapshothandler.SnapshotHandler, name='snap_post', handler_method='create', methods=['POST']),
+    webapp2.Route(_format(r'/api/snapshots/<cont_name:projects>'),                                                  snapshothandler.SnapshotHandler, name='snap_proj', handler_method='get_all', methods=['GET']),
+    webapp2.Route(_format(r'/api/snapshots/<cont_name:projects>/<cid:{cid_re}>'),                                   snapshothandler.SnapshotHandler, name='snap_delete', handler_method='remove', methods=['DELETE']),
+    webapp2.Route(_format(r'/api/snapshots/<cont_name:projects>/<cid:{cid_re}>/publish'),                           snapshothandler.SnapshotHandler, name='snap_publish', handler_method='publish', methods=['PUT']),
+    webapp2.Route(_format(r'/api/snapshots/<cont_name:{cont_name_re}>/<cid:{cid_re}>'),                             snapshothandler.SnapshotHandler, name='snap_get', methods=['GET']),
+    webapp2.Route(_format(r'/api/snapshots/<par_cont_name:projects>/<par_id:{cid_re}>/<cont_name:sessions>'),       snapshothandler.SnapshotHandler, name='snap_proj_ses', handler_method='get_all', methods=['GET']),
+    webapp2.Route(_format(r'/api/snapshots/<par_cont_name:sessions>/<par_id:{cid_re}>/<cont_name:acquisitions>'),   snapshothandler.SnapshotHandler, name='snap_ses_acq', handler_method='get_all', methods=['GET']),
 ]
 
 

--- a/api/dao/snapshot.py
+++ b/api/dao/snapshot.py
@@ -61,10 +61,10 @@ def remove(method, _id):
     return result
 
 
-def make_public(method, _id):
+def make_public(method, _id, public=True):
     snapshot_id = bson.objectid.ObjectId(_id)
-    result = config.db.project_snapshots.find_one_and_update({'_id': snapshot_id}, {'$set':{'public': True}})
+    result = config.db.project_snapshots.find_one_and_update({'_id': snapshot_id}, {'$set':{'public': public}})
     session_snapshot_ids = [s['_id'] for s in config.db.session_snapshots.find({'project': snapshot_id})]
-    config.db.session_snapshots.update_many({'_id': {'$in': session_snapshot_ids}}, {'$set':{'public': True}})
-    config.db.acquisition_snapshots.update_many({'session': {'$in': session_snapshot_ids}}, {'$set':{'public': True}})
+    config.db.session_snapshots.update_many({'_id': {'$in': session_snapshot_ids}}, {'$set':{'public': public}})
+    config.db.acquisition_snapshots.update_many({'session': {'$in': session_snapshot_ids}}, {'$set':{'public': public}})
     return result

--- a/api/dao/snapshot.py
+++ b/api/dao/snapshot.py
@@ -47,12 +47,12 @@ def _store(hierarchy):
     return result
 
 
-def create(method, _id, payload):
+def create(method, _id, payload=None):
     hierarchy = _new_version(_id)
     return _store(hierarchy)
 
 
-def remove(method, _id):
+def remove(method, _id, payload=None):
     snapshot_id = bson.objectid.ObjectId(_id)
     result = config.db.project_snapshots.find_one_and_delete({'_id': snapshot_id})
     session_snapshot_ids = [s['_id'] for s in config.db.session_snapshots.find({'project': snapshot_id})]
@@ -61,7 +61,8 @@ def remove(method, _id):
     return result
 
 
-def make_public(method, _id, public=True):
+def make_public(method, _id, payload=None):
+    public = payload['value']
     snapshot_id = bson.objectid.ObjectId(_id)
     result = config.db.project_snapshots.find_one_and_update({'_id': snapshot_id}, {'$set':{'public': public}})
     session_snapshot_ids = [s['_id'] for s in config.db.session_snapshots.find({'project': snapshot_id})]

--- a/api/dao/snapshot.py
+++ b/api/dao/snapshot.py
@@ -1,0 +1,70 @@
+from .. import config
+import bson.objectid
+from pymongo import ReturnDocument
+
+
+def _new_version(project_id):
+    project_id = bson.objectid.ObjectId(project_id)
+    project = config.db.projects.find_one_and_update(
+        {'_id': project_id},
+        {'$inc': {'snapshot_version': 1}},
+        return_document=ReturnDocument.AFTER
+    )
+    version = {
+        'snapshot': project
+    }
+    sessions = list(config.db.sessions.find({'project': project_id}, {'project': 0, 'permissions': 0}))
+    for session in sessions:
+        acquisitions = list(config.db.acquisitions.find({'session': session['_id']}, {'session': 0, 'permissions': 0}))
+        session['permissions'] = project['permissions']
+        for a in acquisitions:
+            a['permissions'] = project['permissions']
+        version[session['_id']] = acquisitions
+    version[project_id] = sessions
+    return version
+
+
+def _store(hierarchy):
+    project = hierarchy['snapshot']
+    project['original'] = project.pop('_id')
+    result = config.db.project_snapshots.insert_one(project)
+    project_id = result.inserted_id
+    for session in hierarchy[project['original']]:
+        session['project'] = project_id
+        session['original'] = session.pop('_id')
+    sessions = config.db.session_snapshots.insert_many(hierarchy[project['original']])
+    session_ids = sessions.inserted_ids
+    acquisitions = []
+    for i, session in enumerate(hierarchy[project['original']]):
+        session_id = session_ids[i]
+        for acquisition in hierarchy[session['original']]:
+            acquisition['session'] = session_id
+            acquisition['original'] = acquisition.pop('_id')
+            acquisitions.append(acquisition)
+        hierarchy[session_id] = hierarchy.pop(session['original'])
+    hierarchy[project_id] = hierarchy.pop(project['original'])
+    config.db.acquisition_snapshots.insert_many(acquisitions)
+    return result
+
+
+def create(method, _id):
+    hierarchy = _new_version(_id)
+    return _store(hierarchy)
+
+
+def remove(method, _id):
+    snapshot_id = bson.objectid.ObjectId(_id)
+    result = config.db.project_snapshots.find_one_and_delete({'_id': snapshot_id})
+    session_snapshot_ids = [s['_id'] for s in config.db.session_snapshots.find({'project': snapshot_id})]
+    config.db.session_snapshots.delete_many({'_id': {'$in': session_snapshot_ids}})
+    config.db.acquisition_snapshots.delete_many({'session': {'$in': session_snapshot_ids}})
+    return result
+
+
+def make_public(method, _id):
+    snapshot_id = bson.objectid.ObjectId(_id)
+    result = config.db.project_snapshots.find_one_and_update({'_id': snapshot_id}, {'$set':{'public': True}})
+    session_snapshot_ids = [s['_id'] for s in config.db.session_snapshots.find({'project': snapshot_id})]
+    config.db.session_snapshots.update_many({'_id': {'$in': session_snapshot_ids}}, {'$set':{'public': True}})
+    config.db.acquisition_snapshots.update_many({'session': {'$in': session_snapshot_ids}}, {'$set':{'public': True}})
+    return result

--- a/api/dao/snapshot.py
+++ b/api/dao/snapshot.py
@@ -47,7 +47,7 @@ def _store(hierarchy):
     return result
 
 
-def create(method, _id):
+def create(method, _id, payload):
     hierarchy = _new_version(_id)
     return _store(hierarchy)
 

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -76,7 +76,7 @@ class GroupHandler(base.RequestHandler):
         payload_validator(payload, 'POST')
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()
         payload['roles'] = [{'_id': self.uid, 'access': 'admin', 'site': self.user_site}]
-        result = mongo_validator(permchecker(self.storage.exec_op))('POST', payload=payload)
+        result = permchecker(mongo_validator(self.storage.exec_op))('POST', payload=payload)
         if result.acknowledged:
             return {'_id': result.inserted_id}
         else:

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -75,7 +75,8 @@ class GroupHandler(base.RequestHandler):
         payload_validator = validators.payload_from_schema_file(self, 'group.json')
         payload_validator(payload, 'POST')
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()
-        payload['roles'] = [{'_id': self.uid, 'access': 'admin', 'site': self.user_site}]
+        if self.uid:
+            payload['roles'] = [{'_id': self.uid, 'access': 'admin', 'site': self.user_site}]
         result = permchecker(mongo_validator(self.storage.exec_op))('POST', payload=payload)
         if result.acknowledged:
             return {'_id': result.inserted_id}

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -102,6 +102,7 @@ class ListHandler(base.RequestHandler):
 
     def __init__(self, request=None, response=None):
         super(ListHandler, self).__init__(request, response)
+        self.list_handler_configurations = list_handler_configurations
 
     def get(self, cont_name, list_name, **kwargs):
         _id = kwargs.pop('cid')
@@ -166,7 +167,7 @@ class ListHandler(base.RequestHandler):
         5) the mongo_validator that will check what will be sent to mongo against a json schema
         6) the keycheck decorator validating the request key
         """
-        config = list_handler_configurations[cont_name][list_name]
+        config = self.list_handler_configurations[cont_name][list_name]
         storage = config['storage']
         permchecker = config['permchecker']
         if config.get('get_full_container'):

--- a/api/handlers/snapshothandler.py
+++ b/api/handlers/snapshothandler.py
@@ -61,6 +61,7 @@ class SnapshotHandler(ContainerHandler):
         origin_id = self.get_param('project')
         if not origin_id:
             self.abort(404, 'project is required to create a snapshot')
+        self.config = self.container_handler_configurations['projects']
         container = origin_storage.get_container(origin_id)
         permchecker = self._get_permchecker(container, container)
         result = permchecker(snapshot.create)('POST', _id=origin_id)

--- a/api/handlers/snapshothandler.py
+++ b/api/handlers/snapshothandler.py
@@ -74,17 +74,17 @@ class SnapshotHandler(ContainerHandler):
         self.config = self.container_handler_configurations[cont_name]
         self.storage = self.config['storage']
         container = self._get_container(snap_id)
-        permchecker = self._get_permchecker(container, container)
+        permchecker = self._get_permchecker(container, None)
         if not container:
             self.abort(404, 'snapshot does not exist')
-        result = permchecker(snapshot.remove)('POST', _id=snap_id)
-        return result
+        result = permchecker(snapshot.remove)('DELETE', _id=snap_id)
+        return {'deleted': 1}
 
     def publish(self, cont_name, **kwargs):
         if cont_name != 'projects':
             self.abort(500, 'method supported only on project snapshots')
         snap_id = kwargs.pop('cid')
-        payload_validator = validators.payload_from_schema_file(self, 'input/public.json')
+        payload_validator = validators.payload_from_schema_file(self, 'public.json')
         payload = self.request.json_body
         # use the validator for the POST route as the key 'value' is required
         payload_validator(payload, 'POST')
@@ -94,7 +94,7 @@ class SnapshotHandler(ContainerHandler):
         if not container:
             self.abort(404, 'snapshot does not exist')
         permchecker = self._get_permchecker(container, container)
-        result = permchecker(snapshot.make_public)('PUT', _id=snap_id, public=payload['value'])
+        result = permchecker(snapshot.make_public)('PUT', _id=snap_id, payload=payload)
         return result
 
     def get_all_for_project(self, **kwargs):

--- a/api/handlers/snapshothandler.py
+++ b/api/handlers/snapshothandler.py
@@ -83,13 +83,17 @@ class SnapshotHandler(ContainerHandler):
         if cont_name != 'projects':
             self.abort(500, 'method supported only on project snapshots')
         snap_id = kwargs.pop('cid')
+        payload_validator = validators.payload_from_schema_file(self, 'input/public.json')
+        payload = self.request.json_body
+        # use the validator for the POST route as the key 'value' is required
+        payload_validator(payload, 'POST')
         self.config = self.container_handler_configurations[cont_name]
         self.storage = self.config['storage']
         container = self._get_container(snap_id)
         if not container:
             self.abort(404, 'snapshot does not exist')
         permchecker = self._get_permchecker(container, container)
-        result = permchecker(snapshot.make_public)('PUT', _id=snap_id)
+        result = permchecker(snapshot.make_public)('PUT', _id=snap_id, public=payload['value'])
         return result
 
     def get_all_for_project(self, **kwargs):

--- a/api/schemas/input/public.json
+++ b/api/schemas/input/public.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "value":             {"type": "boolean"}
+  },
+  "required": ["value"],
+  "additionalProperties": false
+}

--- a/api/validators.py
+++ b/api/validators.py
@@ -43,7 +43,8 @@ expected_input_schemas = set([
     'avatars.json',
     'download.json',
     'tag.json',
-    'enginemetadata.json'
+    'enginemetadata.json',
+    'public.json'
 ])
 mongo_schemas = set()
 input_schemas = set()

--- a/test/integration_tests/test_bids_download.py
+++ b/test/integration_tests/test_bids_download.py
@@ -1,0 +1,253 @@
+import requests
+import json
+import time
+import logging
+import tarfile
+import os
+from nose.tools import with_setup
+
+log = logging.getLogger(__name__)
+sh = logging.StreamHandler()
+log.addHandler(sh)
+log.setLevel(logging.INFO)
+
+
+base_url = 'http://localhost:8080/api'
+test_data = type('',(object,),{'sessions': [], 'acquisitions': []})()
+
+session = None
+
+file_list = [
+    "bids_dataset/CHANGES",
+    "bids_dataset/dataset_description.json",
+    "bids_dataset/participants.tsv",
+    "bids_dataset/README",
+    "bids_dataset/task-livingnonlivingdecisionwithplainormirrorreversedtext_bold.json",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-01/ses-pre/anat/sub-01_ses-pre_inplaneT2.nii.gz",
+    "bids_dataset/sub-01/ses-pre/anat/sub-01_ses-pre_T1w.nii.gz",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-01/ses-post/anat/sub-01_ses-post_inplaneT2.nii.gz",
+    "bids_dataset/sub-01/ses-post/anat/sub-01_ses-post_T1w.nii.gz",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-02/ses-pre/anat/sub-02_ses-pre_inplaneT2.nii.gz",
+    "bids_dataset/sub-02/ses-pre/anat/sub-02_ses-pre_T1w.nii.gz",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-02/ses-post/anat/sub-02_ses-post_inplaneT2.nii.gz",
+    "bids_dataset/sub-02/ses-post/anat/sub-02_ses-post_T1w.nii.gz",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-03/ses-pre/anat/sub-03_ses-pre_inplaneT2.nii.gz",
+    "bids_dataset/sub-03/ses-pre/anat/sub-03_ses-pre_T1w.nii.gz",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-03/ses-post/anat/sub-03_ses-post_inplaneT2.nii.gz",
+    "bids_dataset/sub-03/ses-post/anat/sub-03_ses-post_T1w.nii.gz"
+]
+
+def file_list_to_tree(file_list):
+    # Convert filelist to tree
+    dirTree = {}
+    for item in file_list:
+        path_parts = item.split('/')
+        sub_obj = dirTree
+        for part in path_parts:
+            if not part in sub_obj:
+                sub_obj[part] = {} if path_parts.index(part) < len(path_parts) - 1 else 'file'
+            sub_obj = sub_obj[part]
+
+    # Convert object lists to arrays
+    def objToArr (obj):
+        arr = []
+        for key in obj:
+            if obj[key] == 'file':
+                arr.append({'filename': key})
+            else:
+                arr.append({'name': key, 'children': objToArr(obj[key])})
+        return arr
+
+    return objToArr(dirTree)[0]
+
+
+def setup_download():
+    global session
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': 'test@user.com',
+        'root': True
+    }
+
+    # Convert file list to a tree
+    dataset = file_list_to_tree(file_list)
+
+    # Create a group
+    test_data.group_id = 'test_group_' + str(int(time.time()*1000))
+    payload = {
+        '_id': test_data.group_id
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+
+    # Create a project
+    payload = {
+        'group': test_data.group_id,
+        'label': dataset['name'],
+        'public': False
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/projects', data=payload)
+    test_data.pid = json.loads(r.content)['_id']
+    assert r.ok
+    log.debug('pid = \'{}\''.format(test_data.pid))
+
+    # Crawl file tree
+    for bidsSubject in dataset['children']:
+        if 'filename' in bidsSubject:
+            # Upload project files
+            files = {'file': (bidsSubject['filename'], 'some,data,to,send'),
+                     'tags': ('', '["project"]')}
+            r = session.post(base_url + '/projects/' + test_data.pid +'/files', files=files)
+
+        elif 'children' in bidsSubject:
+            # Create subject directories
+            payload = {
+                'project': test_data.pid,
+                'label': bidsSubject['name'],
+                'subject': {
+                    'code': 'subject'
+                }
+            }
+            payload = json.dumps(payload)
+            r = session.post(base_url + '/sessions', data=payload)
+            subjectId = json.loads(r.content)['_id']
+            test_data.sessions.append(subjectId)
+
+            for bidsSession in bidsSubject['children']:
+                # Create session directories
+                payload = {
+                    'project': test_data.pid,
+                    'label': bidsSession['name'],
+                    'subject': {
+                        'code': subjectId
+                    }
+                }
+                payload = json.dumps(payload)
+                r = session.post(base_url + '/sessions', data=payload)
+                sessionId = json.loads(r.content)['_id']
+                test_data.sessions.append(sessionId)
+
+                for bidsModality in bidsSession['children']:
+                    # Create modality directories
+                    payload = {
+                        'session': sessionId,
+                        'label': bidsModality['name'],
+                    }
+                    payload = json.dumps(payload)
+                    r = session.post(base_url + '/acquisitions', data=payload)
+                    modalityId = json.loads(r.content)['_id']
+                    test_data.acquisitions.append(modalityId)
+
+                    for bidsAcquisition in bidsModality['children']:
+                        # Upload modality files
+                        files = {'file': (bidsAcquisition['filename'], 'some,data,to,send'),
+                                 'tags': ('', '["acquisition"]')}
+                        r = session.post(base_url + '/acquisitions/' + modalityId +'/files', files=files)
+
+
+def teardown_download():
+    success = True
+
+    # remove all the containers created in the test
+    for acquisitionId in test_data.acquisitions:
+        r = session.delete(base_url + '/acquisitions/' + acquisitionId)
+        success = success and r.ok
+    for sessionId in test_data.sessions:
+        r = session.delete(base_url + '/sessions/' + sessionId)
+        success = success and r.ok
+    r = session.delete(base_url + '/projects/' + test_data.pid)
+    success = success and r.ok
+    r = session.delete(base_url + '/groups/' + test_data.group_id)
+    success = success and r.ok
+    session.close()
+
+    # remove tar files
+    os.remove('test_download.tar')
+    os.remove('test_download_symlinks.tar')
+
+    if not success:
+        log.error('error in the teardown. These containers may have not been removed.')
+        log.error(str(test_data.__dict__))
+
+
+def download_dataset(symlinks):
+    # Retrieve a ticket for a batch download
+    payload = {
+        'optional': False,
+        'nodes': [
+            {
+                'level': 'project',
+                '_id': test_data.pid
+            }
+        ]
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/download', data=payload, params={'format': 'bids'})
+    assert r.ok
+
+    # Perform the download
+    ticket = json.loads(r.content)['ticket']
+    params = {'ticket': ticket}
+    if symlinks:
+        params['symlinks'] = True
+    r = session.get(base_url + '/download', params=params)
+    assert r.ok
+    # Save the tar to a file if successful
+    f = open('test_download.tar' if not symlinks else 'test_download_symlinks.tar', 'w')
+    f.write(r.content)
+    f.close()
+
+def get_tar_list(filename):
+    # Generate List of files in tar
+    tar_list = []
+    tar = tarfile.open(filename)
+    for member in tar.getmembers():
+        tar_list.append(member.path)
+    tar.close()
+    return tar_list
+
+
+@with_setup(setup_download, teardown_download)
+def test_download():
+    download_dataset(False)
+    download_dataset(True)
+
+    tar_list = get_tar_list('test_download.tar')
+    tar_list_sym = get_tar_list('test_download_symlinks.tar')
+
+    # Sort lists
+    file_list.sort()
+    tar_list.sort()
+    tar_list_sym.sort()
+
+    # Compare tar lists to original
+    assert file_list == tar_list
+    assert file_list == tar_list_sym
+

--- a/test/integration_tests/test_bids_download_snapshot.py
+++ b/test/integration_tests/test_bids_download_snapshot.py
@@ -1,0 +1,259 @@
+import requests
+import json
+import time
+import logging
+import tarfile
+import os
+from nose.tools import with_setup
+
+log = logging.getLogger(__name__)
+sh = logging.StreamHandler()
+log.addHandler(sh)
+log.setLevel(logging.INFO)
+
+base_url = 'http://localhost:8080/api'
+test_data = type('',(object,),{'sessions': [], 'acquisitions': []})()
+
+session = None
+
+file_list = [
+    "bids_dataset/CHANGES",
+    "bids_dataset/dataset_description.json",
+    "bids_dataset/participants.tsv",
+    "bids_dataset/README",
+    "bids_dataset/task-livingnonlivingdecisionwithplainormirrorreversedtext_bold.json",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-01/ses-pre/func/sub-01_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-01/ses-pre/anat/sub-01_ses-pre_inplaneT2.nii.gz",
+    "bids_dataset/sub-01/ses-pre/anat/sub-01_ses-pre_T1w.nii.gz",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-01/ses-post/func/sub-01_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-01/ses-post/anat/sub-01_ses-post_inplaneT2.nii.gz",
+    "bids_dataset/sub-01/ses-post/anat/sub-01_ses-post_T1w.nii.gz",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-02/ses-pre/func/sub-02_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-02/ses-pre/anat/sub-02_ses-pre_inplaneT2.nii.gz",
+    "bids_dataset/sub-02/ses-pre/anat/sub-02_ses-pre_T1w.nii.gz",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-02/ses-post/func/sub-02_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-02/ses-post/anat/sub-02_ses-post_inplaneT2.nii.gz",
+    "bids_dataset/sub-02/ses-post/anat/sub-02_ses-post_T1w.nii.gz",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-03/ses-pre/func/sub-03_ses-pre_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-03/ses-pre/anat/sub-03_ses-pre_inplaneT2.nii.gz",
+    "bids_dataset/sub-03/ses-pre/anat/sub-03_ses-pre_T1w.nii.gz",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_bold.nii.gz",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-01_events.tsv",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_bold.nii.gz",
+    "bids_dataset/sub-03/ses-post/func/sub-03_ses-post_task-livingnonlivingdecisionwithplainormirrorreversedtext_run-02_events.tsv",
+    "bids_dataset/sub-03/ses-post/anat/sub-03_ses-post_inplaneT2.nii.gz",
+    "bids_dataset/sub-03/ses-post/anat/sub-03_ses-post_T1w.nii.gz"
+]
+
+def file_list_to_tree(file_list):
+    # Convert filelist to tree
+    dirTree = {}
+    for item in file_list:
+        path_parts = item.split('/')
+        sub_obj = dirTree
+        for part in path_parts:
+            if not part in sub_obj:
+                sub_obj[part] = {} if path_parts.index(part) < len(path_parts) - 1 else 'file'
+            sub_obj = sub_obj[part]
+
+    # Convert object lists to arrays
+    def objToArr (obj):
+        arr = []
+        for key in obj:
+            if obj[key] == 'file':
+                arr.append({'filename': key})
+            else:
+                arr.append({'name': key, 'children': objToArr(obj[key])})
+        return arr
+
+    return objToArr(dirTree)[0]
+
+
+def setup_download():
+    global session
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': 'test@user.com',
+        'root': True
+    }
+
+    # Convert file list to a tree
+    dataset = file_list_to_tree(file_list)
+
+    # Create a group
+    test_data.group_id = 'test_group_' + str(int(time.time()*1000))
+    payload = {
+        '_id': test_data.group_id
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+
+    # Create a project
+    payload = {
+        'group': test_data.group_id,
+        'label': dataset['name'],
+        'public': False
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/projects', data=payload)
+    test_data.pid = json.loads(r.content)['_id']
+    assert r.ok
+    log.debug('pid = \'{}\''.format(test_data.pid))
+
+    # Crawl file tree
+    for bidsSubject in dataset['children']:
+        if 'filename' in bidsSubject:
+            # Upload project files
+            files = {'file': (bidsSubject['filename'], 'some,data,to,send'),
+                     'tags': ('', '["project"]')}
+            r = session.post(base_url + '/projects/' + test_data.pid +'/files', files=files)
+
+        elif 'children' in bidsSubject:
+            # Create subject directories
+            payload = {
+                'project': test_data.pid,
+                'label': bidsSubject['name'],
+                'subject': {
+                    'code': 'subject'
+                }
+            }
+            payload = json.dumps(payload)
+            r = session.post(base_url + '/sessions', data=payload)
+            subjectId = json.loads(r.content)['_id']
+            test_data.sessions.append(subjectId)
+
+            for bidsSession in bidsSubject['children']:
+                # Create session directories
+                payload = {
+                    'project': test_data.pid,
+                    'label': bidsSession['name'],
+                    'subject': {
+                        'code': subjectId
+                    }
+                }
+                payload = json.dumps(payload)
+                r = session.post(base_url + '/sessions', data=payload)
+                sessionId = json.loads(r.content)['_id']
+                test_data.sessions.append(sessionId)
+
+                for bidsModality in bidsSession['children']:
+                    # Create modality directories
+                    payload = {
+                        'session': sessionId,
+                        'label': bidsModality['name'],
+                    }
+                    payload = json.dumps(payload)
+                    r = session.post(base_url + '/acquisitions', data=payload)
+                    modalityId = json.loads(r.content)['_id']
+                    test_data.acquisitions.append(modalityId)
+
+                    for bidsAcquisition in bidsModality['children']:
+                        # Upload modality files
+                        files = {'file': (bidsAcquisition['filename'], 'some,data,to,send'),
+                                 'tags': ('', '["acquisition"]')}
+                        r = session.post(base_url + '/acquisitions/' + modalityId +'/files', files=files)
+    r = session.post(base_url + '/snapshots?project=' + test_data.pid)
+    test_data.snap_id = json.loads(r.content)['_id']
+    assert r.ok
+
+
+def teardown_download():
+    success = True
+
+    r = session.delete(base_url +  '/snapshots/projects/' + test_data.snap_id)
+    success = success and r.ok
+    # remove all the containers created in the test
+    for acquisitionId in test_data.acquisitions:
+        r = session.delete(base_url + '/acquisitions/' + acquisitionId)
+        success = success and r.ok
+    for sessionId in test_data.sessions:
+        r = session.delete(base_url + '/sessions/' + sessionId)
+        success = success and r.ok
+    r = session.delete(base_url + '/projects/' + test_data.pid)
+    success = success and r.ok
+    r = session.delete(base_url + '/groups/' + test_data.group_id)
+    success = success and r.ok
+    session.close()
+
+    # remove tar files
+    os.remove('test_download.tar')
+    os.remove('test_download_symlinks.tar')
+
+    if not success:
+        log.error('error in the teardown. These containers may have not been removed.')
+        log.error(str(test_data.__dict__))
+
+
+def download_dataset(symlinks):
+    # Retrieve a ticket for a batch download
+    payload = {
+        'optional': False,
+        'nodes': [
+            {
+                'level': 'project',
+                '_id': test_data.snap_id
+            }
+        ]
+    }
+    snap_url = base_url + '/snapshots'
+    payload = json.dumps(payload)
+    r = session.post(snap_url + '/download', data=payload, params={'format': 'bids'})
+    assert r.ok
+
+
+    # Perform the download
+    ticket = json.loads(r.content)['ticket']
+    params = {'ticket': ticket}
+    if symlinks:
+        params['symlinks'] = True
+    r = session.get(snap_url + '/download', params=params)
+    assert r.ok
+    # Save the tar to a file if successful
+    f = open('test_download.tar' if not symlinks else 'test_download_symlinks.tar', 'w')
+    f.write(r.content)
+    f.close()
+
+def get_tar_list(filename):
+    # Generate List of files in tar
+    tar_list = []
+    tar = tarfile.open(filename)
+    for member in tar.getmembers():
+        tar_list.append(member.path)
+    tar.close()
+    return tar_list
+
+
+@with_setup(setup_download, teardown_download)
+def test_download():
+    download_dataset(False)
+    download_dataset(True)
+
+    tar_list = get_tar_list('test_download.tar')
+    tar_list_sym = get_tar_list('test_download_symlinks.tar')
+
+    # Sort lists
+    file_list.sort()
+    tar_list.sort()
+    tar_list_sym.sort()
+
+    # Compare tar lists to original
+    assert file_list == tar_list
+    assert file_list == tar_list_sym
+

--- a/test/integration_tests/test_containers.py
+++ b/test/integration_tests/test_containers.py
@@ -1,43 +1,79 @@
 import requests
 import json
+import time
+from nose.tools import with_setup
 import logging
+
 log = logging.getLogger(__name__)
 sh = logging.StreamHandler()
 log.addHandler(sh)
 
-requests.packages.urllib3.disable_warnings()
+base_url = 'http://localhost:8080/api'
+adm_user = 'test@user.com'
+test_data = type('',(object,),{})()
 
-base_url = 'https://localhost:8443/api'
+def setup_db():
+    global session
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': adm_user,
+        'root': True
+    }
 
+    # Create a group
+    test_data.group_id = 'test_group_' + str(int(time.time()*1000))
+    payload = {
+        '_id': test_data.group_id
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+    test_data.group_id_1 = 'test_group_' + str(int(time.time()*1000))
+    payload = {
+        '_id': test_data.group_id_1
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+
+def teardown_db():
+    r = session.delete(base_url + '/groups/' + test_data.group_id)
+    assert r.ok
+    r = session.delete(base_url + '/groups/' + test_data.group_id_1)
+    assert r.ok
+
+@with_setup(setup_db, teardown_db)
 def test_projects():
     payload = {
-        'group': 'unknown',
-        'label': 'SciTran/Testing',
+        'group': test_data.group_id,
+        'label': 'test_project',
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/projects', data=payload)
     assert r.ok
     _id = json.loads(r.content)['_id']
-    r = requests.get(base_url + '/projects/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = session.get(base_url + '/projects/' + _id)
     assert r.ok
     payload = {
-        'group': 'scitran',
+        'group':  test_data.group_id_1,
     }
     payload = json.dumps(payload)
-    r = requests.put(base_url + '/projects/' + _id + '?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.put(base_url + '/projects/' + _id, data=payload)
     assert r.ok
-    r = requests.delete(base_url + '/projects/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/projects/' + _id)
     assert r.ok
 
+@with_setup(setup_db, teardown_db)
 def test_sessions():
     payload = {
-        'group': 'unknown',
-        'label': 'SciTran/Testing',
+        'group':  test_data.group_id,
+        'label': 'test_project',
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/projects', data=payload)
     assert r.ok
     pid = json.loads(r.content)['_id']
     payload = {
@@ -46,43 +82,44 @@ def test_sessions():
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/sessions?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/sessions', data=payload)
     assert r.ok
     _id = json.loads(r.content)['_id']
-    r = requests.get(base_url + '/sessions/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = session.get(base_url + '/sessions/' + _id)
     assert r.ok
     payload = {
-        'group': 'unknown',
-        'label': 'SciTran/Testing 2',
+        'group': test_data.group_id,
+        'label': 'test_project_1',
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/projects', data=payload)
     new_pid = json.loads(r.content)['_id']
     assert r.ok
     payload = {
         'project': new_pid,
     }
     payload = json.dumps(payload)
-    r = requests.put(base_url + '/sessions/' + _id + '?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.put(base_url + '/sessions/' + _id, data=payload)
     assert r.ok
-    r = requests.delete(base_url + '/sessions/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/sessions/' + _id)
     assert r.ok
-    r = requests.get(base_url + '/sessions/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = session.get(base_url + '/sessions/' + _id)
     assert r.status_code == 404
-    r = requests.delete(base_url + '/projects/' + pid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/projects/' + pid)
     assert r.ok
-    r = requests.delete(base_url + '/projects/' + new_pid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/projects/' + new_pid)
     assert r.ok
 
+@with_setup(setup_db, teardown_db)
 def test_acquisitions():
     payload = {
-        'group': 'unknown',
-        'label': 'SciTran/Testing',
+        'group':  test_data.group_id,
+        'label': 'test_project',
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/projects', data=payload)
     assert r.ok
     pid = json.loads(r.content)['_id']
     payload = {
@@ -91,7 +128,7 @@ def test_acquisitions():
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/sessions?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/sessions', data=payload)
     assert r.ok
     sid = json.loads(r.content)['_id']
 
@@ -101,7 +138,7 @@ def test_acquisitions():
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/sessions?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/sessions', data=payload)
     assert r.ok
     new_sid = json.loads(r.content)['_id']
 
@@ -111,27 +148,27 @@ def test_acquisitions():
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/acquisitions?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/acquisitions', data=payload)
     assert r.ok
     aid = json.loads(r.content)['_id']
 
-    r = requests.get(base_url + '/acquisitions/' + aid + '?user=admin@user.com&root=true', verify=False)
+    r = session.get(base_url + '/acquisitions/' + aid)
     assert r.ok
 
     payload = {
         'session': new_sid
     }
     payload = json.dumps(payload)
-    r = requests.put(base_url + '/acquisitions/' + aid + '?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.put(base_url + '/acquisitions/' + aid, data=payload)
     assert r.ok
 
-    r = requests.delete(base_url + '/acquisitions/' + aid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/acquisitions/' + aid)
     assert r.ok
-    r = requests.get(base_url + '/acquisitions/' + aid + '?user=admin@user.com&root=true', verify=False)
+    r = session.get(base_url + '/acquisitions/' + aid)
     assert r.status_code == 404
-    r = requests.delete(base_url + '/sessions/' + sid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/sessions/' + sid)
     assert r.ok
-    r = requests.delete(base_url + '/sessions/' + new_sid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/sessions/' + new_sid)
     assert r.ok
-    r = requests.delete(base_url + '/projects/' + pid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/projects/' + pid)
     assert r.ok

--- a/test/integration_tests/test_download.py
+++ b/test/integration_tests/test_download.py
@@ -1,0 +1,137 @@
+import requests
+import json
+import time
+import logging
+from nose.tools import with_setup
+
+log = logging.getLogger(__name__)
+sh = logging.StreamHandler()
+log.addHandler(sh)
+log.setLevel(logging.INFO)
+
+
+base_url = 'http://localhost:8080/api'
+test_data = type('',(object,),{})()
+
+session = None
+
+def setup_download():
+    global session
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': 'test@user.com',
+        'root': True
+    }
+
+    # Create a group
+    test_data.group_id = 'test_group_' + str(int(time.time()*1000))
+    payload = {
+        '_id': test_data.group_id
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+
+    # Create a project
+    payload = {
+        'group': test_data.group_id,
+        'label': 'scitran_testing',
+        'public': False
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/projects', data=payload)
+    test_data.pid = json.loads(r.content)['_id']
+    assert r.ok
+    log.debug('pid = \'{}\''.format(test_data.pid))
+
+    # Create a session
+    payload = {
+        'project': test_data.pid,
+        'label': 'session_testing',
+        'public': False
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/sessions', data=payload)
+    assert r.ok
+    test_data.sid = json.loads(r.content)['_id']
+    log.debug('sid = \'{}\''.format(test_data.sid))
+
+    # Create an acquisition
+    payload = {
+        'session': test_data.sid,
+        'label': 'acq_testing',
+        'public': False
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/acquisitions', data=payload)
+    assert r.ok
+    test_data.aid = json.loads(r.content)['_id']
+    log.debug('aid = \'{}\''.format(test_data.aid))
+
+    ## multiform fields for the file upload
+    files = {'file': ('test.csv', 'some,data,to,send\nanother,row,to,send\n'),
+             'tags': ('', '["incomplete"]'),
+             'metadata': ('',
+                '{"group": {"_id": "scitran"}, ' \
+                '"project": {"label": "Testdata"}, ' \
+                '"session": {"uid": "1.2.840.113619.6.353.10437158128305161617400354036593525848"}, ' \
+                '"file": {"type": "nifti"}, '
+                '"acquisition": {"uid": "1.2.840.113619.2.353.4120.7575399.14591.1403393566.658_1", ' \
+                '"timestamp": "1970-01-01T00:00:00", ' \
+                '"label": "Screen Save", ' \
+                '"instrument": "MRI", ' \
+                '"measurement": "screensave", ' \
+                '"timezone": "America/Los_Angeles"}, ' \
+                '"subject": {"code": "ex7236"}}'
+            )}
+
+    # upload the same file to each container created in the test
+    session.post(base_url + '/acquisitions/' + test_data.aid +'/files', files=files)
+    session.post(base_url + '/sessions/' + test_data.sid +'/files', files=files)
+    session.post(base_url + '/projects/' + test_data.pid +'/files', files=files)
+
+
+def teardown_download():
+    success = True
+    # remove all the container created in the test
+    r = session.delete(base_url + '/acquisitions/' + test_data.aid)
+    success = success and r.ok
+    r = session.delete(base_url + '/sessions/' + test_data.sid)
+    success = success and r.ok
+    r = session.delete(base_url + '/projects/' + test_data.pid)
+    success = success and r.ok
+    r = session.delete(base_url + '/groups/' + test_data.group_id)
+    success = success and r.ok
+    session.close()
+    if not success:
+        log.error('error in the teardown. These containers may have not been removed.')
+        log.error(str(test_data.__dict__))
+
+
+@with_setup(setup_download, teardown_download)
+def test_download():
+    # Retrieve a ticket for a batch download
+    payload = {
+        'optional': False,
+        'nodes': [
+            {
+                'level': 'project',
+                '_id': test_data.pid
+            }
+        ]
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/download', data=payload)
+    assert r.ok
+
+    # Perform the download
+    ticket = json.loads(r.content)['ticket']
+    r = session.get(base_url + '/download', params={'ticket': ticket})
+    assert r.ok
+    # Save the tar to a file if successful
+    f = open('test_download.tar', 'w')
+    f.write(r.content)
+    f.close()
+
+

--- a/test/integration_tests/test_errors.py
+++ b/test/integration_tests/test_errors.py
@@ -6,10 +6,10 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 import warnings
 warnings.filterwarnings('ignore')
-base_url = 'https://localhost:8443/api'
+base_url = 'http://localhost:8080/api'
 
 import pymongo
-db = pymongo.MongoClient('mongodb://localhost/scitran').get_default_database()
+db = pymongo.MongoClient('mongodb://localhost:9001/scitran').get_default_database()
 projects = db.projects
 
 def test_extra_param():
@@ -20,7 +20,7 @@ def test_extra_param():
         'extra_param': 'some_value'
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = requests.post(base_url + '/projects?user=test@user.com&root=true', data=payload)
     assert r.status_code == 400
     r = projects.delete_many({'label': 'SciTran/Testing'})
     assert r.deleted_count == 0

--- a/test/integration_tests/test_groups.py
+++ b/test/integration_tests/test_groups.py
@@ -1,31 +1,38 @@
 import requests
 import json
+import time
 import logging
 log = logging.getLogger(__name__)
 sh = logging.StreamHandler()
 log.addHandler(sh)
 
-requests.packages.urllib3.disable_warnings()
-
-base_url = 'https://localhost:8443/api'
+base_url = 'http://localhost:8080/api'
 
 def test_groups():
-    _id = 'test'
-    r = requests.get(base_url + '/groups/' + _id + '?user=admin@user.com&root=true', verify=False)
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': 'test@user.com',
+        'root': True
+    }
+    _id = 'test_group_' + str(int(time.time()*1000))
+    r = session.get(base_url + '/groups/' + _id)
     assert r.status_code == 404
     payload = {
         '_id': _id
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/groups?user=admin@user.com&root=true', data=payload, verify=False)
+    r = requests.post(base_url + '/groups', data=payload)
+    assert r.status_code == 400
+    r = session.post(base_url + '/groups', data=payload)
     assert r.ok
-    r = requests.get(base_url + '/groups/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = session.get(base_url + '/groups/' + _id)
     assert r.ok
     payload = {
         'name': 'Test group',
     }
     payload = json.dumps(payload)
-    r = requests.put(base_url + '/groups/' + _id + '?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.put(base_url + '/groups/' + _id, data=payload)
     assert r.ok
-    r = requests.delete(base_url + '/groups/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/groups/' + _id)
     assert r.ok

--- a/test/integration_tests/test_notes.py
+++ b/test/integration_tests/test_notes.py
@@ -1,6 +1,6 @@
 import requests
 import json
-import warnings
+import time
 from nose.tools import with_setup
 import logging
 
@@ -8,12 +8,10 @@ log = logging.getLogger(__name__)
 sh = logging.StreamHandler()
 log.addHandler(sh)
 log.setLevel(logging.INFO)
-warnings.filterwarnings('ignore')
 
-adm_user = 'admin@user.com'
-user = 'test@user.com'
+adm_user = 'test@user.com'
 test_data = type('',(object,),{})()
-base_url = 'https://localhost:8443/api'
+base_url = 'http://localhost:8080/api'
 
 def _build_url(_id=None, requestor=adm_user):
     if _id is None:
@@ -22,56 +20,66 @@ def _build_url(_id=None, requestor=adm_user):
         url = test_data.proj_url + '/' + _id + '?user=' + requestor
     return url
 
-
 def setup_db():
+    global session
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': adm_user,
+        'root': True
+    }
+
+    # Create a group
+    test_data.group_id = 'test_group_' + str(int(time.time()*1000))
     payload = {
-        'group': 'unknown',
-        'label': 'SciTran/Testing',
+        '_id': test_data.group_id
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+    payload = {
+        'group': test_data.group_id,
+        'label': 'test_project',
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/projects', data=payload)
     test_data.pid = json.loads(r.content)['_id']
     assert r.ok
     log.debug('pid = \'{}\''.format(test_data.pid))
     test_data.proj_url = base_url + '/projects/{}/notes'.format(test_data.pid)
-    data = {
-        '_id': user,
-        'site': 'local',
-        'access': 'rw'
-    }
-    url = base_url + '/projects/' + test_data.pid + '/permissions?user=admin@user.com&root=true'
-    r = requests.post(url, data=json.dumps(data), verify=False)
-    assert r.ok
 
 def teardown_db():
-    r = requests.delete(base_url + '/projects/' + test_data.pid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/projects/' + test_data.pid)
+    assert r.ok
+    r = session.delete(base_url + '/groups/' + test_data.group_id)
     assert r.ok
 
 @with_setup(setup_db, teardown_db)
 def test_notes():
-    url_post = _build_url(requestor=user)
-    data = {'user': user, 'text':'test note'}
-    r = requests.post(url_post, data=json.dumps(data), verify=False)
+    url_post = test_data.proj_url
+
+    data = {'text':'test note'}
+    r = session.post(url_post, data=json.dumps(data))
     assert r.ok
-    r = requests.get(base_url + '/projects/{}?user={}'.format(test_data.pid, adm_user), verify=False)
+    r = session.get(base_url + '/projects/{}?user={}'.format(test_data.pid, adm_user))
     assert r.ok
     p = json.loads(r.content)
     assert len(p['notes']) == 1
-    assert p['notes'][0]['user'] == user
+    assert p['notes'][0]['user'] == adm_user
     note_id = p['notes'][0]['_id']
-    url_get = _build_url(note_id, user)
-    r = requests.get(url_get, verify=False)
+    url_get = test_data.proj_url + '/' + note_id
+    r = session.get(url_get)
     assert r.ok
     assert json.loads(r.content)['_id'] == note_id
     data = {'text':'modified test note'}
-    r = requests.put(url_get, data=json.dumps(data), verify=False)
+    r = session.put(url_get, data=json.dumps(data))
     assert r.ok
-    r = requests.get(url_get, verify=False)
+    r = session.get(url_get)
     assert r.ok
     assert json.loads(r.content)['text'] == 'modified test note'
-    r = requests.delete(url_get, verify=False)
+    r = session.delete(url_get)
     assert r.ok
-    r = requests.get(url_get, verify=False)
+    r = session.get(url_get)
     assert r.status_code == 404
 

--- a/test/integration_tests/test_permissions.py
+++ b/test/integration_tests/test_permissions.py
@@ -1,6 +1,6 @@
 import requests
 import json
-import warnings
+import time
 from nose.tools import with_setup
 import logging
 
@@ -8,12 +8,13 @@ log = logging.getLogger(__name__)
 sh = logging.StreamHandler()
 log.addHandler(sh)
 log.setLevel(logging.INFO)
-warnings.filterwarnings('ignore')
 
-adm_user = 'admin@user.com'
-user = 'test@user.com'
+adm_user = 'test@user.com'
+user = 'other@user.com'
+user1 = 'other1@user.com'
 test_data = type('',(object,),{})()
-base_url = 'https://localhost:8443/api'
+base_url = 'http://localhost:8080/api'
+session = None
 
 def _build_url(_id=None, requestor=adm_user, site='local'):
     if _id is None:
@@ -24,36 +25,55 @@ def _build_url(_id=None, requestor=adm_user, site='local'):
 
 
 def setup_db():
+    global session
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': adm_user,
+        'root': True
+    }
+
+    # Create a group
+    test_data.group_id = 'test_group_' + str(int(time.time()*1000))
     payload = {
-        'group': 'unknown',
-        'label': 'SciTran/Testing',
+        '_id': test_data.group_id
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+    payload = {
+        'group': test_data.group_id,
+        'label': 'test_project',
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/projects', data=payload)
     test_data.pid = json.loads(r.content)['_id']
     assert r.ok
     log.debug('pid = \'{}\''.format(test_data.pid))
     test_data.proj_url = base_url + '/projects/{}/permissions'.format(test_data.pid)
 
 def teardown_db():
-    r = requests.delete(base_url + '/projects/' + test_data.pid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/projects/' + test_data.pid)
+    assert r.ok
+    r = session.delete(base_url + '/groups/' + test_data.group_id)
     assert r.ok
 
 @with_setup(setup_db, teardown_db)
 def test_permissions():
     url_post = _build_url()
     url_get = _build_url(user)
-    r = requests.get(url_get, verify=False)
+    url_get_1 = _build_url(user1)
+    r = requests.get(url_get)
     assert r.status_code == 404
     data = {
         '_id': user,
         'site': 'local',
         'access': 'ro'
     }
-    r = requests.post(url_post, data = json.dumps(data), verify=False)
+    r = requests.post(url_post, data = json.dumps(data))
     assert r.ok
-    r = requests.get(url_get, verify=False)
+    r = requests.get(url_get)
     assert r.ok
     content = json.loads(r.content)
     assert content['_id'] == user
@@ -62,15 +82,33 @@ def test_permissions():
     data = {
         'access': 'admin'
     }
-    r = requests.put(url_get, data = json.dumps(data), verify=False)
+    r = requests.put(url_get, data = json.dumps(data))
     assert r.ok
-    r = requests.get(url_get, verify=False)
+    data = {
+        '_id': user1,
+        'site': 'local',
+        'access': 'ro'
+    }
+    r = requests.post(url_post, data = json.dumps(data))
+    assert r.ok
+    data = {
+        '_id': user
+    }
+    r = requests.put(url_get_1, data = json.dumps(data))
+    assert r.status_code == 404
+    data = {
+        'site': 'another'
+    }
+    r = requests.put(url_get_1, data = json.dumps(data))
+    assert r.ok
+    url_get_1 = _build_url(user1, site='another')
+    r = requests.get(url_get_1)
     assert r.ok
     content = json.loads(r.content)
-    assert content['_id'] == user
-    assert content['site'] == 'local'
-    assert content['access'] == 'admin'
-    r = requests.delete(url_get, verify=False)
+    assert content['_id'] == user1
+    assert content['site'] == 'another'
+    assert content['access'] == 'ro'
+    r = requests.delete(url_get_1)
     assert r.ok
-    r = requests.get(url_get, verify=False)
+    r = requests.get(url_get_1)
     assert r.status_code == 404

--- a/test/integration_tests/test_tags.py
+++ b/test/integration_tests/test_tags.py
@@ -1,6 +1,6 @@
 import requests
 import json
-import warnings
+import time
 from nose.tools import with_setup
 import logging
 
@@ -8,37 +8,54 @@ log = logging.getLogger(__name__)
 sh = logging.StreamHandler()
 log.addHandler(sh)
 log.setLevel(logging.INFO)
-warnings.filterwarnings('ignore')
 
 adm_user = 'admin@user.com'
 test_data = type('',(object,),{})()
-base_url = 'https://localhost:8443/api'
+base_url = 'http://localhost:8080/api'
+session = None
 
 def _build_url_and_payload(method, tag, newtag=None, requestor=adm_user):
     if method == 'POST':
-        url = test_data.proj_url + '?user=' + requestor
+        url = test_data.proj_url
         payload = json.dumps({'value': tag})
     else:
-        url = test_data.proj_url + '/' + tag + '?user=' + requestor
+        url = test_data.proj_url + '/' + tag
         payload = json.dumps({'value': newtag})
     return url, payload
 
-
 def setup_db():
+    global session
+    session = requests.Session()
+    # all the requests will be performed as root
+    session.params = {
+        'user': 'test@user.com',
+        'root': True
+    }
+
+    # Create a group
+    test_data.group_id = 'test_group_' + str(int(time.time()*1000))
     payload = {
-        'group': 'unknown',
-        'label': 'SciTran/Testing',
+        '_id': test_data.group_id
+    }
+    payload = json.dumps(payload)
+    r = session.post(base_url + '/groups', data=payload)
+    assert r.ok
+    payload = {
+        'group': test_data.group_id,
+        'label': 'test_project',
         'public': False
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/projects?user=admin@user.com&root=true', data=payload, verify=False)
+    r = session.post(base_url + '/projects', data=payload)
     test_data.pid = json.loads(r.content)['_id']
     assert r.ok
     log.debug('pid = \'{}\''.format(test_data.pid))
     test_data.proj_url = base_url + '/projects/{}/tags'.format(test_data.pid)
 
 def teardown_db():
-    r = requests.delete(base_url + '/projects/' + test_data.pid + '?user=admin@user.com&root=true', verify=False)
+    r = session.delete(base_url + '/projects/' + test_data.pid)
+    assert r.ok
+    r = session.delete(base_url + '/groups/' + test_data.group_id)
     assert r.ok
 
 @with_setup(setup_db, teardown_db)
@@ -50,45 +67,45 @@ def test_tags():
     url_get_new, _ = _build_url_and_payload('GET', new_tag)
     url_get_other, _ = _build_url_and_payload('GET', other_tag)
 
-    r = requests.get(url_get_tag, verify=False)
+    r = session.get(url_get_tag)
     assert r.status_code == 404
     url_post, payload = _build_url_and_payload('POST', tag)
-    r = requests.post(url_post, data=payload, verify=False)
+    r = session.post(url_post, data=payload)
     assert r.ok
-    r = requests.get(url_get_tag, verify=False)
+    r = session.get(url_get_tag)
     assert r.ok
     assert json.loads(r.content) == tag
 
     url_post, payload = _build_url_and_payload('POST', new_tag)
-    r = requests.post(url_post, data=payload, verify=False)
+    r = session.post(url_post, data=payload)
     assert r.ok
     url_post, payload = _build_url_and_payload('POST', new_tag)
-    r = requests.post(url_post, data=payload, verify=False)
+    r = session.post(url_post, data=payload)
     assert r.status_code == 404
-    r = requests.get(url_get_new, verify=False)
+    r = session.get(url_get_new)
     assert r.ok
     assert json.loads(r.content) == new_tag
 
     url_put, payload = _build_url_and_payload('PUT', tag, new_tag)
-    r = requests.put(url_put, data=payload, verify=False)
+    r = session.put(url_put, data=payload)
     assert r.status_code == 404
 
-    r = requests.get(url_get_other, verify=False)
+    r = session.get(url_get_other, verify=False)
     assert r.status_code == 404
     url_put, payload = _build_url_and_payload('PUT', tag, other_tag)
-    r = requests.put(url_put, data=payload, verify=False)
+    r = session.put(url_put, data=payload)
     assert r.ok
-    r = requests.get(url_get_other, verify=False)
+    r = session.get(url_get_other)
     assert r.ok
     assert json.loads(r.content) == other_tag
 
-    r = requests.get(url_get_tag, verify=False)
+    r = session.get(url_get_tag)
     assert r.status_code == 404
-    r = requests.delete(url_get_other, verify=False) # url for 'DELETE' is the same as the one for 'GET'
+    r = session.delete(url_get_other) # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = requests.get(url_get_other, verify=False)
+    r = session.get(url_get_other)
     assert r.status_code == 404
-    r = requests.delete(url_get_new, verify=False) # url for 'DELETE' is the same as the one for 'GET'
+    r = session.delete(url_get_new) # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = requests.get(url_get_new, verify=False)
+    r = session.get(url_get_new)
     assert r.status_code == 404

--- a/test/integration_tests/test_users.py
+++ b/test/integration_tests/test_users.py
@@ -7,13 +7,13 @@ log.addHandler(sh)
 
 requests.packages.urllib3.disable_warnings()
 
-base_url = 'https://localhost:8443/api'
+base_url = 'http://localhost:8080/api'
 
 def test_users():
     _id = 'new@user.com'
-    r = requests.get(base_url + '/users/self?user=admin@user.com', verify=False)
+    r = requests.get(base_url + '/users/self?user=test@user.com')
     assert r.ok
-    r = requests.get(base_url + '/users/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = requests.get(base_url + '/users/' + _id + '?user=test@user.com&root=true')
     assert r.status_code == 404
     payload = {
         '_id': _id,
@@ -21,15 +21,15 @@ def test_users():
         'lastname': 'User',
     }
     payload = json.dumps(payload)
-    r = requests.post(base_url + '/users?user=admin@user.com&root=true', data=payload, verify=False)
+    r = requests.post(base_url + '/users?user=test@user.com&root=true', data=payload)
     assert r.ok
-    r = requests.get(base_url + '/users/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = requests.get(base_url + '/users/' + _id + '?user=test@user.com&root=true')
     assert r.ok
     payload = {
         'firstname': 'Realname'
     }
     payload = json.dumps(payload)
-    r = requests.put(base_url + '/users/' + _id + '?user=admin@user.com&root=true', data=payload, verify=False)
+    r = requests.put(base_url + '/users/' + _id + '?user=test@user.com&root=true', data=payload)
     assert r.ok
-    r = requests.delete(base_url + '/users/' + _id + '?user=admin@user.com&root=true', verify=False)
+    r = requests.delete(base_url + '/users/' + _id + '?user=test@user.com&root=true')
     assert r.ok


### PR DESCRIPTION
The main goal of this change is to enable a client to take a copy(snapshot) of a project at a certain point in time.
All the ids of project, sessions and acquisitions are changed. The key of the original project is stored in the key 'original' of its copy.

Snapshots are essentially immutable. They can be removed, but the only property that can be modified is the public flag.

### New routes

#### create a snapshot for the project \<project_id\>
method: POST 
path: api/snapshots?project=\<project_id\>

#### get all the project snapshots
method: GET
path: api/snapshots/projects

#### get all the snapshots for a project id
method: GET
path: api/projects/\<_id\>/snapshots

#### get the details of a project/session/acquisition that belongs to a snapshot
method: GET
path: api/snapshots/(projects|sessions|acquisition)/\<_id\>

#### get all the sessions in a project snapshot
method: GET
path: api/snapshots/projects/\<project_id\>/sessions

#### get all the acquisitions in a session snapshot
method: GET
path: api/snapshots/sessions/\<session_id\>/acquisitions

#### delete the project snapshot with all its sessions and acquisitions
method: DELETE
path: api/snapshots/projects/\<project_id\>

#### publish or unpublish the project snapshot, all its sessions and acquisitions
method: PUT
path: api/snapshots/projects/\<project_id\>/public
body: {'value': True/False}