### PR TITLE
Allow file upload to set guess-type parameter to trigger type hueristics

### DIFF
--- a/api/files.py
+++ b/api/files.py
@@ -240,31 +240,35 @@ class MultiFileStore(object):
                     }, os.path.join(dest_path, filename))
 
 
-FILE_EXTENSIONS = {
-    "archive":      [ ".zip", ".tbz2", ".tar.gz", ".tbz", ".tar.bz2", ".tgz", ".tar", ".txz", ".tar.xz" ],
-    "document":     [ ".docx", ".doc" ],
-    "image":        [ ".jpg", ".tif", ".jpeg", ".gif", ".bmp", ".png", ".tiff" ],
-    "pdf":          [ ".pdf" ],
-    "presentation": [ ".ppt", ".pptx" ],
-    "source code":  [ ".c", ".py", ".cpp", ".js", ".m", ".json", ".java" ],
-    "spredsheet":   [ ".xls", ".xlsx" ],
-    "tabular data": [ ".csv.gz", ".csv" ],
-    "text":         [ ".txt" ],
-    "video":        [ ".mpeg", ".mpg", ".mov", ".mp4" ],
+# File extension --> scitran file type detection hueristics.
+# Listed in precendence order.
+FILE_EXTENSIONS = [
+    # Scientific file types
+    {'bval':         [ '.bval' ]},
+    {'bvec':         [ '.bvec' ]},
+    {'dicom':        [ '.dcm' ]},
+    {'gephysio':     [ '.gephysio.zip' ]},
+    {'nifti':        [ '.nii.gz', '.nii' ]},
+    {'pfile':        [ '.7.gz', '.7' ]},
+    {'qa':           [ '.qa.png', '.qa.json' ]},
 
-    "qa":           [ ".qa.png", ".qa.json" ],
-
-    "bval":         [ ".bval" ],
-    "bvec":         [ ".bvec" ],
-    "dicom":        [ ".dcm" ],
-    "gephysio":     [ ".gephysio.zip" ],
-    "nifti":        [ ".nii.gz", ".nii" ],
-    "pfile":        [ ".7.gz", ".7" ]
-}
+    # Basic file types
+    {'archive':      [ '.zip', '.tbz2', '.tar.gz', '.tbz', '.tar.bz2', '.tgz', '.tar', '.txz', '.tar.xz' ]},
+    {'document':     [ '.docx', '.doc' ]},
+    {'image':        [ '.jpg', '.tif', '.jpeg', '.gif', '.bmp', '.png', '.tiff' ]},
+    {'pdf':          [ '.pdf' ]},
+    {'presentation': [ '.ppt', '.pptx' ]},
+    {'source code':  [ '.c', '.py', '.cpp', '.js', '.m', '.json', '.java' ]},
+    {'spredsheet':   [ '.xls', '.xlsx' ]},
+    {'tabular data': [ '.csv.gz', '.csv' ]},
+    {'text':         [ '.txt' ]},
+    {'video':        [ '.mpeg', '.mpg', '.mov', '.mp4']},
+]
 
 def guess_type_from_filename(filename):
-    for key in FILE_EXTENSIONS:
-        for extension in FILE_EXTENSIONS[key]:
+    for x in FILE_EXTENSIONS:
+        key = x.keys()[0]
+        for extension in x[key]:
             if filename.endswith(extension):
                 return key
     return None

--- a/api/files.py
+++ b/api/files.py
@@ -238,3 +238,33 @@ class MultiFileStore(object):
                         'size': os.path.getsize(os.path.join(dest_path, filename)),
                         'mimetype': util.guess_mimetype(filename)
                     }, os.path.join(dest_path, filename))
+
+
+FILE_EXTENSIONS = {
+    "archive":      [ ".zip", ".tbz2", ".tar.gz", ".tbz", ".tar.bz2", ".tgz", ".tar", ".txz", ".tar.xz" ],
+    "document":     [ ".docx", ".doc" ],
+    "image":        [ ".jpg", ".tif", ".jpeg", ".gif", ".bmp", ".png", ".tiff" ],
+    "pdf":          [ ".pdf" ],
+    "presentation": [ ".ppt", ".pptx" ],
+    "source code":  [ ".c", ".py", ".cpp", ".js", ".m", ".json", ".java" ],
+    "spredsheet":   [ ".xls", ".xlsx" ],
+    "tabular data": [ ".csv.gz", ".csv" ],
+    "text":         [ ".txt" ],
+    "video":        [ ".mpeg", ".mpg", ".mov", ".mp4" ],
+
+    "qa":           [ ".qa.png", ".qa.json" ],
+
+    "bval":         [ ".bval" ],
+    "bvec":         [ ".bvec" ],
+    "dicom":        [ ".dcm" ],
+    "gephysio":     [ ".gephysio.zip" ],
+    "nifti":        [ ".nii.gz", ".nii" ],
+    "pfile":        [ ".7.gz", ".7" ]
+}
+
+def guess_type_from_filename(filename):
+    for key in FILE_EXTENSIONS:
+        for extension in FILE_EXTENSIONS[key]:
+            if filename.endswith(extension):
+                return key
+    return None

--- a/api/upload.py
+++ b/api/upload.py
@@ -122,6 +122,10 @@ def process_upload(request, strategy, container_type=None, id=None, origin=None,
             'metadata': {}
         }
 
+        # Guess upload type by extension on request
+        if request.GET.get('guess-type', '').lower() in ('1', 'true'):
+            info['type'] = files.guess_type_from_filename(info['name'])
+
         placer.process_file_field(field, info)
 
     # Respond either with Server-Sent Events or a standard json map

--- a/test/unit_tests/test_files.py
+++ b/test/unit_tests/test_files.py
@@ -1,0 +1,25 @@
+
+import pytest
+from api import files
+
+
+def test_extension():
+    assert files.guess_type_from_filename('example.pdf') == 'pdf'
+
+def test_multi_extension():
+    assert files.guess_type_from_filename('example.zip') == 'archive'
+    assert files.guess_type_from_filename('example.gephysio.zip') == 'gephysio'
+
+def test_nifti():
+    assert files.guess_type_from_filename('example.nii') == 'nifti'
+    assert files.guess_type_from_filename('example.nii.gz') == 'nifti'
+    assert files.guess_type_from_filename('example.nii.x.gz') == None
+
+def test_qa():
+    assert files.guess_type_from_filename('example.png') == 'image'
+    assert files.guess_type_from_filename('example.qa.png') == 'qa'
+    assert files.guess_type_from_filename('example.qa') == None
+    assert files.guess_type_from_filename('example.qa.png.unknown') == None
+
+def test_unknown():
+    assert files.guess_type_from_filename('example.unknown') == None


### PR DESCRIPTION
On request from @dpuccetti and @lmperry - allow an uploading client to set `guess-type=true` on any upload endpoint (that uses a Placer - ref #159) and set a data type based on extension heuristic. Handily avoids duplicating [this map](https://github.com/scitran/reaper/blob/travis/reaper/types.json) in three different places, and trivial to implement so I just went ahead :+1: 

Both asked if this could just be the default, but I figured a safer option for now is to hide it behind a flag. We can always make it the default later.