### PR TITLE
Explicit schema versioning and upgrades

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -32,6 +32,11 @@ class Config(base.RequestHandler):
             ';'
         )
 
+class Version(base.RequestHandler):
+
+    def get(self):
+        return config.get_version()
+
 #regexes used in routing table:
 routing_regexes = {
     # group id regex
@@ -77,7 +82,8 @@ routes = [
         webapp2.Route(r'/sites',            centralclient.CentralClient, handler_method='sites', methods=['GET']),
         webapp2.Route(r'/register',         centralclient.CentralClient, handler_method='register', methods=['POST']),
         webapp2.Route(r'/config',           Config, methods=['GET']),
-        webapp2.Route(r'/config.js',        Config, handler_method='get_js', methods=['GET'])
+        webapp2.Route(r'/config.js',        Config, handler_method='get_js', methods=['GET']),
+        webapp2.Route(r'/version',          Version, methods=['GET']),
     ]),
     webapp2.Route(r'/api/users',            userhandler.UserHandler, handler_method='get_all', methods=['GET']),
     webapp2.Route(r'/api/users',            userhandler.UserHandler, methods=['POST']),

--- a/api/config.py
+++ b/api/config.py
@@ -133,5 +133,8 @@ def get_public_config():
         'auth': __config.get('auth'),
     }
 
+def get_version():
+    return db.version.find_one({"_id": "version"}, {"_id":0})
+
 def get_item(outer, inner):
     return get_config()[outer][inner]

--- a/api/config.py
+++ b/api/config.py
@@ -134,7 +134,7 @@ def get_public_config():
     }
 
 def get_version():
-    return db.version.find_one({"_id": "version"}, {"_id":0})
+    return db.version.find_one({'_id': 'version'})
 
 def get_item(outer, inner):
     return get_config()[outer][inner]

--- a/bin/database.py
+++ b/bin/database.py
@@ -1,13 +1,13 @@
+#!/usr/bin/env python
 import json
 
-from .. import config
+from api import config
 
 
 print 'This is the stub database maintenance script.'
 
-print 'DB uri: ' + str(config.get_item('persistent', 'db_uri')))
+print 'DB uri: ' + str(config.get_item('persistent', 'db_uri'))
 
 user = config.db.users.find_one({})
-user_j = json.dumps(user)
 
-print 'Example user from db: ' + user_j
+print 'Example user from db: {0}'.format(user)

--- a/bin/database.py
+++ b/bin/database.py
@@ -1,0 +1,13 @@
+import json
+
+from .. import config
+
+
+print 'This is the stub database maintenance script.'
+
+print 'DB uri: ' + str(config.get_item('persistent', 'db_uri')))
+
+user = config.db.users.find_one({})
+user_j = json.dumps(user)
+
+print 'Example user from db: ' + user_j

--- a/bin/database.py
+++ b/bin/database.py
@@ -47,13 +47,13 @@ def upgrade_schema():
     try:
         if db_version < 1:
             # scitran/core issue #206
-            config.db.version.insert_one({"_id": "version", "database": CURRENT_DATABASE_VERSION})
+            config.db.version.insert_one({'_id': 'version', 'database': CURRENT_DATABASE_VERSION})
     except Exception as e:
         print 'Incremental upgrade of db failed'
         print e
         sys.exit(1)
     else:
-        config.db.version.update_one({"_id": "version"}, {"$set": {"database": CURRENT_DATABASE_VERSION}})
+        config.db.version.update_one({'_id': 'version'}, {'$set': {'database': CURRENT_DATABASE_VERSION}})
         sys.exit(0)
 try:
     if len(sys.argv) > 1:

--- a/bin/database.py
+++ b/bin/database.py
@@ -1,29 +1,48 @@
 #!/usr/bin/env python
 
-"""
-Suggested parameters:
-    upgradeSchema       Upgrades the DB to the required schema version.
-                        Returns (0) if upgrade is successful
-
-    confirmSchemaMatch  Returns (0)  if DB schema version matches requirements.
-                        Returns (42) if DB schema version does not match
-                                     requirements and can be upgraded.
-                        Returns (43) if DB schema version does not match
-                                     requirements and cannot be upgraded,
-                                     perhaps because code is at lower version
-                                     than the DB schema version.
-"""
-
-
 import json
-
 from api import config
 
