### PR TITLE
Retrofit of upload logic

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -73,6 +73,7 @@ routes = [
         webapp2.Route(r'/download',         download.Download, handler_method='download', methods=['GET', 'POST'], name='download'),
         webapp2.Route(r'/reaper',           upload.Upload, handler_method='reaper', methods=['POST']),
         webapp2.Route(r'/uploader',         upload.Upload, handler_method='uploader', methods=['POST']),
+        webapp2.Route(r'/packfile',         upload.Upload, handler_method='packfile', methods=['POST']),
         webapp2.Route(r'/engine',           upload.Upload, handler_method='engine', methods=['POST']),
         webapp2.Route(r'/sites',            centralclient.CentralClient, handler_method='sites', methods=['GET']),
         webapp2.Route(r'/register',         centralclient.CentralClient, handler_method='register', methods=['POST']),

--- a/api/api.py
+++ b/api/api.py
@@ -73,7 +73,6 @@ routes = [
         webapp2.Route(r'/download',         download.Download, handler_method='download', methods=['GET', 'POST'], name='download'),
         webapp2.Route(r'/reaper',           upload.Upload, handler_method='reaper', methods=['POST']),
         webapp2.Route(r'/uploader',         upload.Upload, handler_method='uploader', methods=['POST']),
-        webapp2.Route(r'/packfile',         upload.Upload, handler_method='packfile', methods=['POST']),
         webapp2.Route(r'/engine',           upload.Upload, handler_method='engine', methods=['POST']),
         webapp2.Route(r'/sites',            centralclient.CentralClient, handler_method='sites', methods=['GET']),
         webapp2.Route(r'/register',         centralclient.CentralClient, handler_method='register', methods=['POST']),
@@ -118,6 +117,7 @@ routes = [
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>'),                                      listhandler.ListHandler, methods=['POST'], name='tags_post'),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.ListHandler, name='tags'),
 
+    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/packfile'),                                     listhandler.FileListHandler, name='packfile', handler_method='packfile', methods=['POST']),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:files>'),                                     listhandler.FileListHandler, name='files_post', methods=['POST']),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:files>/<name:{filename_re}>'),            listhandler.FileListHandler, name='files'),
 

--- a/api/dao/__init__.py
+++ b/api/dao/__init__.py
@@ -1,2 +1,5 @@
 class APIStorageException(Exception):
     pass
+
+def noop(*args, **kwargs):
+    pass

--- a/api/dao/reaperutil.py
+++ b/api/dao/reaperutil.py
@@ -48,6 +48,34 @@ class TargetContainer(object):
             return_document=pymongo.collection.ReturnDocument.AFTER
         )
 
+# TODO: already in code elsewhere? Location?
+def get_container(cont_name, _id):
+    cont_name += 's'
+    _id = bson.ObjectId(_id)
+
+    return config.db[cont_name].find_one({
+        '_id': _id,
+    })
+
+def upsert_fileinfo(cont_name, _id, fileinfo):
+    # TODO: make all functions take singular noun
+    cont_name += 's'
+
+    # TODO: make all functions consume strings
+    _id = bson.ObjectId(_id)
+
+    # OPPORTUNITY: could potentially be atomic if we pass a closure to perform the modification
+    result = config.db[cont_name].find_one({
+        '_id': _id,
+        'files.name': fileinfo['name'],
+    })
+
+    if result is None:
+        fileinfo['created'] = fileinfo['modified']
+        return add_fileinfo(cont_name, _id, fileinfo)
+    else:
+        return update_fileinfo(cont_name, _id, fileinfo)
+
 def update_fileinfo(cont_name, _id, fileinfo):
     update_set = {'files.$.modified': datetime.datetime.utcnow()}
     # in this method, we are overriding an existing file.

--- a/api/files.py
+++ b/api/files.py
@@ -9,15 +9,53 @@ import collections
 
 from . import util
 from . import config
