### PR TITLE
Add ability to replace metadata fields in API

### DIFF
--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -48,8 +48,10 @@ def default_container(handler, container=None, target_parent_container=None):
 
             if has_access and projection:
                 return exec_op(method, _id=_id, payload=payload, projection=projection)
+            if has_access and recursive:
+                return exec_op(method, _id=_id, payload=payload, recursive=recursive, r_payload=r_payload, replace_metadata=replace_metadata)
             elif has_access:
-                return exec_op(method, _id=_id, payload=payload)
+                return exec_op(method, _id=_id, payload=payload, replace_metadata=replace_metadata)
             else:
                 handler.abort(403, 'user not authorized to perform a {} operation on the container'.format(method))
         return f

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -15,7 +15,7 @@ def default_container(handler, container=None, target_parent_container=None):
     on the container before actually executing this method.
     """
     def g(exec_op):
-        def f(method, _id=None, payload=None, recursive=False):
+        def f(method, _id=None, payload=None, recursive=False, r_payload=None, replace_metadata=False):
             projection = None
             if method == 'GET' and container.get('public', False):
                 has_access = True

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -25,7 +25,8 @@ class ContainerStorage(object):
         return self._get_el(_id)
 
     def exec_op(self, action, _id=None, payload=None, query=None, user=None,
-                public=False, projection=None, recursive=False):
+                public=False, projection=None, recursive=False, r_payload=None,
+                replace_metadata=True):
         """
         Generic method to exec an operation.
         The request is dispatched to the corresponding private methods.
@@ -40,7 +41,7 @@ class ContainerStorage(object):
         if action == 'DELETE':
             return self._delete_el(_id)
         if action == 'PUT':
-            return self._update_el(_id, payload, recursive)
+            return self._update_el(_id, payload, recursive, r_payload, replace_metadata)
         if action == 'POST':
             return self._create_el(payload)
         raise ValueError('action should be one of GET, POST, PUT, DELETE')
@@ -49,17 +50,28 @@ class ContainerStorage(object):
         log.debug(payload)
         return self.dbc.insert_one(payload)
 
-    def _update_el(self, _id, payload, recursive=False):
+    def _update_el(self, _id, payload, recursive=False, r_payload=None, replace_metadata=False):
+        replace = None
+        if replace_metadata:
+            replace = {}
+            if payload.get('metadata') is not None:
+                replace['metadata'] = util.mongo_sanitize_fields(payload.pop('metadata'))
+            if payload.get('subject') is not None and payload['subject'].get('metadata') is not None:
+                    replace['subject.metadata'] = util.mongo_sanitize_fields(payload['subject'].pop('metadata'))
+
         update = {
             '$set': util.mongo_dict(payload)
         }
+        if replace is not None:
+            update['$set'].update(replace)
+
         if self.use_object_id:
             try:
                 _id = bson.objectid.ObjectId(_id)
             except bson.errors.InvalidId as e:
                 raise APIStorageException(e.message)
-        if recursive:
-            self._propagate_changes(_id, update)
+        if recursive and r_payload is not None:
+            self._propagate_changes(_id, {'$set': util.mongo_dict(r_payload)})
         return self.dbc.update_one({'_id': _id}, update)
 
     def _propagate_changes(self, _id, update):

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -26,11 +26,12 @@ class ContainerStorage(object):
 
     def exec_op(self, action, _id=None, payload=None, query=None, user=None,
                 public=False, projection=None, recursive=False, r_payload=None,
-                replace_metadata=True):
+                replace_metadata=False):
         """
         Generic method to exec an operation.
         The request is dispatched to the corresponding private methods.
         """
+
         check = consistencychecker.get_container_storage_checker(action, self.cont_name)
         data_op = payload or {'_id': _id}
         check(data_op)

--- a/api/util.py
+++ b/api/util.py
@@ -48,6 +48,26 @@ def mongo_dict(d):
         )
     return dict(_mongo_list(d))
 
+def mongo_sanitize_fields(d):
+    """
+    Sanitize keys of arbitrarily structured map without flattening into dot notation
+
+    Adapted from http://stackoverflow.com/questions/8429318/how-to-use-dot-in-field-name
+    """
+
+    if isinstance(d, dict):
+        return {mongo_sanitize_fields(str(key)): value if isinstance(value, str) else mongo_sanitize_fields(value) for key,value in d.iteritems()}
+    elif isinstance(d, list):
+        return [mongo_sanitize_fields(element) for element in i]
+    elif isinstance(d, str):
+        # not allowing dots nor dollar signs in fieldnames
+        d = d.replace('.','_')
+        d = d.replace('$', '-')
+        return d
+    else:
+        return d
+
+
 
 def user_perm(permissions, _id, site=None):
     for perm in permissions:


### PR DESCRIPTION
Closes #267 as it solves the immediate problem. 

This acts as a halfway point to having dedicated endpoints for modifying `metadata` fields. As there is no way currently to delete fields inside the arbitrary `metadata` map, sending the flag `replace_metadata` with a put request will change all metadata field updates in the container to be a replace rather than a patch.

More thought should be put into how to properly handle unstructured map updates and deletes. 