+CURRENT_DATABASE_VERSION = 1 # An int that is bumped when a new 
 
-print 'This is the stub database maintenance script.'
+def confirm_schema_match():
+	"""
+	Checks version of database schema
 
-print 'DB uri: ' + str(config.get_item('persistent', 'db_uri'))
+	Returns (0)  if DB schema version matches requirements.
+	Returns (42) if DB schema version does not match
+	             requirements and can be upgraded.
+	Returns (43) if DB schema version does not match
+	             requirements and cannot be upgraded,
+	             perhaps because code is at lower version
+	             than the DB schema version.
+	"""
 
-user = config.db.users.find_one({})
+	version = config.db.version.find_one({"_id": "version"})
+	if version is None or version.get('database', None) is None:
+		return 42 # At version 0
 
-print 'Example user from db: {0}'.format(user)
+	db_version = version.get('database', 0)
+	if not isinstance(db_version, int) or db_version > CURRENT_DATABASE_VERSION:
+		return 43 
+	elif db_version < CURRENT_DATABASE_VERSION:
+		return 42
+	else:
+		return 0
+
+def upgrade_schema():
+	"""
+	Upgrades db to the current schema version
+    
+    Returns (0) if upgrade is successful
+    """
+
+	# In progress
+	# db_version = version.get('database',0)
+	
+	# if db_version < 1:
+	# 	# rename the metadata fields
+	# 	config.db.container.update_many({}, {"$rename": {"metadata": "info"}})
+
+	# config.db.version.update_one({"_id": "version"}, {"$set": {"database": CURRENT_DATABASE_VERSION}})
+	return 0

--- a/bin/database.py
+++ b/bin/database.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import logging
 from api import config
 
 CURRENT_DATABASE_VERSION = 1 # An int that is bumped when a new schema change is made
@@ -30,11 +31,17 @@ def confirm_schema_match():
 
     db_version = get_db_version()
     if not isinstance(db_version, int) or db_version > CURRENT_DATABASE_VERSION:
+        logging.error('The stored db schema version of %s is incompatible with required version %s', 
+                       str(db_version), CURRENT_DATABASE_VERSION)
         sys.exit(43) 
     elif db_version < CURRENT_DATABASE_VERSION:
         sys.exit(42)
     else:
         sys.exit(0)
+
+def upgrade_to_1():
+    # scitran/core issue #206
+    config.db.version.insert_one({'_id': 'version', 'database': CURRENT_DATABASE_VERSION})
 
 def upgrade_schema():
     """
@@ -46,15 +53,14 @@ def upgrade_schema():
     db_version = get_db_version()
     try:
         if db_version < 1:
-            # scitran/core issue #206
-            config.db.version.insert_one({'_id': 'version', 'database': CURRENT_DATABASE_VERSION})
+            upgrade_to_1()
     except Exception as e:
-        print 'Incremental upgrade of db failed'
-        print e
+        logging.exception('Incremental upgrade of db failed')
         sys.exit(1)
     else:
         config.db.version.update_one({'_id': 'version'}, {'$set': {'database': CURRENT_DATABASE_VERSION}})
         sys.exit(0)
+
 try:
     if len(sys.argv) > 1:
         if sys.argv[1] == 'confirm_schema_match':
@@ -62,11 +68,11 @@ try:
         elif sys.argv[1] == 'upgrade_schema':
             upgrade_schema()
         else:
-            print 'Unknown method name given as argv to database.py'
+            logging.error('Unknown method name given as argv to database.py')
             sys.exit(1)
     else:
-        print 'No method name given as argv to database.py'
+        logging.error('No method name given as argv to database.py')
         sys.exit(1)
 except Exception as e:
-    print e
+    logging.exception()
     sys.exit(1)

--- a/bin/database.py
+++ b/bin/database.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python
+
+"""
+Suggested parameters:
+    upgradeSchema       Upgrades the DB to the required schema version.
+                        Returns (0) if upgrade is successful
+
+    confirmSchemaMatch  Returns (0) if DB schema version matches requirements.
+                        Returns (42) if DB schema version does not match requirements.
+"""
+
+
 import json
 
 from api import config

--- a/bin/database.py
+++ b/bin/database.py
@@ -3,46 +3,46 @@
 import json
 from api import config
 
-CURRENT_DATABASE_VERSION = 1 # An int that is bumped when a new 
+CURRENT_DATABASE_VERSION = 1 # An int that is bumped when a new schema change is made
 
 def confirm_schema_match():
-	"""
-	Checks version of database schema
+    """
+    Checks version of database schema
 
-	Returns (0)  if DB schema version matches requirements.
-	Returns (42) if DB schema version does not match
-	             requirements and can be upgraded.
-	Returns (43) if DB schema version does not match
-	             requirements and cannot be upgraded,
-	             perhaps because code is at lower version
-	             than the DB schema version.
-	"""
+    Returns (0)  if DB schema version matches requirements.
+    Returns (42) if DB schema version does not match
+                 requirements and can be upgraded.
+    Returns (43) if DB schema version does not match
+                 requirements and cannot be upgraded,
+                 perhaps because code is at lower version
+                 than the DB schema version.
+    """
 
-	version = config.db.version.find_one({"_id": "version"})
-	if version is None or version.get('database', None) is None:
-		return 42 # At version 0
+    version = config.db.version.find_one({"_id": "version"})
+    if version is None or version.get('database', None) is None:
+        return 42 # At version 0
 
-	db_version = version.get('database', 0)
-	if not isinstance(db_version, int) or db_version > CURRENT_DATABASE_VERSION:
-		return 43 
-	elif db_version < CURRENT_DATABASE_VERSION:
-		return 42
-	else:
-		return 0
+    db_version = version.get('database', 0)
+    if not isinstance(db_version, int) or db_version > CURRENT_DATABASE_VERSION:
+        return 43 
+    elif db_version < CURRENT_DATABASE_VERSION:
+        return 42
+    else:
+        return 0
 
 def upgrade_schema():
-	"""
-	Upgrades db to the current schema version
+    """
+    Upgrades db to the current schema version
     
     Returns (0) if upgrade is successful
     """
 
