### PR TITLE
Lookup gravatar and save info on login

### DIFF
--- a/api/base.py
+++ b/api/base.py
@@ -156,17 +156,15 @@ class RequestHandler(webapp2.RequestHandler):
             query.pop('sz', None)
             u = u._replace(query=urllib.urlencode(query, True))
             provider_avatar = urlparse.urlunparse(u)
-            default = provider_avatar
-
-            gravatar = util.resolve_gravatar(uid)
-            if gravatar is not None:
-                default = gravatar
-
-            # If the user has no avatar set, mark this default as their chosen avatar.
-            config.db.users.update_one({'_id': uid, 'avatar': {'$exists': False}}, {'$set':{'avatar': default, 'modified': timestamp}})
-
             # Update the user's provider avatar if it has changed.
             config.db.users.update_one({'_id': uid, 'avatars.provider': {'$ne': provider_avatar}}, {'$set':{'avatars.provider': provider_avatar, 'modified': timestamp}})
+
+            # If the user has no avatar set, mark their provider_avatar as their chosen avatar.
+            config.db.users.update_one({'_id': uid, 'avatar': {'$exists': False}}, {'$set':{'avatar': provider_avatar, 'modified': timestamp}})
+
+        # Look to see if user has a Gravatar
+        gravatar = util.resolve_gravatar(uid)
+        if gravatar is not None:
             # Update the user's gravatar if it has changed.
             config.db.users.update_one({'_id': uid, 'avatars.gravatar': {'$ne': gravatar}}, {'$set':{'avatars.gravatar': gravatar, 'modified': timestamp}})
 

--- a/api/base.py
+++ b/api/base.py
@@ -156,12 +156,19 @@ class RequestHandler(webapp2.RequestHandler):
             query.pop('sz', None)
             u = u._replace(query=urllib.urlencode(query, True))
             provider_avatar = urlparse.urlunparse(u)
+            default = provider_avatar
 
-            # If the user has no avatar set, mark this as their chosen avatar.
-            config.db.users.update_one({'_id': uid, 'avatar': {'$exists': False}}, {'$set':{'avatar': provider_avatar, 'modified': timestamp}})
+            gravatar = util.resolve_gravatar(uid)
+            if gravatar is not None:
+                default = gravatar
+
+            # If the user has no avatar set, mark this default as their chosen avatar.
+            config.db.users.update_one({'_id': uid, 'avatar': {'$exists': False}}, {'$set':{'avatar': default, 'modified': timestamp}})
 
             # Update the user's provider avatar if it has changed.
             config.db.users.update_one({'_id': uid, 'avatars.provider': {'$ne': provider_avatar}}, {'$set':{'avatars.provider': provider_avatar, 'modified': timestamp}})
+            # Update the user's gravatar if it has changed.
+            config.db.users.update_one({'_id': uid, 'avatars.gravatar': {'$ne': gravatar}}, {'$set':{'avatars.gravatar': gravatar, 'modified': timestamp}})
 
         return uid
 

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -1,7 +1,5 @@
 import datetime
-import hashlib
 import pymongo
-import requests
 
 from .. import base
 from .. import util
@@ -127,7 +125,7 @@ class UserHandler(base.RequestHandler):
 
         # If the user exists but has no set avatar, try to get one
         if user and avatar is None:
-            gravatar = self._resolve_gravatar(email)
+            gravatar = util.resolve_gravatar(email)
 
             if gravatar is not None:
                 user = config.db['users'].find_one_and_update({
@@ -148,19 +146,6 @@ class UserHandler(base.RequestHandler):
             self.redirect(str(default), code=307)
         else:
             self.abort(404, 'no avatar')
-
-    def _resolve_gravatar(self, email):
-        """
-        Given an email, returns a URL if that email has a gravatar set.
-        Otherwise returns None.
-        """
-
-        gravatar = 'https://gravatar.com/avatar/' + hashlib.md5(email).hexdigest() + '?s=512'
-
-        if requests.head(gravatar, params={'d': '404'}):
-            return gravatar
-        else:
-            return None
 
     def _get_user(self, _id):
         user = self.storage.get_container(_id)

--- a/api/util.py
+++ b/api/util.py
@@ -8,6 +8,8 @@ import os
 import pytz
 import tempdir as tempfile
 import uuid
+import requests
+import hashlib
 
 from . import config
 MIMETYPES = [
@@ -53,6 +55,18 @@ def user_perm(permissions, _id, site=None):
             return perm
     else:
         return {}
+
+def resolve_gravatar(email):
+    """
+    Given an email, returns a URL if that email has a gravatar set.
+    Otherwise returns None.
+    """
+
+    gravatar = 'https://gravatar.com/avatar/' + hashlib.md5(email).hexdigest() + '?s=512'
+    if requests.head(gravatar, params={'d': '404'}):
+        return gravatar
+    else:
+        return None
 
 
 def container_fileinfo(container, filename):


### PR DESCRIPTION
Fixes #241.

Tried to find the cleanest "fix" to this. Now on login, we check for a user's gravatar and save it to the avatars list if it is not present. For users logging in for the first time, we will save their gravatar as default if it exists instead of their provider's avatar. Users experiencing issues from #241 should still be able to change their default to their gravatar in user profile settings. 