### PR TITLE
Add /jobs/x/retry

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -209,6 +209,7 @@ routes = [
         webapp2.Route(r'/reap',             JobsHandler, handler_method='reap_stale', methods=['POST']),
         webapp2.Route(r'/add',              JobsHandler, handler_method='add', methods=['POST']),
         webapp2.Route(r'/<:[^/]+>',         JobHandler,  name='job'),
+        webapp2.Route(r'/<:[^/]+>/retry',   JobHandler,  name='job', handler_method='retry', methods=['POST']),
     ]),
     webapp2.Route(r'/api/gears',             GearsHandler),
     webapp2_extras.routes.PathPrefixRoute(r'/api/gears', [

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -94,6 +94,9 @@ class Job(object):
     @classmethod
     def get(cls, _id):
         doc = config.db.jobs.find_one({'_id': bson.ObjectId(_id)})
+        if doc is None:
+            raise Exception('Job not found')
+
         return cls.load(doc)
 
     def map(self):

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -79,11 +79,17 @@ class Queue(object):
             log.info('Permanently failed job %s (after %d attempts)' % (job._id, job.attempt))
             return
 
+
         new_job = copy.deepcopy(job)
         new_job._id = None
+        new_job.previous_job_id = job._id
+
         new_job.state = 'pending'
         new_job.attempt += 1
-        new_job.previous_job_id = job._id
+
+        now = datetime.datetime.utcnow()
+        new_job.created = now
+        new_job.modified = now
 
         new_id = new_job.insert()
         log.info('respawned job %s as %s (attempt %d)' % (job._id, new_id, new_job.attempt))


### PR DESCRIPTION
![screenshot-area-2016-05-20-155853](https://cloud.githubusercontent.com/assets/265071/15441983/d0db2f16-1ea3-11e6-9eda-a6d28df5b325.png)

Closes #316. Relates flywheel-io/frontend#349.
Also included a minor bugfix - retried jobs were sharing timestamps with their predecessors.