### PR TITLE
Allow timestamps to be set as null

### DIFF
--- a/api/schemas/input/acquisition.json
+++ b/api/schemas/input/acquisition.json
@@ -13,7 +13,7 @@
         "uid":          {"type": "string"},
         "instrument":   {"type": "string"},
         "measurement":  {"type": "string"},
-        "timestamp":    {"type": "string", "format": "date-time"},
+        "timestamp":    {"type": ["string", "null"], "format": "date-time"},
         "timezone":     {"type": "string"}
     },
     "required": ["label", "session"],

--- a/api/schemas/input/enginemetadata.json
+++ b/api/schemas/input/enginemetadata.json
@@ -24,7 +24,7 @@
                 "metadata":     {"type": ["object", "null"]},
                 "operator":     {"type": ["string", "null"]},
                 "uid":          {"type": ["string", "null"]},
-                "timestamp":    {"type": "string", "format": "date-time"},
+                "timestamp":    {"type": ["string", "null"], "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "subject":      {"$ref": "subject.json"},
                 "files":        {
@@ -43,7 +43,7 @@
                 "uid":          {"type": ["string", "null"]},
                 "instrument":   {"type": ["string", "null"]},
                 "measurement":  {"type": ["string", "null"]},
-                "timestamp":    {"type": "string", "format": "date-time"},
+                "timestamp":    {"type": ["string", "null"], "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "files":        {
                     "type": ["array", "null"],

--- a/api/schemas/input/labelupload.json
+++ b/api/schemas/input/labelupload.json
@@ -33,7 +33,7 @@
                 "metadata":     {"type": ["object", "null"]},
                 "operator":     {"type": ["string", "null"]},
                 "uid":          {"type": ["string", "null"]},
-                "timestamp":    {"type": "string", "format": "date-time"},
+                "timestamp":    {"type": ["string", "null"], "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "subject":      {"$ref": "subject.json"},
                 "files":        {
@@ -53,7 +53,7 @@
                 "uid":          {"type": ["string", "null"]},
                 "instrument":   {"type": ["string", "null"]},
                 "measurement":  {"type": ["string", "null"]},
-                "timestamp":    {"type": "string", "format": "date-time"},
+                "timestamp":    {"type": ["string", "null"], "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "files":        {
                     "type": ["array", "null"],

--- a/api/schemas/input/packfile.json
+++ b/api/schemas/input/packfile.json
@@ -24,7 +24,7 @@
             "type": "object",
             "properties": {
                 "label":        {"type": "string"},
-                "timestamp":    {"type": "string", "format": "date-time"},
+                "timestamp":    {"type": ["string", "null"], "format": "date-time"},
                 "timezone":     {"type": "string"}
             },
             "additionalProperties": false,

--- a/api/schemas/input/session.json
+++ b/api/schemas/input/session.json
@@ -11,7 +11,7 @@
 
         "project":      {"type": "string"},
         "uid":          {"type": "string"},
-        "timestamp":    {"type": "string", "format": "date-time"},
+        "timestamp":    {"type": ["string", "null"], "format": "date-time"},
         "timezone":     {"type": "string"},
         "subject":      {"$ref": "subject.json"}
     },

--- a/api/schemas/input/uidupload.json
+++ b/api/schemas/input/uidupload.json
@@ -33,7 +33,7 @@
                 "metadata":     {"type": ["object", "null"]},
                 "operator":     {"type": ["string", "null"]},
                 "uid":          {"type": "string"},
-                "timestamp":    {"type": "string", "format": "date-time"},
+                "timestamp":    {"type": ["string", "null"], "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "subject":      {"$ref": "subject.json"},
                 "files":        {
@@ -53,7 +53,7 @@
                 "uid":          {"type": "string"},
                 "instrument":   {"type": ["string", "null"]},
                 "measurement":  {"type": ["string", "null"]},
-                "timestamp":    {"type": "string", "format": "date-time"},
+                "timestamp":    {"type": ["string", "null"], "format": "date-time"},
                 "timezone":     {"type": ["string", "null"]},
                 "files":        {
                     "type": ["array", "null"],


### PR DESCRIPTION
@dpuccetti requested this for when users clear a timestamp from a session. @rentzso and @ryansanford will this negate the effort we did to remove all blank string timestamps for Elastic or will it handle nulls correctly?