### PR TITLE
Avatar improvements

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -86,8 +86,10 @@ routes = [
     webapp2.Route(r'/api/users',            userhandler.UserHandler, methods=['POST']),
     webapp2_extras.routes.PathPrefixRoute(r'/api/users', [
         webapp2.Route(r'/self',                                 userhandler.UserHandler, handler_method='self', methods=['GET']),
+        webapp2.Route(r'/self/avatar',                          userhandler.UserHandler, handler_method='self_avatar', methods=['GET']),
         webapp2.Route(_format(r'/<_id:{user_id_re}>'),          userhandler.UserHandler, name='user'),
         webapp2.Route(_format(r'/<uid:{user_id_re}>/groups'),   grouphandler.GroupHandler, handler_method='get_all', methods=['GET'], name='groups'),
+        webapp2.Route(_format(r'/<uid:{user_id_re}>/avatar'),   userhandler.UserHandler, handler_method='avatar', methods=['GET'], name='avatar'),
     ]),
     webapp2.Route(r'/api/jobs',             jobs.Jobs),
     webapp2_extras.routes.PathPrefixRoute(r'/api/jobs', [

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -381,8 +381,6 @@ class FileListHandler(ListHandler):
         # Authorize: confirm project exists
         project = config.db['projects'].find_one({ '_id': bson.ObjectId(_id)})
 
-        print project
-
         if project is None:
             raise Exception('Project ' + _id + ' does not exist')
 


### PR DESCRIPTION
1. Moved a bunch of oauth & avatar logic out of the main application flow into their own functions.
1. Separated out the caching of tokens from their fetch / validation.
1. Added some comments to walk through the reasoning of the authN logic.
1. Removed 3rd-party network requirement (gravatar) for adding a user.
1. Added new route `/users/id/avatar` that will redirect you to the user's avatar URL, checking gravitar if applicable. 404s on no possible avatar. Result should be great for `ng-src` or `<img>`.
1. Removed some errant print statements left over from other changes.

The result should be very amicable to moving more logic into stateless classes - hooray!
I am intentionally leaving that off for now, since this is an easier changeset.

One more thing I would like to do is add a optional url param `default=url` to the new endpoint. @mrDarcyMurphy mentioned that they have some default avatars to display (as opposed to an empty white box...), but I didn't want to code in that specific route. If `default` is present it'll never 404, and instead redirect to your passed default in that case. I'll add that before merging.