### PR TITLE
Change search verb from GET to POST

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -261,7 +261,7 @@ routes = [
 
     webapp2.Route(_format(r'/api/<par_cont_name:groups>/<par_id:{group_id_re}>/<cont_name:projects>'),          containerhandler.ContainerHandler, name='cont_sublist_groups', handler_method='get_all', methods=['GET']),
     webapp2.Route(_format(r'/api/<par_cont_name:{cont_name_re}>/<par_id:{cid_re}>/<cont_name:{cont_name_re}>'), containerhandler.ContainerHandler, name='cont_sublist', handler_method='get_all', methods=['GET']),
-    webapp2.Route(_format(r'/api/search'),                                            searchhandler.SearchHandler, handler_method='advanced_search', name='es_proxy', methods=['GET']),
+    webapp2.Route(_format(r'/api/search'),                                            searchhandler.SearchHandler, handler_method='advanced_search', name='es_proxy', methods=['POST']),
     webapp2.Route(_format(r'/api/search/files'),                                      searchhandler.SearchHandler, handler_method='get_datatree', name='es_data', methods=['GET']),
     webapp2.Route(_format(r'/api/search/<cont_name:{cont_name_re}>'),                 searchhandler.SearchHandler, name='es_proxy', methods=['GET']),
     webapp2.Route(_format(r'/api/schemas/<schema:{schema_re}>'),                      schemahandler.SchemaHandler, name='schemas', methods=['GET']),


### PR DESCRIPTION
Created a PR to document, many libraries and clients ignore entity bodies set on `GET` requests, [Angular being one of them](http://stackoverflow.com/questions/35184426/angular2-http-get-with-body) (Postman as well, curl allows it). HTTP docs have been more vague, [this SO](http://stackoverflow.com/a/15656853) having some discussion mentioning the ambiguity.

Therefore we're changing `api/search` requests to a `POST` rather than a `GET`.