### PR TITLE
Stop using handler.abort in validators

### DIFF
--- a/api/base.py
+++ b/api/base.py
@@ -9,6 +9,7 @@ import jsonschema
 
 from . import util
 from . import config
+from . import validators
 
 log = config.log
 
@@ -128,6 +129,8 @@ class RequestHandler(webapp2.RequestHandler):
         # Otherwise use a generic 500 error code.
         if isinstance(exception, webapp2.HTTPException):
             code = exception.code
+        elif isinstance(exception, validators.InputValidationException):
+            code = 400
         else:
             code = 500
         util.send_json_http_exception(self.response, str(exception), code)

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -308,8 +308,8 @@ class ContainerHandler(base.RequestHandler):
 
 
     def _get_validators(self):
-        mongo_validator = validators.mongo_from_schema_file(self, self.config.get('storage_schema_file'))
-        payload_validator = validators.payload_from_schema_file(self, self.config.get('payload_schema_file'))
+        mongo_validator = validators.mongo_from_schema_file(self.config.get('storage_schema_file'))
+        payload_validator = validators.payload_from_schema_file(self.config.get('payload_schema_file'))
         return mongo_validator, payload_validator
 
     def _get_parent_container(self, payload):

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -58,8 +58,8 @@ class GroupHandler(base.RequestHandler):
             self.abort(404, 'no such Group: ' + _id)
         permchecker = groupauth.default(self, group)
         payload = self.request.json_body
-        mongo_validator = validators.mongo_from_schema_file(self, 'group.json')
-        payload_validator = validators.payload_from_schema_file(self, 'group.json')
+        mongo_validator = validators.mongo_from_schema_file('group.json')
+        payload_validator = validators.payload_from_schema_file('group.json')
         payload_validator(payload, 'PUT')
         result = mongo_validator(permchecker(self.storage.exec_op))('PUT', _id=_id, payload=payload)
         if result.modified_count == 1:
@@ -71,8 +71,8 @@ class GroupHandler(base.RequestHandler):
         self._init_storage()
         permchecker = groupauth.default(self, None)
         payload = self.request.json_body
-        mongo_validator = validators.mongo_from_schema_file(self, 'group.json')
-        payload_validator = validators.payload_from_schema_file(self, 'group.json')
+        mongo_validator = validators.mongo_from_schema_file('group.json')
+        payload_validator = validators.payload_from_schema_file('group.json')
         payload_validator(payload, 'POST')
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()
         payload['roles'] = [{'_id': self.uid, 'access': 'admin', 'site': self.user_site}]

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -181,9 +181,9 @@ class ListHandler(base.RequestHandler):
                 permchecker = permchecker(self, container)
         else:
             self.abort(404, 'Element {} not found in container {}'.format(_id, storage.cont_name))
-        mongo_validator = validators.mongo_from_schema_file(self, config.get('storage_schema_file'))
-        input_validator = validators.payload_from_schema_file(self, config.get('input_schema_file'))
-        keycheck = validators.key_check(self, config.get('storage_schema_file'))
+        mongo_validator = validators.mongo_from_schema_file(config.get('storage_schema_file'))
+        input_validator = validators.payload_from_schema_file(config.get('input_schema_file'))
+        keycheck = validators.key_check(config.get('storage_schema_file'))
         return container, permchecker, storage, mongo_validator, input_validator, keycheck
 
 

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -64,8 +64,8 @@ class UserHandler(base.RequestHandler):
         user = self._get_user(_id)
         permchecker = userauth.default(self, user)
         payload = self.request.json_body
-        mongo_validator = validators.mongo_from_schema_file(self, 'user.json')
-        payload_validator = validators.payload_from_schema_file(self, 'user.json')
+        mongo_validator = validators.mongo_from_schema_file('user.json')
+        payload_validator = validators.payload_from_schema_file('user.json')
         payload_validator(payload, 'PUT')
         payload['modified'] = datetime.datetime.utcnow()
         result = mongo_validator(permchecker(self.storage.exec_op))('PUT', _id=_id, payload=payload)
@@ -78,8 +78,8 @@ class UserHandler(base.RequestHandler):
         self._init_storage()
         permchecker = userauth.default(self)
         payload = self.request.json_body
-        mongo_validator = validators.mongo_from_schema_file(self, 'user.json')
-        payload_validator = validators.payload_from_schema_file(self, 'user.json')
+        mongo_validator = validators.mongo_from_schema_file('user.json')
+        payload_validator = validators.payload_from_schema_file('user.json')
         payload_validator(payload, 'POST')
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()
         payload['root'] = payload.get('root', False)

--- a/api/upload.py
+++ b/api/upload.py
@@ -62,7 +62,7 @@ class Upload(base.RequestHandler):
                 self.abort(400, str(e))
             if not file_store.metadata:
                 self.abort(400, 'metadata is missing')
-            metadata_validator = validators.payload_from_schema_file(self, 'uploader.json')
+            metadata_validator = validators.payload_from_schema_file('uploader.json')
             metadata_validator(file_store.metadata, 'POST')
             try:
                 target_containers = reaperutil.create_root_to_leaf_hierarchy(file_store.metadata, file_store.files)
@@ -108,7 +108,7 @@ class Upload(base.RequestHandler):
                 self.abort(400, str(e))
             if not file_store.metadata:
                 self.abort(400, 'metadata is missing')
-            metadata_validator = validators.payload_from_schema_file(self, 'enginemetadata.json')
+            metadata_validator = validators.payload_from_schema_file('enginemetadata.json')
             metadata_validator(file_store.metadata, 'POST')
             file_infos = file_store.metadata['acquisition'].pop('files', [])
             now = datetime.datetime.utcnow()


### PR DESCRIPTION
raise exceptions instead (caught by `base.RequestHandler.handle_exception`)

partially addresses #66 