### PR TITLE
Create restrictions on file fields

### DIFF
--- a/api/placer.py
+++ b/api/placer.py
@@ -104,6 +104,8 @@ class TargetedPlacer(Placer):
         self.saved = []
 
     def process_file_field(self, field, info):
+        if self.metadata is not None:
+            info.update(self.metadata)
         self.save_file(field, info)
         self.saved.append(info)
 

--- a/api/schemas/input/file.json
+++ b/api/schemas/input/file.json
@@ -1,16 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "oneOf": [
+      { "$ref": "file.json#/definitions/MR" },
+      { "$ref": "file.json#/definitions/physio" },
+      { "$ref": "file.json#/definitions/CT" }
+  ],
   "properties": {
     "name":           { "type": "string" },
-    "type":           { "type": "string" },
+    "type":           { "enum": ["dicom", "nifti", null] },
     "mimetype":       { "type": "string" },
-    "instrument":     { "type": "string" },
-    "measurements": {
-      "items": { "type": "string"},
-      "type": "array",
-      "uniqueItems": true
-    },
+    "instrument":     {},
+    "measurements":   {},
     "tags": {
       "items": { "type": "string"},
       "type": "array",
@@ -20,5 +21,52 @@
       "type": "object"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "MR": {
+      "type": "object",
+      "properties": {
+        "instrument": { "enum": ["MR"] },
+        "measurements": {
+          "type": "array",
+          "items": {
+            "enum": ["mr_measurement1",
+                     "mr_measurement2",
+                     "mr_measurement3"]
+          },
+        "uniqueItems": true
+        }
+      }
+    },
+    "physio": {
+      "type": "object",
+      "properties": {
+        "instrument": { "enum": ["Physio"] },
+        "measurements": {
+          "items": {
+            "enum": ["physio_measurement1",
+                     "physio_measurement2",
+                     "physio_measurement3"]
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      }
+    },
+    "CT": {
+      "type": "object",
+      "properties": {
+        "instrument": { "enum": ["CT"] },
+        "measurements": {
+          "items": {
+            "enum": ["ct_measurement1",
+                     "ct_measurement2",
+                     "ct_measurement3"]
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      }
+    }
+  }
 }

--- a/api/schemas/input/file.json
+++ b/api/schemas/input/file.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "oneOf": [
+  "anyOf": [
       { "$ref": "file.json#/definitions/MR" },
       { "$ref": "file.json#/definitions/physio" },
       { "$ref": "file.json#/definitions/CT" }

--- a/api/schemas/mongo/file.json
+++ b/api/schemas/mongo/file.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "oneOf": [
+  "anyOf": [
       { "$ref": "file.json#/definitions/MR" },
       { "$ref": "file.json#/definitions/physio" },
       { "$ref": "file.json#/definitions/CT" }

--- a/api/schemas/mongo/file.json
+++ b/api/schemas/mongo/file.json
@@ -1,20 +1,21 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "oneOf": [
+      { "$ref": "file.json#/definitions/MR" },
+      { "$ref": "file.json#/definitions/physio" },
+      { "$ref": "file.json#/definitions/CT" }
+  ],
   "properties": {
     "name":           { "type": "string" },
     "created":        {},
     "modified":       {},
-    "type":           { "type": "string" },
+    "type":           { "enum": ["dicom", "nifti", null] },
     "mimetype":       { "type": "string" },
     "size":           { "type": "integer" },
     "hash":           { "type": "string" },
-    "instrument":     { "type": "string" },
-    "measurements": {
-      "items": { "type": "string"},
-      "type": "array",
-      "uniqueItems": true
-    },
+    "instrument":       {},
+    "measurements":   {},
     "tags": {
       "items": { "type": "string"},
       "type": "array",
@@ -26,5 +27,52 @@
   },
   "required": ["name", "created", "modified", "size", "hash"],
   "key_fields": ["name"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+      "MR": {
+          "type": "object",
+          "properties": {
+              "instrument": { "enum": ["MR"] },
+              "measurements": {
+                  "type": "array",
+                  "items": {
+                      "enum": ["mr_measurement1",
+                               "mr_measurement2",
+                               "mr_measurement3"]
+                  },
+                "uniqueItems": true
+              }
+          }
+      },
+      "physio": {
+          "type": "object",
+          "properties": {
+              "instrument": { "enum": ["Physio"] },
+              "measurements": {
+                "items": {
+                  "enum": ["physio_measurement1",
+                           "physio_measurement2",
+                           "physio_measurement3"]
+                },
+                "type": "array",
+                "uniqueItems": true
+              }
+          }
+      },
+      "CT": {
+          "type": "object",
+          "properties": {
+              "instrument": { "enum": ["CT"] },
+              "measurements": {
+                "items": {
+                  "enum": ["ct_measurement1",
+                           "ct_measurement2",
+                           "ct_measurement3"]
+                },
+                "type": "array",
+                "uniqueItems": true
+              }
+          }
+      }
+  }
 }


### PR DESCRIPTION
Closes #231.
Closes #210.

Restrictions to type, instrument (becoming modality when `data-model-v2` is merged), and measurements working as expected for targeted upload. `EnginePlacer` also sets these fields and uses the `file.json` schema so although untested it should also work as expected. 

@gsfr please review this prototype when you have a chance.

Whitelisted values are temporary placeholders, do not merge until they are replaced with real values. 