### PR TITLE
allow access to containers for all users

### DIFF
--- a/api/handlers/searchhandler.py
+++ b/api/handlers/searchhandler.py
@@ -128,4 +128,3 @@ class SearchHandler(base.RequestHandler):
         except elasticsearch.exceptions.ConnectionError as e:
             self.abort(503, 'elasticsearch is not available')
         return results
-


### PR DESCRIPTION
Sensitive data like subject firstname and lastname will be left off.
Also file contents won't be available.

@gsfr @nagem could you give it a look?

@dpuccetti this enables getting the name of a project for all users.