### PR TITLE
Don't modify the dict when loading a job

### DIFF
--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -3,6 +3,7 @@ Jobs
 """
 
 import bson
+import copy
 import datetime
 
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
@@ -76,8 +77,11 @@ class Job(object):
         self._id             = _id
 
     @classmethod
-    def load(cls, d):
+    def load(cls, e):
         # TODO: validate
+
+        # Don't modify the map
+        d = copy.deepcopy(e)
 
         if d.get('inputs', None):
             inputs = d['inputs']


### PR DESCRIPTION
Fixes a bug that crashes `/jobs/next` when running a job with a pre-existing request.