### PR TITLE
Add /container/id/jobs endpoint

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -225,6 +225,7 @@ routes = [
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>'),                          containerhandler.ContainerHandler, name='cont_list', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>'),                          containerhandler.ContainerHandler, methods=['POST']),
     webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>'),           containerhandler.ContainerHandler, name='cont_details', methods=['GET','PUT','DELETE']),
+    webapp2.Route(_format(r'/api/<cont_name:{cont_name_re}>/<cid:{cid_re}>/jobs'),           containerhandler.ContainerHandler, name='cont_jobs', handler_method='get_jobs', methods=['GET']),
 
     webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:roles>'),                                        listhandler.ListHandler, name='group_roles_post'),
     webapp2.Route(_format(r'/api/<cont_name:groups>/<cid:{group_id_re}>/<list_name:roles>/<site:{site_id_re}>/<_id:{user_id_re}>'),    listhandler.ListHandler, name='group_roles', methods=['GET', 'PUT', 'DELETE']),

--- a/api/encoder.py
+++ b/api/encoder.py
@@ -1,3 +1,4 @@
+from pymongo.cursor import Cursor
 import bson.objectid
 import datetime
 import json
@@ -12,6 +13,8 @@ def custom_json_serializer(obj):
         return pytz.timezone('UTC').localize(obj).isoformat()
     elif isinstance(obj, Job):
         return obj.map()
+    elif isinstance(obj, Cursor):
+        return list(obj)
     raise TypeError(repr(obj) + " is not JSON serializable")
 
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -131,6 +131,30 @@ class Queue(object):
         return result
 
     @staticmethod
+    def search(container, states=None, tags=None):
+        """
+        Search the queue for jobs that mention a specific container and (optionally) match some set of states or tags.
+        """
+
+        filter = """
+            for (var key in this['inputs']) {
+                var ct = this['inputs'][key]['container_type']
+                var ci = this['inputs'][key]['container_id']
+                if (ct === '$cT$' && ci == '$cI$') { return true }
+            }
+        """.replace('$cT$', container.container_type).replace('$cI$', container.container_id)
+
+        query = { "$where": filter }
+
+        if states is not None and len(states) > 0:
+            query['state'] = {"$in": states}
+
+        if tags is not None and len(tags) > 0:
+            query['tags'] = {"$in": tags}
+
+        return config.db.jobs.find(query)
+
+    @staticmethod
     def get_statistics():
         """
         Return a variety of interesting information about the job queue.


### PR DESCRIPTION
This endpoint will allow a user to see jobs that consumed a particular container.
Unlike all other job endpoints currently, it is accessible to non-superusers (read access is required).

Also supported are filtering by both tags and states.

For example: `/acquisitions/3/jobs?states=pending&states=failed&tags=a&tags=b` -->

```javascript
[
    {
        "_id": "57336257ea360500272c2f11", 
        "algorithm_id": "dicom_mr_classifier", 
        "state": "pending", 
        "tags": [
            "a"
        ]
        //...
    }, 
    {
        "_id": "57336257ea360500272c2f12", 
        "algorithm_id": "dcm_convert", 
        "state": "failed", 
        "tags": [
            "b"
        ]
       // ...
    }
]
```
