### PR TITLE
Add stateful uploads

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -81,6 +81,7 @@ routes = [
     webapp2_extras.routes.PathPrefixRoute(r'/api', [
         webapp2.Route(r'/download',         download.Download, handler_method='download', methods=['GET', 'POST'], name='download'),
         webapp2.Route(r'/upload/<strategy:label|uid>',           upload.Upload, handler_method='upload', methods=['POST']),
+        webapp2.Route(r'/clean-packfiles',  upload.Upload, handler_method='clean_packfile_tokens', methods=['POST']),
         webapp2.Route(r'/engine',           upload.Upload, handler_method='engine', methods=['POST']),
         webapp2.Route(r'/sites',            centralclient.CentralClient, handler_method='sites', methods=['GET']),
         webapp2.Route(r'/register',         centralclient.CentralClient, handler_method='register', methods=['POST']),
@@ -132,7 +133,9 @@ routes = [
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>'),                                      listhandler.TagsListHandler, methods=['POST'], name='tags_post'),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.TagsListHandler, name='tags'),
 
+    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/packfile-start'),                                     listhandler.FileListHandler, name='packfile-start', handler_method='packfile_start', methods=['POST']),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/packfile'),                                     listhandler.FileListHandler, name='packfile', handler_method='packfile', methods=['POST']),
+    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/packfile-end'),                                     listhandler.FileListHandler, name='packfile-end', handler_method='packfile_end'),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:files>'),                                     listhandler.FileListHandler, name='files_post', methods=['POST']),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:files>/<name:{filename_re}>'),            listhandler.FileListHandler, name='files'),
 

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -141,7 +141,7 @@ class ContainerHandler(base.RequestHandler):
                     j_id_b = bson.ObjectId(j_id)
 
                 # Join from database if we haven't for this origin before
-                if result['join-origin'][j_type].get(j_id, None) is None:
+                if j_type != 'unknown' and result['join-origin'][j_type].get(j_id, None) is None:
                     result['join-origin'][j_type][j_id] = config.db[j_type + 's'].find_one({'_id': j_id_b})
 
         return result

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import dateutil
 import json
+import uuid
 
 from .. import base
 from .. import config
@@ -442,7 +443,7 @@ class FileListHandler(ListHandler):
         query = {
             'type': 'packfile',
             'project': project_id,
-            '_id': bson.ObjectId(token_id),
+            '_id': token_id,
         }
 
         # Server-Sent Events are fired in the browser in such a way that one cannot dictate their headers.
