### PR TITLE
Add curator to collection on POST, cleanup existing collections without a curator field

### DIFF
--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -36,6 +36,7 @@ class CollectionsHandler(ContainerHandler):
             'site': self.user_site,
             'access': 'admin'
         }]
+        payload['curator'] = self.uid
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()
         result = mongo_validator(self.storage.exec_op)('POST', payload=payload)
 

--- a/bin/database.py
+++ b/bin/database.py
@@ -85,8 +85,9 @@ def upgrade_to_3():
 
     Set first user with admin permissions found as curator if one does not exist
     """
-
-    collections = config.db.collections.find({'curator': {'$exists': False}, 'permissions.access': 'admin'})
+    query = {'curator': {'$exists': False}, 'permissions.access': 'admin'}
+    projection = {'permissions.$':1}
+    collections = config.db.collections.find(query, projection)
     for coll in collections:
         admin = coll['permissions'][0]['_id']
         query = {'_id': coll['_id']}


### PR DESCRIPTION
Fixes #263.

Mongo pipeline for finding collections with one user that has admin permissions is a bit complex, on Mongo 3.2 we could use `$filter` like so:

```
pipeline = [
        {'$match': {'curator': {'$exists': False}, 'permissions.access': 'admin'}},
        {'$project': {
             'cid': '$_id',
             'perms': {
                '$filter': {
                   'input': '$permissions',
                   'as': 'perms',
                   'cond': {'permissions.access': 'admin'}
                }
             }
        }},
        {'$match': {'perms': {'$size': 1}}}
    ]
```

