### PR TITLE
Create or recreate ttl index on db intialization

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -5,7 +5,6 @@ import logging
 import pymongo
 import datetime
 import elasticsearch
-import json
 
 
 logging.basicConfig(
@@ -164,7 +163,6 @@ def create_or_recreate_ttl_index(coll_name, index_name, ttl):
 
 
 def initialize_db():
-
     log.info('Initializing database, creating indexes')
     # TODO jobs indexes
     # TODO review all indexes

--- a/api/config.py
+++ b/api/config.py
@@ -151,6 +151,8 @@ def create_or_recreate_ttl_index(coll_name, index_name, ttl):
     index_list = db[coll_name].index_information()
     if index_list:
         for index in index_list:
+            # search for index by given name 
+            # example: "timestamp_1": {"key": [["timestamp", 1]], ...}
             if index_list[index]['key'][0][0] == index_name:
                 if index_list[index].get('expireAfterSeconds', None) != ttl:
                     # drop existing, recreate below


### PR DESCRIPTION
Fixes https://github.com/scitran/core/issues/224.

Mongo does not allow indexes to be modified, suggests they be dropped and recreated if something (like `expireAfterSeconds`) needs to be changed.

For reference, this is an example of what `index_information()` returns for the authtokens collection:
`{"_id_": 
	{  "ns": "scitran.authtokens", 
	   "key": [["_id", 1]], "v": 1
	}, 
 "timestamp_1": 
 	{  "key": [["timestamp", 1]], 
 	   "ns": "scitran.authtokens", 
 	   "expireAfterSeconds": 600, 
 	   "v": 1
 	}
}`