### PR TITLE
Google style docstring support

### DIFF
--- a/api/dao/consistencychecker.py
+++ b/api/dao/consistencychecker.py
@@ -40,6 +40,7 @@ def user_on_permission(data_op, **kwargs):
         if not config.db.users.find_one({'_id': data_op['_id']}):
             raise APIConsistencyException('user does not exist')
 
+def field_on_container(parent_field, parent_container_name):		
     """Checks that if we are moving or creating a container,
     the new parent container already exists.
 

--- a/api/dao/consistencychecker.py
+++ b/api/dao/consistencychecker.py
@@ -40,7 +40,6 @@ def user_on_permission(data_op, **kwargs):
         if not config.db.users.find_one({'_id': data_op['_id']}):
             raise APIConsistencyException('user does not exist')
 
-def field_on_container(parent_field, parent_container_name):
     """Checks that if we are moving or creating a container,
     the new parent container already exists.
 
@@ -55,6 +54,16 @@ def check_children(foreign_key_field, container_name):
     """Check that a container has no children.
 
     Used before DELETE operations.
+
+    Args:
+        foreign_key_field (str): key field name in container_name collection
+        container_name (str): db collection to search
+
+    Returns:
+        None:
+
+    Raises:
+        APIConsistencyException: Child document found
     """
     def f(data_op, **kwargs):
         if config.db[container_name].find_one({foreign_key_field: data_op['_id']}):

--- a/api/dao/consistencychecker.py
+++ b/api/dao/consistencychecker.py
@@ -40,7 +40,7 @@ def user_on_permission(data_op, **kwargs):
         if not config.db.users.find_one({'_id': data_op['_id']}):
             raise APIConsistencyException('user does not exist')
 
-def field_on_container(parent_field, parent_container_name):		
+def field_on_container(parent_field, parent_container_name):
     """Checks that if we are moving or creating a container,
     the new parent container already exists.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinxcontrib.httpdomain',


### PR DESCRIPTION
Documentation generator support of google style docstrings.

Reference:
http://www.sphinx-doc.org/en/stable/ext/napoleon.html#module-sphinx.ext.napoleon
http://google.github.io/styleguide/pyguide.html#Comments
