### PR TITLE
Add queue configuration options

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -36,6 +36,10 @@ DEFAULT_CONFIG = {
         'registered': False,
         'ssl_cert': None,
     },
+    'queue': {
+        'max_retries': 3,
+        'retry_on_fail': False,
+    },
     'auth': {
         'client_id': '1052740023071-n20pk8h5uepdua3r8971pc6jrf25lvee.apps.googleusercontent.com',
         'id_endpoint': 'https://www.googleapis.com/plus/v1/people/me/openIdConnect',

--- a/sample.config
+++ b/sample.config
@@ -21,6 +21,9 @@
 #SCITRAN_SITE_REGISTERED=""
 #SCITRAN_SITE_SSL_CERT=""
 
+#SCITRAN_QUEUE_MAX_RETRIES=3,
+#SCITRAN_QUEUE_RETRY_ON_FAIL=false
+
 #SCITRAN_PERSISTENT_PATH="./persistent"
 #SCITRAN_PERSISTENT_DATA_PATH="./persistent/data"   # for fine-grain control
 #SCITRAN_PERSISTENT_DB_PATH="./persistent/db"       # for fine-grain control


### PR DESCRIPTION
Closes #314. #268.

Adds two configuration options: One to limit how many times a job will be retried (under any circumstances), and one to toggle retrying of jobs that were explicitly failed (to prevent retry spam).

New runtime configuration for @ryansanford & @lmperry.