+from . import tempdir as tempfile
 
 log = config.log
 
+DEFAULT_HASH_ALG='sha384'
 
 def move_file(path, target_path):
     target_dir = os.path.dirname(target_path)
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
     shutil.move(path, target_path)
+
+def move_form_file_field_into_cas(file_field):
+    """
+    Given a file form field, move the (downloaded, tempdir-stored) file into the CAS.
+
+    Requires an augmented file field; see upload.process_upload() for details.
+    """
+
+    if not file_field.hash or not file_field.path:
+        raise Exception("Field is not a file field with hash and path")
+
+    base   = config.get_item('persistent', 'data_path')
+    cas    = util.path_from_hash(file_field.hash)
+    move_file(file_field.path, os.path.join(base, cas))
+
+def hash_file_formatted(path, hash_alg=None):
+    """
+    Return the scitran-formatted hash of a file, specified by path.
+
+    REVIEW: if there's an intelligent io-copy in python stdlib, I missed it. This uses an arbitrary buffer size :/
+    """
+
+    hash_alg = hash_alg or DEFAULT_HASH_ALG
+    hasher = hashlib.new(hash_alg)
+
+    BUF_SIZE = 65536
+
+    with open(path, 'rb') as f:
+        while True:
+            data = f.read(BUF_SIZE)
+            if not data:
+                break
+            hasher.update(data)
+
+    return util.format_hash(hash_alg, hasher.hexdigest())
+
 
 class FileStoreException(Exception):
     pass
@@ -26,6 +64,7 @@ class HashingFile(file):
     def __init__(self, file_path, hash_alg):
         super(HashingFile, self).__init__(file_path, "wb")
         self.hash_alg = hashlib.new(hash_alg)
+        self.hash_name = hash_alg
 
     def write(self, data):
         self.hash_alg.update(data)
@@ -34,8 +73,39 @@ class HashingFile(file):
     def get_hash(self):
         return self.hash_alg.hexdigest()
 
+    def get_formatted_hash(self):
+        return util.format_hash(self.hash_name, self.get_hash())
+
 ParsedFile = collections.namedtuple('ParsedFile', ['info', 'path'])
 
+def process_form(request, hash_alg=None):
+    """
+    Some workarounds to make webapp2 process forms in an intelligent way, and hash files we process.
+    Could subsume getHashingFieldStorage.
+
+    This is a bit arcane, and deals with webapp2 / uwsgi / python complexities. Ask a team member, sorry!
+
+    Returns the processed form, and the tempdir it was stored in.
+    Keep tempdir in scope until you don't need it anymore; it will be deleted on GC.
+    """
+
+    hash_alg = hash_alg or DEFAULT_HASH_ALG
+
+    # Store form file fields in a tempdir
+    tempdir = tempfile.TemporaryDirectory(prefix='.tmp', dir=config.get_item('persistent', 'data_path'))
+    tempdir_path = tempdir.name
+
+    # Deep vodoo; docs?
+    env = request.environ.copy()
+    env.setdefault('CONTENT_LENGTH', '0')
+    env['QUERY_STRING'] = ''
+
+    # Wall-clock warning: despite its name, getHashingFieldStorage will actually process the entire form to disk. This involves recieving the entire upload stream and storing any files in the tempdir.
+    form = getHashingFieldStorage(tempdir.name, DEFAULT_HASH_ALG)(
+        fp=request.body_file, environ=env, keep_blank_values=True
+    )
+
+    return (form, tempdir)
 
 def getHashingFieldStorage(upload_dir, hash_alg):
     class HashingFieldStorage(cgi.FieldStorage):
