### PR TITLE
Add origin tracking to files

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -370,7 +370,7 @@ class FileListHandler(ListHandler):
         container, permchecker, storage, mongo_validator, payload_validator, keycheck = self._initialize_request(cont_name_plural, list_name, _id)
         permchecker(noop)('POST', _id=_id)
 
-        return upload.process_upload(self.request, upload.Strategy.targeted, cont_name, _id, self.origin)
+        return upload.process_upload(self.request, upload.Strategy.targeted, container_type=cont_name, id=_id, origin=self.origin)
 
     def packfile(self, cont_name, **kwargs):
         _id = kwargs.pop('cid')
@@ -396,4 +396,4 @@ class FileListHandler(ListHandler):
             else:
                 raise Exception('Not authorized')
 
-        return upload.process_upload(self.request, upload.Strategy.packfile, None, None, self.origin)
+        return upload.process_upload(self.request, upload.Strategy.packfile, origin=self.origin)

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -370,7 +370,7 @@ class FileListHandler(ListHandler):
         container, permchecker, storage, mongo_validator, payload_validator, keycheck = self._initialize_request(cont_name_plural, list_name, _id)
         permchecker(noop)('POST', _id=_id)
 
-        return upload.process_upload(self.request, upload.Strategy.targeted, cont_name, _id)
+        return upload.process_upload(self.request, upload.Strategy.targeted, cont_name, _id, self.origin)
 
     def packfile(self, cont_name, **kwargs):
         _id = kwargs.pop('cid')
@@ -396,4 +396,4 @@ class FileListHandler(ListHandler):
             else:
                 raise Exception('Not authorized')
 
-        return upload.process_upload(self.request, upload.Strategy.packfile)
+        return upload.process_upload(self.request, upload.Strategy.packfile, None, None, self.origin)

--- a/api/placer.py
+++ b/api/placer.py
@@ -21,12 +21,13 @@ class Placer(object):
     Interface for a placer, which knows how to process files and place them where they belong - on disk and database.
     """
 
-    def __init__(self, container_type, container, id, metadata, timestamp):
+    def __init__(self, container_type, container, id, metadata, timestamp, origin):
         self.container_type = container_type
-        self.container	  = container
-        self.id			 = id
-        self.metadata	   = metadata
-        self.timestamp	  = timestamp
+        self.container      = container
+        self.id             = id
+        self.metadata       = metadata
+        self.timestamp      = timestamp
+        self.origin         = origin
 
     def check(self):
         """
@@ -234,7 +235,11 @@ class PackfilePlacer(Placer):
             'instrument': None,
             'measurements': [],
             'tags': [],
-            'metadata': {}
+            'metadata': {},
+
+            # Manually add the file orign to the packfile metadata.
+            # This is set by upload.process_upload on each file, but we're not storing those.
+            'origin': self.origin
         }
 
         # Get or create a session based on the hierarchy and provided labels.

--- a/api/placer.py
+++ b/api/placer.py
@@ -89,7 +89,7 @@ class TargetedPlacer(Placer):
 
     def check(self):
         self.requireTarget()
-        validators.validate_data(self.metadata, 'file.json', 'POST', optional=True)
+        validators.validate_data(self.metadata, 'file.json', 'input', 'POST', optional=True)
         self.saved = []
 
     def process_file_field(self, field, info):
@@ -124,7 +124,7 @@ class EnginePlacer(Placer):
 
     def check(self):
         self.requireTarget()
-        validators.validate_data(self.metadata, 'enginemetadata.json', 'POST', optional=True)
+        validators.validate_data(self.metadata, 'enginemetadata.json', 'input', 'POST', optional=True)
 
     def process_file_field(self, field, info):
         if self.metadata is not None:
@@ -160,7 +160,7 @@ class PackfilePlacer(Placer):
 
     def check(self):
         self.requireMetadata()
-        validators.validate_data(self.metadata, 'packfile.json', 'POST')
+        validators.validate_data(self.metadata, 'packfile.json', 'input', 'POST')
 
         # Save required fields
         self.p_id  = self.metadata['project']['_id']

--- a/api/types.py
+++ b/api/types.py
@@ -1,0 +1,9 @@
+from . import util
+
+# Origin represents the different methods a request can be authenticated.
+Origin = util.Enum('Origin', {
+    'user':    'user',    # An authenticated user
+    'device':  'device',  # A connected device (reaper, script, etc)
+    'job':     'job',     # Made on behalf of a job (downloading data, uploading results, etc)
+    'unknown': 'unknown', # Other or public
+})

--- a/api/util.py
+++ b/api/util.py
@@ -149,3 +149,17 @@ class Enum(baseEnum.Enum):
     # This overrides that behaviour and removes the prefix.
     def __str__(self):
         return str(self.name)
+
+    # Allow equality comparison with strings against the enum's name.
+
+    def __ne__(self, other):
+        if isinstance(other, basestring):
+            return self.name != other
+        else:
+            return super.__ne__(other)
+
+    def __eq__(self, other):
+        if isinstance(other, basestring):
+            return self.name == other
+        else:
+            return super.__eq__(other)

--- a/api/validators.py
+++ b/api/validators.py
@@ -2,6 +2,7 @@ import os
 import re
 import copy
 import json
+import util
 import requests
 import jsonschema
 from jsonschema.compat import urlopen, urlsplit
@@ -16,7 +17,7 @@ class InputValidationException(Exception):
 class DBValidationException(Exception):
     pass
 
-def validate_data(data, schema_url, verb, optional=False):
+def validate_data(data, schema_json, schema_type, verb, optional=False):
     """
     Convenience method to validate a JSON schema against some action.
 
@@ -26,7 +27,8 @@ def validate_data(data, schema_url, verb, optional=False):
     if optional and data is None:
         return
 
-    validator = from_schema_path(schema_url)
+    schema_uri = util.schema_uri(schema_type, schema_json)
+    validator = from_schema_path(schema_uri)
     validator(data, verb)
 
 def _validate_json(json_data, schema, resolver):


### PR DESCRIPTION
All files now have an `origin` map, with a `type` string (device, user, job, or unknown) and an `id` field pointing to the corresponding document. If a file was stored before this change, the type returns unknown.

In addition, routes that return an object, or objects, with a `files` array, can now take an optional `join=origin` request parameter. This will add a `join-origin` key to each object, containing a context map of the various origin documents. Use this to prevent N calls to various other endpoints. 

Example:

```js
// on the file object
 "origin": {
      "type": "user",  // can be user | device | job | unknown
      "id": "nathanielkofalt@invenshure.com"
    }
```

Example of a `join-origin`:

```js
{
    "files": [ 
        { "origin": { "type":"user", "id":"foo" }}
        // ... 
    ],

    "join-origin": {
        "users":    {"foo": obj, "bar": obj },
        "devices":  {"foo": obj},
        "jobs":     {"foo": obj}
    }
}
```

Along the way, the job generator had to gain additional insight to throw job IDs onto upload URLs, the Placer gained an origin field for placing files, not-Placer uploads had origin hacked into them, and the base request init now knows a bit more about the requester.

Closes #163.