-	# In progress
-	# db_version = version.get('database',0)
-	
-	# if db_version < 1:
-	# 	# rename the metadata fields
-	# 	config.db.container.update_many({}, {"$rename": {"metadata": "info"}})
+    # In progress
+    # db_version = version.get('database',0)
+    
+    # if db_version < 1:
+    #   # rename the metadata fields
+    #   config.db.container.update_many({}, {"$rename": {"metadata": "info"}})
 
-	# config.db.version.update_one({"_id": "version"}, {"$set": {"database": CURRENT_DATABASE_VERSION}})
-	return 0
+    # config.db.version.update_one({"_id": "version"}, {"$set": {"database": CURRENT_DATABASE_VERSION}})
+    return 0

--- a/bin/database.py
+++ b/bin/database.py
@@ -8,7 +8,7 @@ CURRENT_DATABASE_VERSION = 1 # An int that is bumped when a new schema change is
 
 def get_db_version():
 
-    version = config.db.version.find_one({"_id": "version"})
+    version = config.get_version()
     if version is None or version.get('database', None) is None:
         return 0
     else:

--- a/bin/database.py
+++ b/bin/database.py
@@ -5,8 +5,13 @@ Suggested parameters:
     upgradeSchema       Upgrades the DB to the required schema version.
                         Returns (0) if upgrade is successful
 
-    confirmSchemaMatch  Returns (0) if DB schema version matches requirements.
-                        Returns (42) if DB schema version does not match requirements.
+    confirmSchemaMatch  Returns (0)  if DB schema version matches requirements.
+                        Returns (42) if DB schema version does not match
+                                     requirements and can be upgraded.
+                        Returns (43) if DB schema version does not match
+                                     requirements and cannot be upgraded,
+                                     perhaps because code is at lower version
+                                     than the DB schema version.
 """
 
 


### PR DESCRIPTION
Closes #206.

A script to check if the current db schema version is behind the required db schema version. Also allows applying incremental upgrade changes if the db schema version is behind.

The database version is stored in the field "database" in a document with _id "version" in a new collection called "version". The existing "config" collection was avoided due to existing logic allowing multiple config documents in the config collection, accessing the correct one via a `{'latest': True}` query.

An API endpoint was added that returns the stored version information.

Requirements/of note:
  - The db schema version is an int, bumped when a schema upgrade is required
  - No version document assumes a current version of 0
  - The upgrade from 0 to 1 is the addition of a version document
  - The version document is purposefully generic, allowing other version types to be added in the future
  - There are many try/except blocks to prevent any errors in database.py escaping with an exit code of 0.