@@ -74,7 +144,7 @@ class FileStore(object):
     The operations could be safely interleaved with other actions like permission checks or database updates.
     """
 
-    def __init__(self, request, dest_path, filename=None, hash_alg='sha384'):
+    def __init__(self, request, dest_path, filename=None, hash_alg=DEFAULT_HASH_ALG):
         self.body = request.body_file
         self.environ = request.environ.copy()
         self.environ.setdefault('CONTENT_LENGTH', '0')
@@ -136,11 +206,12 @@ def identical(hash_0, path_0, hash_1, path_1):
     else:
         return hash_0 == hash_1
 
+# TODO: Hopefully deprecated by unification branch
 class MultiFileStore(object):
     """This class provides and interface for file uploads.
     """
 
-    def __init__(self, request, dest_path, filename=None, hash_alg='sha384'):
+    def __init__(self, request, dest_path, filename=None, hash_alg=DEFAULT_HASH_ALG):
         self.body = request.body_file
         self.environ = request.environ.copy()
         self.environ.setdefault('CONTENT_LENGTH', '0')

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -4,13 +4,15 @@ import copy
 import datetime
 
 from .. import base
-from .. import util
+from .. import config
 from .. import files
 from .. import rules
-from .. import config
-from .. import validators
 from .. import tempdir as tempfile
+from .. import upload
+from .. import util
+from .. import validators
 from ..auth import listauth, always_ok
+from ..dao import noop
 from ..dao import liststorage
 from ..dao import APIStorageException
 
@@ -353,54 +355,14 @@ class FileListHandler(ListHandler):
         return result
 
     def post(self, cont_name, list_name, **kwargs):
-        force = self.is_true('force')
-        _id = kwargs.pop('cid')
-        container, permchecker, storage, mongo_validator, payload_validator, keycheck = self._initialize_request(cont_name, list_name, _id)
 
-        result = None
-        with tempfile.TemporaryDirectory(prefix='.tmp', dir=config.get_item('persistent', 'data_path')) as tempdir_path:
-            file_store = files.FileStore(self.request, tempdir_path, filename=kwargs.get('name'))
-            payload = file_store.payload
-            file_datetime = datetime.datetime.utcnow()
-            file_properties = {
-                'name': file_store.filename,
-                'size': file_store.size,
-                'hash': file_store.hash,
-                'created': file_datetime,
-                'modified': file_datetime,
-            }
-            if file_store.metadata:
-                file_properties['metadata'] = file_store.metadata
-                if file_store.metadata.get('mimetype'):
-                    file_properties['mimetype'] = file_store.metadata['mimetype']
-            if file_store.tags:
-                file_properties['tags'] = file_store.tags
-            dest_path = os.path.join(config.get_item('persistent', 'data_path'), util.path_from_hash(file_properties['hash']))
-            query_params = None
-            if not force:
-                method = 'POST'
-            else:
-                filename = file_store.filename
-                filepath = file_store.path
-                for f in container.get('files', []):
-                    if f['name'] == filename:
-                        if file_store.identical(filepath, f['hash']):
-                            log.debug('Dropping    %s (identical)' % filename)
-                            os.remove(filepath)
-                            return {'modified': 0}
-                        else:
-                            log.debug('Replacing   %s' % filename)
-                            method = 'PUT'
-                            query_params = {'name':filename}
-                        break
-                else:
-                    method = 'POST'
-            file_store.move_file(dest_path)
-            payload_validator(payload, method)
-            payload.update(file_properties)
-            payload['mimetype'] = payload.get('mimetype') or util.guess_mimetype(file_store.filename)
-            result = keycheck(mongo_validator(permchecker(storage.exec_op)))(method, _id=_id, query_params=query_params, payload=payload)
-            if not result or result.modified_count != 1:
-                self.abort(404, 'Element not added in list {} of container {} {}'.format(storage.list_name, storage.cont_name, _id))
-            rules.create_jobs(config.db, container, cont_name[:-1], payload)
-        return {'modified': result.modified_count}
+        # TODO: plural consistency
+        cont_name = cont_name[:-1]
+
+        _id = kwargs.pop('cid')
+
+        # Authorize
+        container, permchecker, storage, mongo_validator, payload_validator, keycheck = self._initialize_request(cont_name + 's', list_name, _id)
+        permchecker(noop)('POST', _id=_id)
+
+        return upload.process_upload(self.request, upload.Strategy.targeted, cont_name, _id)

--- a/api/placer.py
+++ b/api/placer.py
@@ -166,9 +166,10 @@ class PackfilePlacer(Placer):
         self.s_label = self.metadata['session']['label']
         self.a_label = self.metadata['acquisition']['label']
 
-        # Get project permissions
+        # Get project info that we need later
         project = config.db['projects'].find_one({ '_id': bson.ObjectId(self.p_id)})
         self.permissions = project.get('permissions', {})
+        self.g_id = project['group']
 
         # If a timestamp was provided, use that for zip files. Otherwise use a set date.
         # Normally we'd use epoch, but zips cannot support years older than 1980, so let's use that instead.
@@ -239,7 +240,8 @@ class PackfilePlacer(Placer):
         # Get or create a session based on the hierarchy and provided labels.
         s = {
             'project': bson.ObjectId(self.p_id),
-            'label': self.s_label
+            'label': self.s_label,
+            'group': self.g_id
         }
 
         # self.permissions

--- a/api/placer.py
+++ b/api/placer.py
@@ -1,0 +1,278 @@
+import bson
+import copy
+import datetime
+import dateutil
+import os
+import pymongo
+import zipfile
+
+from . import base
+from . import config
+from . import files
+from . import rules
+from . import tempdir as tempfile
+from . import util
+from . import validators
+from .dao import reaperutil, APIStorageException
+
+
+class Placer(object):
+    """
+    Interface for a placer, which knows how to process files and place them where they belong - on disk and database.
+    """
+
+    def __init__(self, container_type, container, id, metadata, timestamp):
+        self.container_type = container_type
+        self.container	  = container
+        self.id			 = id
+        self.metadata	   = metadata
+        self.timestamp	  = timestamp
+
+    def check(self):
+        """
+        Run any pre-processing checks. Expected to throw on error.
+        """
+        raise NotImplementedError()
+
+    def process_file_field(self, field, info):
+        """"
+        Process a single file field.
+        """
+        raise NotImplementedError()
+
+    def finalize(self):
+        """
+        Run any post-processing work. Expected to return output for the callee.
+        """
+        raise NotImplementedError()
+
+    def requireTarget(self):
+        """
+        Helper function that throws unless a container was provided.
+        """
+        if self.id is None or self.container is None or self.container_type is None:
+            raise Exception('Must specify a target')
+
+    def requireMetadata(self):
+        """
+        Helper function that throws unless metadata was provided.
+        """
+        if self.metadata == None:
+            raise Exception('Metadata required')
+
+    def save_file(self, field, info):
+        """
+        Helper function that moves a file saved via a form field into our CAS.
+        May trigger jobs, if applicable, so this should only be called once we're ready for that.
+
+        Requires an augmented file field; see process_upload() for details.
+        """
+
+        # Save file
+        files.move_form_file_field_into_cas(field)
+
+        # Update the DB
+        reaperutil.upsert_fileinfo(self.container_type, self.id, info)
+
+        # Queue any jobs as a result of this upload
+        rules.create_jobs(config.db, self.container, self.container_type, info)
+
+
+class TargetedPlacer(Placer):
+    """
+    A placer that can accept N files to a specific container (acquisition, etc).
+
+    LIMITATION: To temporarily avoid messing with the JSON schema, this endpoint can only consume one file :(
+    An exception is thrown in upload.process_upload() if you try. This could be fixed by making a better schema.
+    """
+
+    def check(self):
+        self.requireTarget()
+        validators.validate_data(self.metadata, 'file.json', 'POST', optional=True)
+        self.saved = []
+
+    def process_file_field(self, field, info):
+        self.save_file(field, info)
+        self.saved.append(info)
+
+    def finalize(self):
+        return self.saved
+
+
+class ReaperPlacer(Placer):
+    """
+    A placer that can accept files sent to it from a reaper.
+    Currently a stub.
+    """
+
+    # def check(self):
+    # 	self.requireMetadata()
+
+    # def process_file_field(self, field, info):
+    # 	pass
+
+    # def finalize(self):
+    # 	pass
+
+
+class EnginePlacer(Placer):
+    """
+    A placer that can accept files sent to it from an engine.
+    Currently a stub.
+    """
+
+    def check(self):
+        self.requireTarget()
+        validators.validate_data(self.metadata, 'enginemetadata.json', 'POST', optional=True)
+
+    def process_file_field(self, field, info):
+        if self.metadata is not None:
+            # OPPORTUNITY: hard-coded container levels will need to go away soon
+            # Engine shouldn't know about container names; maybe parent contexts?
+            # How will this play with upload unification? Unify schemas as well?
+            file_mds = self.metadata.get('acquisition', {}).get('files', [])
+
+            for file_md in file_mds:
+                if file_md['name'] == info['name']:
+                    break
+            else:
+                file_md = None
+
+            for x in ('type', 'instrument', 'measurements', 'tags', 'metadata'):
+                info[x] = file_md.get(x) or info[x]
+
+        self.save_file(field, info)
+
+    def finalize(self):
+        # Updating various properties of the hierarchy; currently assumes acquisitions; might need fixing for other levels.
+        # NOTE: only called in EnginePlacer
+        bid = bson.ObjectId(self.id)
+        self.obj = reaperutil.update_container_hierarchy(self.metadata, bid, '')
+
+        return {}
+
+
+class PackfilePlacer(Placer):
+    """
+    A place that can accept N files, save them into a zip archive, and place the result on an acquisition.
+    """
+
+    def check(self):
+        self.requireMetadata()
+        validators.validate_data(self.metadata, 'packfile.json', 'POST')
+
+        # Save required fields
+        self.p_id  = self.metadata['project']['_id']
+        self.s_label = self.metadata['session']['label']
+        self.a_label = self.metadata['acquisition']['label']
+
+        # If a timestamp was provided, use that for zip files. Otherwise use a set date.
+        # Normally we'd use epoch, but zips cannot support years older than 1980, so let's use that instead.
+        # Then, given the ISO string, convert it to an epoch integer.
+        minimum = datetime.datetime(1980, 1, 1).isoformat()
+        stamp   = self.metadata['acquisition'].get('timestamp', minimum)
+        self.ziptime = int(dateutil.parser.parse(stamp).strftime('%s'))
+
+        # The zipfile is a santizied acquisition label
+        self.dir = util.sanitize_string_to_filename(self.a_label)
+        self.name = self.dir + '.zip'
+
+        # Make a tempdir to store zip until moved
+        # OPPORTUNITY: this is also called in files.py. Could be a util func.
+        self.tempdir = tempfile.TemporaryDirectory(prefix='.tmp', dir=config.get_item('persistent', 'data_path'))
+
+        # Create a zip in the tempdir that later gets moved into the CAS.
+        self.path = os.path.join(self.tempdir.name, 'temp.zip')
+        self.zip  = zipfile.ZipFile(self.path, 'w', zipfile.ZIP_DEFLATED, allowZip64=True)
+
+        # OPPORTUNITY: add zip comment
+        # self.zip.comment = json.dumps(metadata, default=metadata_encoder)
+
+        # Bit of a silly hack: write our tempdir directory into the zip (not including its contents).
+        # Creates an empty directory entry in the zip which will hold all the files inside.
+        # This way, when you expand a zip, you'll get folder/things instead of a thousand dicoms splattered everywhere.
+        self.zip.write(self.tempdir.name, self.dir)
+
+    def process_file_field(self, field, info):
+        # Set the file's mtime & atime.
+        os.utime(field.path, (self.ziptime, self.ziptime))
+
+        # Place file into the zip folder we created before
+        self.zip.write(field.path, os.path.join(self.dir, field.filename))
+
+    def finalize(self):
+        self.zip.close()
+
+        # Create an anyonmous object in the style of our augmented file fields.
+        # Not a great practice. See process_upload() for details.
+        cgi_field = util.obj_from_map({
+            'filename': self.name,
+            'path':	 self.path,
+            'size':	 os.path.getsize(self.path),
+            'hash':	 files.hash_file_formatted(self.path),
+            'mimetype': util.guess_mimetype('lol.zip'),
+            'modified': self.timestamp
+        })
+
+        # Similarly, create the info map that is consumed by helper funcs. Clear duplication :(
+        # This could be coalesced into a single map thrown on file fields, for example.
+        # Used in the API return.
+        cgi_info = {
+            'name':	 cgi_field.filename,
+            'modified': cgi_field.modified,
+            'size':	 cgi_field.size,
+            'hash':	 cgi_field.hash,
+
+            'type': self.metadata['packfile']['type'],
+
+            # OPPORTUNITY: packfile endpoint could be extended someday to take additional metadata.
+            'instrument': None,
+            'measurements': [],
+            'tags': [],
+            'metadata': {}
+        }
+
+        # Get or create a session based on the hierarchy and provided labels.
+        s = {
+            'project': bson.ObjectId(self.p_id),
+            'label': self.s_label
+        }
+
+        # Add the subject if one was provided
+        new_s = copy.deepcopy(s)
+        subject = self.metadata['session'].get('subject')
+        if subject is not None:
+            new_s['subject'] = subject
+
+        session = config.db['session' + 's'].find_one_and_update(s, {
+                '$set': new_s
+            },
+            upsert=True,
+            return_document=pymongo.collection.ReturnDocument.AFTER
+        )
+
+        # Get or create an acquisition based on the hierarchy and provided labels.
+        fields = {
+            'session': session['_id'],
+            'label': self.a_label
+        }
+
+        acquisition = config.db['acquisition' + 's'].find_one_and_update(fields, {
+                '$set': fields
+            },
+            upsert=True,
+            return_document=pymongo.collection.ReturnDocument.AFTER
+        )
+
+        # Set instance target for helper func
+        self.container_type = 'acquisition'
+        self.id			 = str(acquisition['_id'])
+        self.container	  = acquisition
+
+        self.save_file(cgi_field, cgi_info)
+
+        return {
+            'acquisition_id': str(acquisition['_id']),
+            'session_id':	 str(session['_id']),
+            'info': cgi_info
+        }

--- a/api/schemas/input/packfile.json
+++ b/api/schemas/input/packfile.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Packfile",
+    "type": "object",
+    "properties": {
+        "project":      {
+            "type": "object",
+            "properties": {
+                "_id":          {"type": "string"}
+            },
+            "additionalProperties": false,
+            "required": ["_id"]
+        },
+        "session":      {
+            "type": "object",
+            "properties": {
+                "label":        {"type": "string"},
+                "subject":      {"$ref": "subject.json"}
+            },
+            "additionalProperties": false,
+            "required": ["label"]
+        },
+        "acquisition":  {
+            "type": "object",
+            "properties": {
+                "label":        {"type": "string"},
+                "timestamp":    {"type": "string", "format": "date-time"},
+                "timezone":     {"type": "string"}
+            },
+            "additionalProperties": false,
+            "required": ["label"]
+        },
+        "packfile":  {
+            "type": "object",
+            "properties": {
+                "type":         {"type": "string"}
+            },
+            "additionalProperties": false,
+            "required": ["type"]
+        }
+    },
+    "required": ["project", "session", "acquisition", "packfile"],
+    "additionalProperties": false
+}

--- a/api/upload.py
+++ b/api/upload.py
@@ -266,7 +266,3 @@ class Upload(base.RequestHandler):
                     rules.create_jobs(config.db, acquisition_obj, 'acquisition', file_)
             return [{'name': k, 'hash': v.info.get('hash'), 'size': v.info.get('size')} for k, v in merged_files.items()]
 
-    def packfile(self):
-        # TODO: Perm check
-
-        return process_upload(self.request, Strategy.packfile)

--- a/api/upload.py
+++ b/api/upload.py
@@ -1,17 +1,129 @@
 import bson
-import os.path
 import datetime
+import json
+import os.path
 
 from . import base
-from . import util
+from . import config
 from . import files
 from . import rules
-from . import config
-from .dao import reaperutil, APIStorageException
-from . import validators
 from . import tempdir as tempfile
+from . import placer as pl
+from . import util
+from . import validators
+from .dao import reaperutil, APIStorageException
 
 log = config.log
+
+Strategy = util.Enum('Strategy', {
+    'targeted' : pl.TargetedPlacer,   # Upload N files to a container.
+    'reaper':    pl.ReaperPlacer,     # Upload N files from a scientific data source.
+    'engine'   : pl.EnginePlacer,	  # Upload N files from the result of a successful job.
+    'packfile' : pl.PackfilePlacer	  # Upload N files as a new packfile to a container.
+})
+
+def process_upload(request, strategy, container_type=None, id=None):
+    """
+    Universal file upload entrypoint.
+
+    Format:
+        Multipart form upload with N file fields, each with their desired filename.
+        For technical reasons, no form field names can be repeated. Instead, use (file1, file2) and so forth.
+
+        Depending on the type of upload, a non-file form field called "metadata" may/must also be sent.
+        If present, it is expected to be a JSON string matching the schema for the upload strategy.
+
+        Currently, the JSON returned may vary by strategy.
+
+        Some examples:
+        curl -F file1=@science.png   -F file2=@rules.png url
+        curl -F metadata=<stuff.json -F file=@data.zip   url
+        http --form POST url metadata=@stuff.json file@data.zip
+
+    Features:
+                                               | targeted |  reaper   | engine | packfile
+        Must specify a target container        |     X    |           |    X   |
+        May create hierarchy on demand         |          |     X     |        |     X
+
+        May  send metadata about the files     |     X    |     X     |    X   |     X
+        MUST send metadata about the files     |          |     X     |        |     X
+
+        Creates a packfile from uploaded files |          |           |        |     X
+    """
+
+    if not isinstance(strategy, Strategy):
+        raise Exception('Unknown upload strategy')
+
+    if id is not None and container_type == None:
+        raise Exception('Unspecified container type')
+
+    if container_type is not None and container_type not in ('acquisition', 'session', 'project', 'collection'):
+        raise Exception('Unknown container type')
+
+    timestamp = datetime.datetime.utcnow()
+
+    container = None
+    if container_type and id:
+        container = reaperutil.get_container(container_type, id)
+
+    # The vast majority of this function's wall-clock time is spent here.
+    # Tempdir is deleted off disk once out of scope, so let's hold onto this reference.
+    form, tempdir = files.process_form(request)
+
+    metadata = None
+    if 'metadata' in form:
+        # Slight misnomer: the metadata field, if present, is sent as a normal form field, NOT a file form field.
+        metadata = json.loads(form['metadata'].file.getvalue())
+
+    placer_class = strategy.value
+    placer = placer_class(container_type, container, id, metadata, timestamp)
+    placer.check()
+
+    # Browsers, when sending a multipart upload, will send files with field name "file" (if sinuglar)
+    # or "file1", "file2", etc (if multiple). Following this convention is probably a good idea.
+    # Here, we accept any
+    file_fields = filter(lambda x: form[x].filename is not None, form)
+
+    # TODO: Change schemas to enabled targeted uploads of more than one file.
+    # Ref docs from placer.TargetedPlacer for details.
+    if strategy == Strategy.targeted and len(file_fields) > 1:
+        raise Exception("Targeted uploads can only send one file")
+
+    for field in file_fields:
+        field = form[field]
+
+        # Sanitize form's filename (read: prevent malicious escapes, bad characters, etc)
+        field.filename = os.path.basename(field.filename)
+        field.filename = util.sanitize_string_to_filename(field.filename)
+
+        # Augment the cgi.FieldStorage with a variety of custom fields.
+        # Not the best practice. Open to improvements.
+        # These are presumbed to be required by every function later called with field as a parameter.
+        field.path	 = os.path.join(tempdir.name, field.filename)
+        field.size	 = os.path.getsize(field.path)
+        field.hash	 = field.file.get_formatted_hash()
+        field.mimetype = util.guess_mimetype(field.filename) # TODO: does not honor metadata's mime type if any
+        field.modified = timestamp
+
+        # create a file-info map commonly used elsewhere in the codebase.
+        # Stands in for a dedicated object... for now.
+        info = {
+            'name':	 field.filename,
+            'modified': field.modified, #
+            'size':	 field.size,
+            'hash':	 field.hash,
+
+            'type': None,
+            'instrument': None,
+            'measurements': [],
+            'tags': [],
+            'metadata': {}
+        }
+
+        placer.process_file_field(field, info)
+
+    return placer.finalize()
+
 
 class Upload(base.RequestHandler):
 
@@ -153,3 +265,8 @@ class Upload(base.RequestHandler):
                     }
                     rules.create_jobs(config.db, acquisition_obj, 'acquisition', file_)
             return [{'name': k, 'hash': v.info.get('hash'), 'size': v.info.get('size')} for k, v in merged_files.items()]
+
+    def packfile(self):
+        # TODO: Perm check
+
+        return process_upload(self.request, Strategy.packfile)

--- a/api/util.py
+++ b/api/util.py
@@ -79,6 +79,24 @@ def guess_mimetype(filepath):
     mime, _ = mimetypes.guess_type(filepath)
     return mime or 'application/octet-stream'
 
+def sanitize_string_to_filename(value):
+    """
+    Best-effort attempt to remove blatantly poor characters from a string before turning into a filename.
+
+    Happily stolen from the internet.
+    http://stackoverflow.com/a/7406369
+    """
+
+    keepcharacters = (' ','.','_')
+    return "".join([c for c in value if c.isalnum() or c in keepcharacters]).rstrip()
+
+def obj_from_map(_map):
+    """
+    Creates an anonymous object with properties determined by the passed (shallow) map.
+    Hides the esoteric python syntax.
+    """
+
+    return type('',(object,),_map)()
 
 def path_from_hash(hash_):
     """

--- a/api/validators.py
+++ b/api/validators.py
@@ -51,6 +51,7 @@ expected_input_schemas = set([
     'download.json',
     'tag.json',
     'enginemetadata.json',
+    'packfile.json',
     'uploader.json',
     'reaper.json'
 ])
@@ -70,6 +71,19 @@ for schema_filepath in glob.glob(schema_path + '/schemas/input/*.json'):
     resolver_input.resolve(schema_file)
 
 assert input_schemas == expected_input_schemas, '{} is different from {}'.format(input_schemas, expected_input_schemas)
+
+def validate_data(data, schema_name, verb, optional=False):
+    """
+    Convenience method to validate a JSON schema against some action.
+
+    If optional is set, validate_data won't complain about null data.
+    """
+
+    if optional and data is None:
+        return
+
+    validator = payload_from_schema_file(schema_name)
+    validator(data, verb)
 
 def _validate_json(json_data, schema, resolver):
     jsonschema.validate(json_data, schema, resolver=resolver)


### PR DESCRIPTION
This constitutes a significant overhaul of file upload processing into logic that can be deduplicated, made consistent, and eventually optimized.

Two of four upload scenarios are covered by this change: targeted (files to a single container), and a new mode packfile (files to a single zip archive). Connector and engine uploads have not been modified, but clear groundwork is laid for that transition.

Relates #159.