### PR TITLE
Return 409 if container with given id in POST exists

### DIFF
--- a/api/base.py
+++ b/api/base.py
@@ -14,7 +14,7 @@ from . import files
 from . import config
 from .types import Origin
 from . import validators
-from .dao import APIConsistencyException
+from .dao import APIConsistencyException, APIConflictException
 
 log = config.log
 
@@ -251,6 +251,8 @@ class RequestHandler(webapp2.RequestHandler):
             code = 400
         elif isinstance(exception, APIConsistencyException):
             code = 400
+        elif isinstance(exception, APIConflictException):
+            code = 409
         elif isinstance(exception, files.FileStoreException):
             code = 400
         else:

--- a/api/dao/__init__.py
+++ b/api/dao/__init__.py
@@ -4,5 +4,8 @@ class APIStorageException(Exception):
 class APIConsistencyException(Exception):
     pass
 
+class APIConflictException(Exception):
+	pass
+
 def noop(*args, **kwargs):
     pass

--- a/api/dao/liststorage.py
+++ b/api/dao/liststorage.py
@@ -74,7 +74,7 @@ class ListStorage(object):
         log.debug('update {}'.format(update))
         result = self.dbc.update_one(query, update)
         if result.matched_count < 1:
-            raise APIConflictException('List item already exists.')
+            raise APIConflictException('Item already exists in list.')
         return result
 
     def _update_el(self, _id, query_params, payload, exclude_params):
@@ -153,7 +153,10 @@ class StringListStorage(ListStorage):
         update = {'$push': {self.list_name: payload}}
         log.debug('query {}'.format(query))
         log.debug('update {}'.format(update))
-        return self.dbc.update_one(query, update)
+        result = self.dbc.update_one(query, update)
+        if result.matched_count < 1:
+            raise APIConflictException('Item already exists in list.')
+        return result
 
     def _update_el(self, _id, query_params, payload, exclude_params):
         log.debug('query_params {}'.format(payload))

--- a/api/dao/liststorage.py
+++ b/api/dao/liststorage.py
@@ -3,7 +3,7 @@ import bson.objectid
 
 from .. import config
 from . import consistencychecker
-from . import APIStorageException
+from . import APIStorageException, APIConflictException
 
 log = config.log
 
@@ -72,7 +72,10 @@ class ListStorage(object):
         update = {'$push': {self.list_name: payload} }
         log.debug('query {}'.format(query))
         log.debug('update {}'.format(update))
-        return self.dbc.update_one(query, update)
+        result = self.dbc.update_one(query, update)
+        if result.matched_count < 1:
+            raise APIConflictException('List item already exists.')
+        return result
 
     def _update_el(self, _id, query_params, payload, exclude_params):
         log.debug('query_params {}'.format(query_params))


### PR DESCRIPTION
Fixes #303.

Works on all containers except groups (users, projects, sessions, acquisitions). Groups have upsert logic on their POSTs.

@ryansanford also requested a 409 if object already exists in lists, will add an option for that functionality in a new commit to this branch - whether or not we can accurately make that distinction is up for discussion. 