### PR TITLE
Add archiving functionality for containers

### DIFF
--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -33,7 +33,10 @@ def default_container(handler, container=None, target_parent_container=None):
                     _get_access(handler.uid, handler.user_site, target_parent_container) >= INTEGER_ROLES['admin']
                 )
             elif method == 'PUT' and target_parent_container is None:
-                has_access = _get_access(handler.uid, handler.user_site, container) >= INTEGER_ROLES['rw']
+                required_perm = 'rw'
+                if 'archived' in payload.keys():
+                    required_perm = 'admin'
+                has_access = _get_access(handler.uid, handler.user_site, container) >= INTEGER_ROLES[required_perm]
             else:
                 has_access = False
 

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -73,6 +73,8 @@ class ContainerStorage(object):
         elif self.cont_name == "sessions":
             config.db.acquisitions.update_many(
                 {'session': _id}, update)
+        else:
+            raise ValueError('changes can only be propagated from project or session level')
 
     def _delete_el(self, _id):
         if self.use_object_id:

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -23,7 +23,8 @@ class ContainerStorage(object):
     def get_container(self, _id):
         return self._get_el(_id)
 
-    def exec_op(self, action, _id=None, payload=None, query=None, user=None, public=False, projection=None):
+    def exec_op(self, action, _id=None, payload=None, query=None, user=None, 
+                public=False, projection=None, recursive=False):
         """
         Generic method to exec an operation.
         The request is dispatched to the corresponding private methods.
@@ -36,7 +37,7 @@ class ContainerStorage(object):
         if action == 'DELETE':
             return self._delete_el(_id)
         if action == 'PUT':
-            return self._update_el(_id, payload)
+            return self._update_el(_id, payload, recursive)
         if action == 'POST':
             return self._create_el(payload)
         raise ValueError('action should be one of GET, POST, PUT, DELETE')
@@ -45,7 +46,7 @@ class ContainerStorage(object):
         log.debug(payload)
         return self.dbc.insert_one(payload)
 
-    def _update_el(self, _id, payload):
+    def _update_el(self, _id, payload, recursive=False):
         update = {
             '$set': util.mongo_dict(payload)
         }
@@ -54,7 +55,24 @@ class ContainerStorage(object):
                 _id = bson.objectid.ObjectId(_id)
             except bson.errors.InvalidId as e:
                 raise APIStorageException(e.message)
+        if recursive:
+            self._propagate_changes(_id, update)
         return self.dbc.update_one({'_id': _id}, update)
+
+    def _propagate_changes(self, _id, update):
+        """
+        Propagates changes down the heirarchy tree when a PUT is marked as recursive.
+        """
+
+        if self.cont_name == "projects":
+            session_ids = [s['_id'] for s in config.db.sessions.find({'project': _id}, [])]
+            config.db.sessions.update_many(
+                {'project': _id}, update)
+            config.db.acquisitions.update_many(
+                {'session': {'$in': session_ids}}, update)
+        elif self.cont_name == "sessions":
+            config.db.acquisitions.update_many(
+                {'session': _id}, update)
 
     def _delete_el(self, _id):
         if self.use_object_id:

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -132,6 +132,9 @@ class ContainerHandler(base.RequestHandler):
             query = {par_cont_name[:-1]: par_id}
         else:
             query = {}
+        # only return unarchived sessions and acquisitions when includeArchived flag is present
+        if cont_name in ['sessions', 'acquisitions'] and not self.is_true('includeArchived'):
+            query['archived'] = {'$ne': True}
         # this request executes the actual reqeust filtering containers based on the user permissions
         results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection)
         if results is None:

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -132,8 +132,7 @@ class ContainerHandler(base.RequestHandler):
             query = {par_cont_name[:-1]: par_id}
         else:
             query = {}
-        # only return unarchived sessions and acquisitions when includeArchived flag is present
-        if cont_name in ['sessions', 'acquisitions'] and not self.is_true('includeArchived'):
+        if not self.is_true('includeArchived'):
             query['archived'] = {'$ne': True}
         # this request executes the actual reqeust filtering containers based on the user permissions
         results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection)

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -257,7 +257,7 @@ class ContainerHandler(base.RequestHandler):
         payload_validator(payload, 'PUT')
         # Check if any payload keys are a propogated property, ensure they all are
         rec = False
-        if set(payload.keys()).intersection(set(self.config['propagated_properties'])):
+        if set(payload.keys()).intersection(set(self.config.get('propagated_properties', []))):
             if not set(payload.keys()).issubset(set(self.config['propagated_properties'])):
                 self.abort(400, 'Cannot update propagated properties together with unpropagated properties')
             else:

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -257,7 +257,7 @@ class ContainerHandler(base.RequestHandler):
         payload_validator(payload, 'PUT')
         # Check if any payload keys are a propogated property, ensure they all are
         rec = False
-        if set(payload.keys()) & set(self.config['propagated_properties']):
+        if set(payload.keys()).intersection(set(self.config['propagated_properties'])):
             if not set(payload.keys()).issubset(set(self.config['propagated_properties'])):
                 self.abort(400, 'Cannot update propagated properties together with unpropagated properties')
             else:

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -132,7 +132,7 @@ class ContainerHandler(base.RequestHandler):
             query = {par_cont_name[:-1]: par_id}
         else:
             query = {}
-        if not self.is_true('includeArchived'):
+        if not self.is_true('archived'):
             query['archived'] = {'$ne': True}
         # this request executes the actual reqeust filtering containers based on the user permissions
         results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection)
@@ -305,7 +305,6 @@ class ContainerHandler(base.RequestHandler):
         """
         group_ids = list(set((p['group'] for p in self.get_all('projects'))))
         return list(config.db.groups.find({'_id': {'$in': group_ids}}, ['name']))
