### PR TITLE
Add prefetch feature, defaults to off

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -39,6 +39,7 @@ DEFAULT_CONFIG = {
     'queue': {
         'max_retries': 3,
         'retry_on_fail': False,
+        'prefetch': False
     },
     'auth': {
         'client_id': '1052740023071-n20pk8h5uepdua3r8971pc6jrf25lvee.apps.googleusercontent.com',

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -9,6 +9,7 @@ import datetime
 
 from .. import config
 from .jobs import Job
+from .gears import get_gear_by_name
 
 log = config.log
 
@@ -142,9 +143,14 @@ class Queue(object):
             return None
 
         job = Job.load(result)
-        request = job.generate_request()
 
-        # Second, update document to store formula request.
+        if job.request is not None:
+            log.info('Job ' + job._id + ' already has a request, so not generating')
+            print job.request
+            return result
+
+        # Generate, save, and return a job request.
+        request = job.generate_request(get_gear_by_name(job.name))
         result = config.db.jobs.find_one_and_update(
             {
                 '_id': bson.ObjectId(job._id)


### PR DESCRIPTION
Fixes #320. @ryansanford 

Adds a new option, `queue.prefetch`. If enabled, a sanity-check job is added to the queue when a gear is created or updated. This will cause a connected queue consumer to download the gear in question. The job is tagged `prefetch` for easy monitoring & early-warning.

Not a substitute for intelligent asset distribution & management; this is just a trivial fix for several users who only have one queue consumer to slightly decrease initial job latency. **Disabled by default.**