### PR TITLE
Ensure timestamps are not blank strings

### DIFF
--- a/api/schemas/input/acquisition.json
+++ b/api/schemas/input/acquisition.json
@@ -13,7 +13,7 @@
         "uid":          {"type": "string"},
         "instrument":   {"type": "string"},
         "measurement":  {"type": "string"},
-        "timestamp":    {"type": "string"},
+        "timestamp":    {"type": "string", "format": "date-time"},
         "timezone":     {"type": "string"}
     },
     "required": ["label"],

--- a/api/schemas/input/enginemetadata.json
+++ b/api/schemas/input/enginemetadata.json
@@ -24,7 +24,7 @@
                 "metadata":     {"type": ["object", "null"]},
                 "operator":     {"type": ["string", "null"]},
                 "uid":          {"type": ["string", "null"]},
-                "timestamp":    {"type": ["string", "null"]},
+                "timestamp":    {"type": "string", "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "subject":      {"$ref": "subject.json"},
                 "files":        {
@@ -43,7 +43,7 @@
                 "uid":          {"type": ["string", "null"]},
                 "instrument":   {"type": ["string", "null"]},
                 "measurement":  {"type": ["string", "null"]},
-                "timestamp":    {"type": ["string", "null"]},
+                "timestamp":    {"type": "string", "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "files":        {
                     "type": ["array", "null"],

--- a/api/schemas/input/labelupload.json
+++ b/api/schemas/input/labelupload.json
@@ -33,7 +33,7 @@
                 "metadata":     {"type": ["object", "null"]},
                 "operator":     {"type": ["string", "null"]},
                 "uid":          {"type": ["string", "null"]},
-                "timestamp":    {"type": ["string", "null"]},
+                "timestamp":    {"type": "string", "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "subject":      {"$ref": "subject.json"},
                 "files":        {
@@ -53,7 +53,7 @@
                 "uid":          {"type": ["string", "null"]},
                 "instrument":   {"type": ["string", "null"]},
                 "measurement":  {"type": ["string", "null"]},
-                "timestamp":    {"type": ["string", "null"]},
+                "timestamp":    {"type": "string", "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "files":        {
                     "type": ["array", "null"],

--- a/api/schemas/input/session.json
+++ b/api/schemas/input/session.json
@@ -11,7 +11,7 @@
 
         "project":      {"type": "string"},
         "uid":          {"type": "string"},
-        "timestamp":    {"type": "string"},
+        "timestamp":    {"type": "string", "format": "date-time"},
         "timezone":     {"type": "string"},
         "subject":      {"$ref": "subject.json"}
     },

--- a/api/schemas/input/uidupload.json
+++ b/api/schemas/input/uidupload.json
@@ -33,7 +33,7 @@
                 "metadata":     {"type": ["object", "null"]},
                 "operator":     {"type": ["string", "null"]},
                 "uid":          {"type": "string"},
-                "timestamp":    {"type": ["string", "null"]},
+                "timestamp":    {"type": "string", "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "subject":      {"$ref": "subject.json"},
                 "files":        {
@@ -53,7 +53,7 @@
                 "uid":          {"type": "string"},
                 "instrument":   {"type": ["string", "null"]},
                 "measurement":  {"type": ["string", "null"]},
-                "timestamp":    {"type": ["string", "null"]},
+                "timestamp":    {"type": "string", "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "files":        {
                     "type": ["array", "null"],

--- a/api/validators.py
+++ b/api/validators.py
@@ -32,7 +32,7 @@ def validate_data(data, schema_json, schema_type, verb, optional=False):
     validator(data, verb)
 
 def _validate_json(json_data, schema, resolver):
-    jsonschema.validate(json_data, schema, resolver=resolver)
+    jsonschema.validate(json_data, schema, resolver=resolver, format_checker=jsonschema.FormatChecker())
 
 class RefResolver(jsonschema.RefResolver):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytz==2015.7
 requests==2.9.1
 requests-toolbelt==0.6.0
 rfc3987==1.3.4
+strict-rfc3339==0.7
 webapp2==2.5.2
 WebOb==1.5.1
 elasticsearch==1.9.0


### PR DESCRIPTION
Fixes #292.

@rentzso here is the fix you requested - the date-time format does not allow blank strings so in-code checks are unnecessary. This is also not a breaking change to any of our frontend logic.