### PR TITLE
Add join=origin logic to acquisitions on collections

### DIFF
--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -158,8 +158,9 @@ class CollectionsHandler(ContainerHandler):
         self._filter_all_permissions(sessions, self.uid, self.user_site)
         if self.is_true('measurements'):
             self._add_session_measurements(sessions)
-        if self.debug:
-            for sess in sessions:
+        for sess in sessions:
+            sess = self.handle_origin(sess)
+            if self.debug:
                 sess['debug'] = {}
                 sid = str(sess['_id'])
                 sess['debug']['details'] = self.uri_for('cont_details', cont_name='sessions', cid=sid, _full=True) + '?user=' + self.get_param('user', '')

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -193,6 +193,8 @@ class CollectionsHandler(ContainerHandler):
                 acq['debug'] = {}
                 aid = str(acq['_id'])
                 acq['debug']['details'] = self.uri_for('cont_details', cont_name='acquisitions', cid=aid, _full=True) + '?user=' + self.get_param('user', '')
+        for acquisition in acquisitions:
+            acquisition = self.handle_origin(acquisition)
         return acquisitions
 
 


### PR DESCRIPTION
Closes https://github.com/scitran/core/issues/242

@dpuccetti make sure this works for you when you get a chance and I'll merge it onto master.

Would we also want the `join=origin` param available for `api/collections/<cid>/sessions`?