### PR TITLE
Fix Mimetype Error

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -345,7 +345,7 @@ class FileListHandler(ListHandler):
                 self.response.app_iter = open(filepath, 'rb')
                 self.response.headers['Content-Length'] = str(fileinfo['size']) # must be set after setting app_iter
                 if self.is_true('view'):
-                    self.response.headers['Content-Type'] = str(fileinfo['mimetype'])
+                    self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', ''))
                 else:
                     self.response.headers['Content-Type'] = 'application/octet-stream'
                     self.response.headers['Content-Disposition'] = 'attachment; filename="' + filename + '"'

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -345,7 +345,7 @@ class FileListHandler(ListHandler):
                 self.response.app_iter = open(filepath, 'rb')
                 self.response.headers['Content-Length'] = str(fileinfo['size']) # must be set after setting app_iter
                 if self.is_true('view'):
-                    self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', ''))
+                    self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/unknown'))
                 else:
                     self.response.headers['Content-Type'] = 'application/octet-stream'
                     self.response.headers['Content-Disposition'] = 'attachment; filename="' + filename + '"'

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -345,7 +345,7 @@ class FileListHandler(ListHandler):
                 self.response.app_iter = open(filepath, 'rb')
                 self.response.headers['Content-Length'] = str(fileinfo['size']) # must be set after setting app_iter
                 if self.is_true('view'):
-                    self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/unknown'))
+                    self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/octet-stream'))
                 else:
                     self.response.headers['Content-Type'] = 'application/octet-stream'
                     self.response.headers['Content-Disposition'] = 'attachment; filename="' + filename + '"'

--- a/api/upload.py
+++ b/api/upload.py
@@ -107,6 +107,7 @@ def process_upload(request, strategy, container_type=None, id=None, origin=None)
             'name':	 field.filename,
             'modified': field.modified, #
             'size':	 field.size,
+            'mimetype': field.mimetype,
             'hash':	 field.hash,
             'origin': origin,
 


### PR DESCRIPTION
Closes https://github.com/scitran/core/issues/201

After discussion with @rentzso, we decided to go back to using `application/octet-stream` as the default mimetype. This fix is assuring files have proper mimetypes again so anytime there is a file without a mimetype it is a bug and we should prevent the browser from deciding what to do with the file. 