@@ -463,7 +464,7 @@ class FileListHandler(ListHandler):
 
         # Update token timestamp
         config.db['tokens'].update_one({
-            '_id': bson.ObjectId(token_id)
+            '_id': token_id,
         }, {
             '$set': {
                 'modified': datetime.datetime.utcnow()
@@ -500,6 +501,7 @@ class FileListHandler(ListHandler):
 
         # Save token for stateful uploads
         result = config.db['tokens'].insert_one({
+            '_id': str(uuid.uuid4()),
             'type': 'packfile',
             'user': self.uid,
             'project': _id,

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -448,11 +448,7 @@ class FileListHandler(ListHandler):
 
         # Server-Sent Events are fired in the browser in such a way that one cannot dictate their headers.
         # For these endpoints, authentication must be disabled because the normal Authorization header will not be present.
-        # There are several valid ways to fix this, including switching to cookies, or allowing the inclusion of the Authorization token as a request parameter.
-        #
-        # In lieu of solutions, this workaround allows users to merely provide their token id for these endpoints.
-        # This is not ideal because mongo ObjectIds are very predictable and not exactly nonces...
-        # Because the current scope of SSE endpoints are merely completing an in-flight packfile, this limitation seems acceptable for now.
+        # In this case, the document id will serve instead.
         if check_user:
             query['user'] = self.uid
 

--- a/api/placer.py
+++ b/api/placer.py
@@ -460,7 +460,7 @@ class PackfilePlacer(Placer):
 
         # Delete token
         token  = self.context['token']
-        config.db['tokens'].delete_one({ '_id': bson.ObjectId(token) })
+        config.db['tokens'].delete_one({ '_id': token })
 
         result = {
             'acquisition_id': str(acquisition['_id']),

--- a/api/placer.py
+++ b/api/placer.py
@@ -4,6 +4,7 @@ import datetime
 import dateutil
 import os
 import pymongo
+import shutil
 import zipfile
 
 from . import base
@@ -22,13 +23,22 @@ class Placer(object):
     Interface for a placer, which knows how to process files and place them where they belong - on disk and database.
     """
 
-    def __init__(self, container_type, container, id, metadata, timestamp, origin):
+    def __init__(self, container_type, container, id, metadata, timestamp, origin, context):
         self.container_type = container_type
         self.container      = container
         self.id             = id
         self.metadata       = metadata
         self.timestamp      = timestamp
+
+        # An origin map for the caller
         self.origin         = origin
+
+        # A placer-defined map for breaking the Placer abstraction layer.
+        self.context        = context
+
+        # Should the caller expect a normal map return, or a generator that gets mapped to Server-Sent Events?
+        self.sse            = False
+
 
     def check(self):
         """
@@ -208,12 +218,70 @@ class EnginePlacer(Placer):
         return self.saved
 
 
-class PackfilePlacer(Placer):
+class TokenPlacer(Placer):
     """
-    A place that can accept N files, save them into a zip archive, and place the result on an acquisition.
+    A placer that can accept N files and save them to a persistent directory across multiple requests.
+    Intended for use with a token that tracks where the files will be stored.
     """
 
     def check(self):
+        token = self.context['token']
+
+        if token is None:
+            raise Exception('TokenPlacer requires a token')
+
+        # This logic is used by:
+        #   TokenPlacer.check
+        #   PackfilePlacer.check
+        #   upload.clean_packfile_tokens
+        #
+        # It must be kept in sync between each instance.
+        base = config.get_item('persistent', 'data_path')
+        self.folder = os.path.join(base, 'tokens', 'packfile', token)
+
+        util.mkdir_p(self.folder)
+
+        self.saved = []
+        self.paths = []
+
+    def process_file_field(self, field, info):
+        self.saved.append(info)
+        self.paths.append(field.path)
+
+    def finalize(self):
+        for path in self.paths:
+            dest = os.path.join(self.folder, os.path.basename(path))
+            shutil.move(path, dest)
+
+        return self.saved
+
+
+class PackfilePlacer(Placer):
+    """
+    A placer that can accept N files, save them into a zip archive, and place the result on an acquisition.
+    """
+
+    def check(self):
+        # This endpoint is an SSE endpoint
+        self.sse            = True
+
+        token = self.context['token']
+
+        if token is None:
+            raise Exception('PackfilePlacer requires a token')
+
+        # This logic is used by:
+        #   TokenPlacer.check
+        #   PackfilePlacer.check
+        #   upload.clean_packfile_tokens
+        #
+        # It must be kept in sync between each instance.
+        base = config.get_item('persistent', 'data_path')
+        self.folder = os.path.join(base, 'tokens', 'packfile', token)
+
+        if not os.path.isdir(self.folder):
+            raise Exception('Packfile directory does not exist or has been deleted')
+
         self.requireMetadata()
         validators.validate_data(self.metadata, 'packfile.json', 'input', 'POST')
 
@@ -232,6 +300,17 @@ class PackfilePlacer(Placer):
         # Then, given the ISO string, convert it to an epoch integer.
         minimum = datetime.datetime(1980, 1, 1).isoformat()
         stamp   = self.metadata['acquisition'].get('timestamp', minimum)
+
+        # If there was metadata sent back that predates the zip minimum, don't use it.
+        #
+        # Dateutil has overloaded the comparison operators, except it's totally useless:
+        # > TypeError: can't compare offset-naive and offset-aware datetimes
+        #
+        # So instead, epoch-integer both and compare that way.
+        if int(dateutil.parser.parse(stamp).strftime('%s')) < int(dateutil.parser.parse(minimum).strftime('%s')):
+            stamp = minimum
+
+        # Remember the timestamp integer for later use with os.utime.
         self.ziptime = int(dateutil.parser.parse(stamp).strftime('%s'))
 
         # The zipfile is a santizied acquisition label
@@ -255,14 +334,36 @@ class PackfilePlacer(Placer):
         self.zip.write(self.tempdir.name, self.dir)
 
     def process_file_field(self, field, info):
-        # Set the file's mtime & atime.
-        os.utime(field.path, (self.ziptime, self.ziptime))
-
-        # Place file into the zip folder we created before
-        self.zip.write(field.path, os.path.join(self.dir, field.filename))
+        # Should not be called with any files
+        raise Exception('Files must already be uploaded')
 
     def finalize(self):
+
+        paths = os.listdir(self.folder)
+        max = len(paths)
+
+        # Write all files to zip
+        complete = 0
+        for path in paths:
+            p = os.path.join(self.folder, path)
+
+            # Set the file's mtime & atime.
+            os.utime(p, (self.ziptime, self.ziptime))
+
+            # Place file into the zip folder we created before
+            self.zip.write(p, os.path.join(self.dir, os.path.basename(path)))
+
+            # Report progress
+            complete += 1
+            yield util.json_sse_pack({
+                'event': 'progress',
+                'data': { 'done': complete, 'total': max, 'percent': (complete / float(max)) * 100 },
+            })
+
         self.zip.close()
+
+        # Remove the folder created by TokenPlacer
+        shutil.rmtree(self.folder)
 
         # Create an anyonmous object in the style of our augmented file fields.
         # Not a great practice. See process_upload() for details.
@@ -298,50 +399,53 @@ class PackfilePlacer(Placer):
         }
 
         # Get or create a session based on the hierarchy and provided labels.
-        s = {
+        query = {
             'project': bson.ObjectId(self.p_id),
             'label': self.s_label,
             'group': self.g_id
         }
 
-        # self.permissions
+        # Updates if existing
+        updates = {}
+        updates['permissions'] = self.permissions
+        updates['modified']    = self.timestamp
+        updates = util.mongo_dict(updates)
 
-        # Add the subject if one was provided
-        new_s = copy.deepcopy(s)
-        subject = self.metadata['session'].get('subject')
-        if subject is not None:
-            new_s['subject'] = subject
-        new_s['modified']    = self.timestamp
-        new_s = util.mongo_dict(new_s)
+        # Extra properties on insert
+        insert_map = copy.deepcopy(query)
+        insert_map['created'] = self.timestamp
+        insert_map.update(self.metadata['session'])
 
-        # Permissions should always be an exact copy
-        new_s['permissions'] = self.permissions
-
-        session = config.db['session' + 's'].find_one_and_update(s, {
-                '$set': new_s,
-                '$setOnInsert': {
-                    'created': self.timestamp
-                }
+        session = config.db['session' + 's'].find_one_and_update(
+            query, {
+                '$set': updates,
+                '$setOnInsert': insert_map
             },
             upsert=True,
             return_document=pymongo.collection.ReturnDocument.AFTER
         )
 
         # Get or create an acquisition based on the hierarchy and provided labels.
-        fields = {
+        query = {
             'session': session['_id'],
-            'label': self.a_label
+            'label': self.a_label,
         }
 
-        new_a = copy.deepcopy(fields)
-        new_a['permissions'] = self.permissions
-        new_a['modified']    = self.timestamp
+        # Updates if existing
+        updates = {}
+        updates['permissions'] = self.permissions
+        updates['modified']    = self.timestamp
+        updates = util.mongo_dict(updates)
 
-        acquisition = config.db['acquisition' + 's'].find_one_and_update(fields, {
-                '$set': new_a,
-                '$setOnInsert': {
-                    'created': self.timestamp
-                }
+        # Extra properties on insert
+        insert_map = copy.deepcopy(query)
+        insert_map['created'] = self.timestamp
+        insert_map.update(self.metadata['acquisition'])
+
+        acquisition = config.db['acquisition' + 's'].find_one_and_update(
+            query, {
+                '$set': updates,
+                '$setOnInsert': insert_map
             },
             upsert=True,
             return_document=pymongo.collection.ReturnDocument.AFTER
@@ -354,8 +458,18 @@ class PackfilePlacer(Placer):
 
         self.save_file(cgi_field, cgi_info)
 
-        return {
+        # Delete token
+        token  = self.context['token']
+        config.db['tokens'].delete_one({ '_id': bson.ObjectId(token) })
+
+        result = {
             'acquisition_id': str(acquisition['_id']),
             'session_id':	 str(session['_id']),
-            'info': cgi_info
+            'info': cgi_info,
         }
+
+        # Report result
+        yield util.json_sse_pack({
+            'event': 'result',
+            'data': result,
+        })

--- a/api/upload.py
+++ b/api/upload.py
@@ -2,6 +2,7 @@ import bson
 import datetime
 import json
 import os.path
+import shutil
 
 from . import base
 from . import config
@@ -17,13 +18,14 @@ log = config.log
 
 Strategy = util.Enum('Strategy', {
     'targeted'   : pl.TargetedPlacer,   # Upload N files to a container.
-    'engine'     : pl.EnginePlacer,	  # Upload N files from the result of a successful job.
-    'packfile'   : pl.PackfilePlacer,	  # Upload N files as a new packfile to a container.
+    'engine'     : pl.EnginePlacer,     # Upload N files from the result of a successful job.
+    'token'      : pl.TokenPlacer,      # Upload N files to a saved folder based on a token.
+    'packfile'   : pl.PackfilePlacer,   # Upload N files as a new packfile to a container.
     'labelupload': pl.LabelPlacer,
     'uidupload'  : pl.UIDPlacer,
 })
 
-def process_upload(request, strategy, container_type=None, id=None, origin=None):
+def process_upload(request, strategy, container_type=None, id=None, origin=None, context=None, response=None, metadata=None):
     """
     Universal file upload entrypoint.
 
@@ -71,18 +73,14 @@ def process_upload(request, strategy, container_type=None, id=None, origin=None)
     # Tempdir is deleted off disk once out of scope, so let's hold onto this reference.
     form, tempdir = files.process_form(request)
 
-    metadata = None
     if 'metadata' in form:
-        # Slight misnomer: the metadata field, if present, is sent as a normal form field, NOT a file form field.
-        metadata_file = form['metadata'].file
         try:
-            metadata = json.loads(metadata_file.getvalue())
-        except AttributeError:
+            metadata = json.loads(form['metadata'].value)
+        except Exception:
             raise files.FileStoreException('wrong format for field "metadata"')
 
-
     placer_class = strategy.value
-    placer = placer_class(container_type, container, id, metadata, timestamp, origin)
+    placer = placer_class(container_type, container, id, metadata, timestamp, origin, context)
     placer.check()
 
     # Browsers, when sending a multipart upload, will send files with field name "file" (if sinuglar)
@@ -126,7 +124,16 @@ def process_upload(request, strategy, container_type=None, id=None, origin=None)
 
         placer.process_file_field(field, info)
 
-    return placer.finalize()
+    # Respond either with Server-Sent Events or a standard json map
+    if placer.sse and not response:
+        raise Exception("Programmer error: response required")
+    elif placer.sse:
+        log.debug('SSE')
+        response.headers['Content-Type'] = 'text/event-stream; charset=utf-8'
+        response.headers['Connection']   = 'keep-alive'
+        response.app_iter = placer.finalize()
+    else:
+        return placer.finalize()
 
 
 class Upload(base.RequestHandler):
@@ -184,16 +191,19 @@ class Upload(base.RequestHandler):
 
     def engine(self):
         """
-        URL format: api/engine?level=<container_type>&id=<container_id>
-
-        It expects a multipart/form-data request with a "metadata" field (json valid against api/schemas/input/enginemetadata)
-        and 0 or more file fields with a non null filename property (filename is null for the "metadata").
+        URL format: api/engine?level=<container_type>&id=<container_id>&job=<job_id>
         """
+
+        if not self.superuser_request:
+            self.abort(402, 'uploads must be from an authorized drone')
+
         level = self.get_param('level')
         if level is None:
             self.abort(404, 'container level is required')
+
         if level != 'acquisition':
             self.abort(404, 'engine uploads are supported only at the acquisition level')
+
         acquisition_id = self.get_param('id')
         if not acquisition_id:
             self.abort(404, 'container id is required')
@@ -255,3 +265,63 @@ class Upload(base.RequestHandler):
                     }
                     rules.create_jobs(config.db, acquisition_obj, 'acquisition', file_)
             return [{'name': k, 'hash': v.info.get('hash'), 'size': v.info.get('size')} for k, v in merged_files.items()]
+
+    def clean_packfile_tokens(self):
+        """
+        Clean up expired upload tokens and invalid token directories.
+
+        Ref placer.TokenPlacer and FileListHandler.packfile_start for context.
+        """
+
+        if not self.superuser_request:
+            self.abort(402, 'uploads must be from an authorized drone')
+
+        # Race condition: we could delete tokens & directories that are currently processing.
+        # For this reason, the modified timeout is long.
+        result = config.db['tokens'].delete_many({
+            'type': 'packfile',
+            'modified': {'$lt': datetime.datetime.utcnow() - datetime.timedelta(hours=1)},
+        })
+
+        removed = result.deleted_count
+        if removed > 0:
+            log.info('Removed ' + str(removed) + ' expired packfile tokens')
+
+        # Next, find token directories and remove any that don't map to a token.
+
+        # This logic is used by:
+        #   TokenPlacer.check
+        #   PackfilePlacer.check
+        #   upload.clean_packfile_tokens
+        #
+        # It must be kept in sync between each instance.
+        base = config.get_item('persistent', 'data_path')
+        folder = os.path.join(base, 'tokens', 'packfile')
+
+        util.mkdir_p(folder)
+        paths = os.listdir(folder)
+        cleaned = 0
+
+        for token in paths:
+            path = os.path.join(folder, token)
+
+            result = None
+            try:
+                result = config.db['tokens'].find_one({
+                    '_id': bson.ObjectId(token)
+                })
+            except bson.errors.InvalidId:
+                # Folders could be an invalid mongo ID, in which case they're definitely expired :)
+                pass
+
+            if result is None:
+                log.info('Cleaning expired token directory ' + token)
+                shutil.rmtree(path)
+                cleaned += 1
+
+        return {
+            'removed': {
+                'tokens': removed,
+                'directories': cleaned,
+            }
+        }


### PR DESCRIPTION
This changes the packfile endpoints to accept batches of files, staging them until they're explicitly completed. Dodges various limitations in the server leaking file descriptors, and the browser saying no to exceedingly large uploads.

Accomplished with minimal drama by implementing an intermediary placers which is very simple, and modifying the existing Packfile placer to consume the result. Does not implement orphan ticket cleanup.