### PR TITLE
Lookup jobs at session level

### DIFF
--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -86,6 +86,11 @@ class ContainerReference(object):
         if type not in CONT_TYPES:
             raise Exception('Container type must be one of {}'.format(CONT_TYPES))
 
+        if not isinstance(type, basestring):
+           raise Exception('Container type must be of type str')
+        if not isinstance(id, basestring):
+           raise Exception('Container id must be of type str')
+
         self.type = type
         self.id   = id
 

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -58,6 +58,21 @@ def get_container(cont_name, _id):
         '_id': _id,
     })
 
+def get_children(cont_name, _id):
+    """
+    Given a container name and id, return all children of that object in the hierarchy
+    """
+    cid = bson.ObjectId(_id)
+    if cont_name == 'session':
+        return config.db.acquisitions.find({'session': cid})
+    elif cont_name == 'project':
+        return config.db.sessions.find({'project': cid})
+    elif cont_name == 'group':
+        # groups do not use ObjectIds
+        return config.db.projects.find({'group':_id})
+    else:
+        raise ValueError('Children can only be listed from group, project or session level')
+
 def propagate_changes(cont_name, _id, query, update):
     """
     Propagates changes down the heirarchy tree.


### PR DESCRIPTION
In order to optimize the `api/<cont_name>/<cont_id>/jobs` endpoint, it has been modified to only accept sessions, and returns a json map of acquisitions from the given session and jobs they are associated with. 

Example request:
```
GET /api/sessions/3/jobs?states=pending&states=failed&tags=a&tags=b HTTP/1.1
```

Example response:
```
HTTP/1.1 200 OK
Vary: Accept-Encoding
Content-Type: application/json; charset=utf-8
{
  "576c17a1ae22e9bc2ba01d8f": [
    {
      "name": "dcm-convert",
      "tags": [
        "dcm-convert"
      ],
      ...
    }
  ],
  "576c1796ae22e9bc2ba01d8e": [
    {
      "name": "dcm-convert",
      "tags": [
        "dcm-convert"
      ],
      ...
    },
    {
      "name": "dcm-convert",
      "tags": [
        "dcm-convert"
      ],
      ...
    }
  ]
}
```