### PR TITLE
Add tags to groups

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -126,6 +126,10 @@ routes = [
     webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:roles>'),                                        listhandler.ListHandler, name='group_roles_post'),
     webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:roles>/<site:{site_id_re}>/<_id:{user_id_re}>'),    listhandler.ListHandler, name='group_roles', methods=['GET', 'PUT', 'DELETE']),
 
+
+    webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:tags>'),                                      listhandler.ListHandler, methods=['POST'], name='tags_post'),
+    webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.ListHandler, name='tags'),
+
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>'),                                      listhandler.ListHandler, methods=['POST'], name='tags_post'),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.ListHandler, name='tags'),
 

--- a/api/api.py
+++ b/api/api.py
@@ -61,7 +61,7 @@ routing_regexes = {
     # tag regex
     # length between 3 and 24 characters
     # any character allowed except '/''
-    'tag_re': '[^/]{3,24}',
+    'tag_re': '[^/]{1,32}',
     # filename regex
     # any character allowed except '/'
     'filename_re': '[^/]+',
@@ -127,11 +127,11 @@ routes = [
     webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:roles>/<site:{site_id_re}>/<_id:{user_id_re}>'),    listhandler.ListHandler, name='group_roles', methods=['GET', 'PUT', 'DELETE']),
 
 
-    webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:tags>'),                                      listhandler.ListHandler, methods=['POST'], name='tags_post'),
-    webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.ListHandler, name='tags'),
+    webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:tags>'),                                      listhandler.TagsListHandler, methods=['POST'], name='tags_post'),
+    webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.TagsListHandler, name='tags'),
 
-    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>'),                                      listhandler.ListHandler, methods=['POST'], name='tags_post'),
-    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.ListHandler, name='tags'),
+    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>'),                                      listhandler.TagsListHandler, methods=['POST'], name='tags_post'),
+    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:tags>/<value:{tag_re}>'),                     listhandler.TagsListHandler, name='tags'),
 
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/packfile'),                                     listhandler.FileListHandler, name='packfile', handler_method='packfile', methods=['POST']),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/<list_name:files>'),                                     listhandler.FileListHandler, name='files_post', methods=['POST']),

--- a/api/auth/listauth.py
+++ b/api/auth/listauth.py
@@ -52,6 +52,22 @@ def group_roles_sublist(handler, container):
         return f
     return g
 
+def group_tags_sublist(handler, container):
+    """
+    This is the customized permissions checker for tags operations.
+    """
+    access = _get_access(handler.uid, handler.user_site, container)
+    def g(exec_op):
+        def f(method, _id, query_params = None, payload = None, exclude_params=None):
+            if method == 'GET'  and access >= INTEGER_ROLES['ro']:
+                return exec_op(method, _id, query_params, payload, exclude_params)
+            elif access >= INTEGER_ROLES['admin']:
+                return exec_op(method, _id, query_params, payload, exclude_params)
+            else:
+                handler.abort(403, 'user not authorized to perform a {} operation on the list'.format(method))
+        return f
+    return g
+
 def permissions_sublist(handler, container):
     """
     the customized permissions checker for permissions operations.

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -305,8 +305,7 @@ class TagsListHandler(ListHandler):
         _id = kwargs.get('cid')
         result = super(TagsListHandler, self).delete(cont_name, list_name, **kwargs)
         if cont_name == 'groups':
-            payload = self.request.json_body
-            deleted_tag = payload.get('value')
+            deleted_tag = kwargs.get('value')
             query = {}
             update = {'$pull': {'tags': deleted_tag}}
             self._propagate_group_tags(_id, query, update)

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -67,7 +67,14 @@ def initialize_list_configurations():
                 'get_full_container': True,
                 'storage_schema_file': 'permission.json',
                 'input_schema_file': 'permission.json'
-            }
+            },
+            'tags': {
+                'storage': liststorage.StringListStorage,
+                'permchecker': listauth.group_tags_sublist,
+                'use_object_id': False,
+                'storage_schema_file': 'tag.json',
+                'input_schema_file': 'tag.json'
+            },
         },
         'projects': copy.deepcopy(container_default_configurations),
         'sessions': copy.deepcopy(container_default_configurations),

--- a/api/schemas/input/tag.json
+++ b/api/schemas/input/tag.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "value":             {"type": "string"}
+    "value":             {"type": "string", "minLength": 1, "maxLength": 32}
   },
   "required": ["value"],
   "additionalProperties": false

--- a/test/integration_tests/test_tags.py
+++ b/test/integration_tests/test_tags.py
@@ -11,11 +11,14 @@ def test_tags(with_a_group_and_a_project, api_as_admin):
     tag = 'test_tag'
     new_tag = 'new_test_tag'
     other_tag = 'other_test_tag'
+    short_tag = 't'
+    too_long_tag = 'this_tag_is_much_too_long_only_allow_32_characters'
 
     tags_path = '/projects/' + data.project_id + '/tags'
     tag_path = tags_path + '/' + tag
     new_tag_path = tags_path + '/' + new_tag
     other_tag_path = tags_path + '/' + other_tag
+    short_tag_path = tags_path + '/' + short_tag
 
     # Add tag and verify
     r = api_as_admin.get(tag_path)
@@ -38,6 +41,15 @@ def test_tags(with_a_group_and_a_project, api_as_admin):
     r = api_as_admin.get(new_tag_path)
     assert r.ok
     assert json.loads(r.content) == new_tag
+
+    # Add short tag and verify
+    payload = json.dumps({'value': short_tag})
+    r = api_as_admin.post(tags_path, data=payload)
+    assert r.ok
+    # Add too long tag and verify
+    payload = json.dumps({'value': too_long_tag})
+    r = api_as_admin.post(tags_path, data=payload)
+    assert r.status_code == 400
 
     # Attempt to update tag, returns 404
     payload = json.dumps({'value': new_tag})
@@ -64,4 +76,8 @@ def test_tags(with_a_group_and_a_project, api_as_admin):
     r = api_as_admin.delete(new_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
     r = api_as_admin.get(new_tag_path)
+    assert r.status_code == 404
+    r = api_as_admin.delete(short_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
+    assert r.ok
+    r = api_as_admin.get(short_tag_path)
     assert r.status_code == 404


### PR DESCRIPTION
Closes #229

Changes:
 - Groups can be tagged
 - Deleting a group tag deletes the tag down the heirarchy
 - Renaming a group tag renames tags down the heirarchy
 - All tags must be 1-32 characters long