-
 
     def _get_validators(self):
         mongo_validator = validators.mongo_from_schema_file(self.config.get('storage_schema_file'))

--- a/api/schemas/input/acquisition.json
+++ b/api/schemas/input/acquisition.json
@@ -5,6 +5,7 @@
     "allOf": [{"$ref": "container.json"}],
     "properties": {
         "public": {},
+        "archived": {},
         "label": {},
         "metadata": {},
 

--- a/api/schemas/input/container.json
+++ b/api/schemas/input/container.json
@@ -4,6 +4,7 @@
     "properties": {
         "_id":          {"type": "string"},
         "public":       {"type": "boolean"},
+        "archived":     {"type": "boolean"},
         "label":        {"type": "string", "minLength": 1, "maxLength": 256},
         "metadata":     {"type": "object"}
     }

--- a/api/schemas/input/project.json
+++ b/api/schemas/input/project.json
@@ -5,6 +5,7 @@
     "allOf": [{"$ref": "container.json"}],
     "properties": {
         "public": {},
+        "archived": {},
         "label": {},
         "metadata": {},
 

--- a/api/schemas/input/session.json
+++ b/api/schemas/input/session.json
@@ -5,6 +5,7 @@
     "allOf": [{"$ref": "container.json"}],
     "properties": {
         "public": {},
+        "archived": {},
         "label": {},
         "metadata": {},
 

--- a/api/schemas/mongo/acquisition.json
+++ b/api/schemas/mongo/acquisition.json
@@ -9,6 +9,7 @@
         "permissions": {},
         "files": {},
         "public": {},
+        "archived": {},
         "label": {},
         "tags": {},
         "metadata": {},

--- a/api/schemas/mongo/container.json
+++ b/api/schemas/mongo/container.json
@@ -9,6 +9,7 @@
         "permissions":  {"type": "array",  "items": {"$ref": "permission.json"}},
         "files":        {"type": "array",  "items": {"$ref": "file.json"}},
         "public":       {"type": "boolean"},
+        "archived":     {"type": "boolean"},
         "label":        {"type": "string"},
         "tags":         {"type": "array", "items": {"type": "string"}},
         "metadata":     {"type": "object"}

--- a/api/schemas/mongo/project.json
+++ b/api/schemas/mongo/project.json
@@ -10,6 +10,7 @@
         "permissions": {},
         "files": {},
         "public": {},
+        "archived": {},
         "label": {},
         "tags": {},
         "metadata": {},

--- a/api/schemas/mongo/session.json
+++ b/api/schemas/mongo/session.json
@@ -10,6 +10,7 @@
         "permissions": {},
         "files": {},
         "public": {},
+        "archived": {},
         "label": {},
         "tags": {},
         "metadata": {},


### PR DESCRIPTION
This request was fulfilled by creating a generic way to push changes down the hierarchy tree. If a property is added to the propagated_properties list on the config in containerhandler.py, any PUT with a payload containing that property will also be applied to children of that object. For example, if a project is marked as 'archived': true, all sessions and acquisitions under that project will also be marked as archived. 

All calls to get_all on a container will only return unarchived objects unless an archived=true flag is passed in the request.

Some assumptions/decisions made:
  - direct GET requests on a specific object will return the object regardless of archived status
  - currently only allows the entire payload to be propagated values or not, throws a 400 if the payload is of mixed property types (this could be changed in the future by creating a different payload on the fly for the child objects instead)
  - only does input and mongo validation on original container type being updated (checking the entire tree each time would only check that the API writers didn't add something to the propagated values list that shouldn't logically be in there)
  - eventually permissions changes and other changes that push down the hierarchy tree can be rolled into the list
  - the PUT will still return modified: 1 when many documents are modified. 

Closes #187 