### PR TITLE
Allow certain file properties to be null

### DIFF
--- a/api/schemas/input/file.json
+++ b/api/schemas/input/file.json
@@ -3,9 +3,9 @@
   "type": "object",
   "properties": {
     "name":           { "type": "string" },
-    "type":           { "type": "string" },
-    "mimetype":       { "type": "string" },
-    "instrument":     { "type": "string" },
+    "type":           { "type": ["string", "null"] },
+    "mimetype":       { "type": ["string", "null"] },
+    "instrument":     { "type": ["string", "null"] },
     "measurements": {
       "items": { "type": "string"},
       "type": "array",


### PR DESCRIPTION
Minor change needed for uploads that cannot be typed by the folder uploader. I hopes this does not violate some implicit assumption that all files are typed.

Ping @rentzso @nagem @kofalt @lmperry 