### PR TITLE
Engine Placer

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -358,6 +358,7 @@ def _update_container(query, update, set_update, cont_name):
 
 def _update_hierarchy(container, container_type, metadata, update_timestamp=False):
     project_id = container['project'] # for sessions
+    now = datetime.datetime.utcnow()
 
     if container_type == 'acquisition':
         update = {}

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -334,52 +334,53 @@ def dict_fileinfos(infos):
     return dict_infos
 
 
-def update_container_hierarchy(metadata, acquisition_id, level):
-    project = metadata.get('project')
-    session = metadata.get('session')
-    acquisition = metadata.get('acquisition')
+def update_container_hierarchy(metadata, cid, container_type):
+    c_metadata = metadata.get(container_type)
     now = datetime.datetime.utcnow()
-    if acquisition.get('timestamp'):
-        acquisition['timestamp'] = dateutil.parser.parse(acquisition['timestamp'])
-    acquisition['modified'] = now
-    acquisition_obj = _update_container({'_id': acquisition_id}, acquisition, 'acquisitions')
-    if acquisition_obj is None:
-        raise APIStorageException('acquisition doesn''t exist')
-    if acquisition.get('timestamp'):
-        session_obj = config.db.sessions.find_one_and_update(
-            {'_id': acquisition_obj['session']},
-            {
-                '$min': dict(timestamp=acquisition['timestamp']),
-                '$set': dict(timezone=acquisition.get('timezone'))
-            },
-            return_document=pymongo.collection.ReturnDocument.AFTER
-        )
-        config.db.projects.find_one_and_update(
-            {'_id': session_obj['project']},
-            {
-                '$max': dict(timestamp=acquisition['timestamp']),
-                '$set': dict(timezone=acquisition.get('timezone'))
-            }
-        )
-    session_obj = None
-    if session:
-        session['modified'] = now
-        session_obj = _update_container({'_id': acquisition_obj['session']}, session, 'sessions')
-    if project:
-        project['modified'] = now
-        if not session_obj:
-            session_obj = config.db.sessions.find_one({'_id': acquisition_obj['session']})
-        _update_container({'_id': session_obj['project']}, project, 'projects')
-    return acquisition_obj
+    if c_metadata.get('timestamp'):
+        c_metadata['timestamp'] = dateutil.parser.parse(c_metadata['timestamp'])
+    c_metadata['modified'] = now
+    c_obj = _update_container({'_id': cid}, {}, c_metadata, container_type)
+    if c_obj is None:
+        raise APIStorageException('container doesn''t exist')
+    if container_type in ['session', 'acquisition']:
+        update_timestamp = True if c_metadata.get('timestamp') else False
+        _update_hierarchy(c_obj, container_type, metadata, update_timestamp)
+    return c_obj
 
-def _update_container(query, update, cont_name):
-    return config.db[cont_name].find_one_and_update(
-        query,
-        {
-            '$set': util.mongo_dict(update)
-        },
+
+def _update_container(query, update, set_update, cont_name):
+    update['$set'] = util.mongo_dict(set_update)
+    return config.db[cont_name].find_one_and_update(query,update,
         return_document=pymongo.collection.ReturnDocument.AFTER
     )
+
+
+def _update_hierarchy(container, container_type, metadata, update_timestamp=False):
+    project_id = container['project'] # for sessions
+
+    if container_type == 'acquisition':
+        update = {}
+        session = metadata.get('session', {})
+        if update_timestamp:
+            update['$min'] = dict(timestamp=container['timestamp'])
+            session['timezone'] = dict(timezone=container.get('timezone'))
+        if session.keys():
+            session['modified'] = now
+            session_obj = _update_container({'_id': container['session']}, update, session, 'sessions')
+        project_id = session_obj['project']
+
+    if project_id is None:
+        raise APIStorageException('Failed to find project id in session obj')
+    update = {}
+    project = metadata.get('project', {})
+    if update_timestamp:
+        update['$max'] = dict(timestamp=container['timestamp'])
+        project['timezone'] = dict(timezone=container.get('timezone'))
+    if project.keys():
+        project['modified'] = now
+        project_obj = _update_container({'_id': project_id}, update, project, 'projects')
+
 
 def merge_fileinfos(parsed_files, infos):
     """it takes a dictionary of "hard_infos" (file size, hash)

--- a/api/placer.py
+++ b/api/placer.py
@@ -190,7 +190,10 @@ class EnginePlacer(Placer):
 
     def check(self):
         self.requireTarget()
-        validators.validate_data(self.metadata, 'enginemetadata.json', 'input', 'POST', optional=True)
+        if self.metadata is not None:
+            log.debug('about to validate')
+            validators.validate_data(self.metadata, 'enginemetadata.json', 'input', 'POST', optional=True)
+            log.debug('validated')
         self.saved = []
 
     def process_file_field(self, field, info):
@@ -215,8 +218,9 @@ class EnginePlacer(Placer):
     def finalize(self):
         # Updating various properties of the hierarchy; currently assumes acquisitions; might need fixing for other levels.
         # NOTE: only called in EnginePlacer
-        bid = bson.ObjectId(self.id)
-        self.obj = hierarchy.update_container_hierarchy(self.metadata, bid, self.container_type)
+        if self.metadata is not None:
+            bid = bson.ObjectId(self.id)
+            self.obj = hierarchy.update_container_hierarchy(self.metadata, bid, self.container_type)
 
         return self.saved
 

--- a/api/placer.py
+++ b/api/placer.py
@@ -198,7 +198,7 @@ class EnginePlacer(Placer):
             # OPPORTUNITY: hard-coded container levels will need to go away soon
             # Engine shouldn't know about container names; maybe parent contexts?
             # How will this play with upload unification? Unify schemas as well?
-            file_mds = self.metadata.get(container_type, {}).get('files', [])
+            file_mds = self.metadata.get(self.container_type, {}).get('files', [])
 
             for file_md in file_mds:
                 if file_md['name'] == info['name']:

--- a/api/placer.py
+++ b/api/placer.py
@@ -191,9 +191,7 @@ class EnginePlacer(Placer):
     def check(self):
         self.requireTarget()
         if self.metadata is not None:
-            log.debug('about to validate')
             validators.validate_data(self.metadata, 'enginemetadata.json', 'input', 'POST', optional=True)
-            log.debug('validated')
         self.saved = []
 
     def process_file_field(self, field, info):

--- a/api/placer.py
+++ b/api/placer.py
@@ -193,14 +193,12 @@ class EnginePlacer(Placer):
         validators.validate_data(self.metadata, 'enginemetadata.json', 'input', 'POST', optional=True)
         self.saved = []
 
-        # Could avoid loops in process_file_field by setting up the
-
     def process_file_field(self, field, info):
         if self.metadata is not None:
             # OPPORTUNITY: hard-coded container levels will need to go away soon
             # Engine shouldn't know about container names; maybe parent contexts?
             # How will this play with upload unification? Unify schemas as well?
-            file_mds = self.metadata.get('acquisition', {}).get('files', [])
+            file_mds = self.metadata.get(container_type, {}).get('files', [])
 
             for file_md in file_mds:
                 if file_md['name'] == info['name']:
@@ -218,7 +216,7 @@ class EnginePlacer(Placer):
         # Updating various properties of the hierarchy; currently assumes acquisitions; might need fixing for other levels.
         # NOTE: only called in EnginePlacer
         bid = bson.ObjectId(self.id)
-        self.obj = hierarchy.update_container_hierarchy(self.metadata, bid, '')
+        self.obj = hierarchy.update_container_hierarchy(self.metadata, bid, self.container_type)
 
         return self.saved
 

--- a/api/schemas/input/enginemetadata.json
+++ b/api/schemas/input/enginemetadata.json
@@ -53,6 +53,5 @@
             "additionalProperties": false
         }
     },
-    "required": ["acquisition"],
     "additionalProperties": false
 }

--- a/api/upload.py
+++ b/api/upload.py
@@ -134,7 +134,6 @@ def process_upload(request, strategy, container_type=None, id=None, origin=None,
     if placer.sse and not response:
         raise Exception("Programmer error: response required")
     elif placer.sse:
-        log.debug('SSE')
         response.headers['Content-Type'] = 'text/event-stream; charset=utf-8'
         response.headers['Connection']   = 'keep-alive'
         response.app_iter = placer.finalize()
@@ -232,7 +231,7 @@ class Upload(base.RequestHandler):
 
         if level == 'analysis':
             context = {'job_id': self.get_param('job')}
-            return process_upload(self.request, Strategy.analysis_job, origin=self.origin, container_type=level, id=cont_id, context=context)
+            return process_upload(self.request, Strategy.analysis_job, origin=self.origin, container_type=level, id=cid, context=context)
         else:
             return process_upload(self.request, Strategy.engine, container_type=level, id=cid, origin=self.origin)
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -222,14 +222,19 @@ class Upload(base.RequestHandler):
         level = self.get_param('level')
         if level is None:
             self.abort(400, 'container level is required')
-        if level not in ['acquisition', 'session', 'project']:
-            self.abort(400, 'container level must be acquisition, session or project.')
+        if level not in ['analysis', 'acquisition', 'session', 'project']:
+            self.abort(400, 'container level must be analysis, acquisition, session or project.')
         cid = self.get_param('id')
         if not cid:
             self.abort(400, 'container id is required')
         else:
-            cid = bson.ObjectId(acquisition_id)
-        return process_upload(self.request, 'engine', container_type=level, id=cid, origin=self.origin)
+            cid = bson.ObjectId(cid)
+
+        if level == 'analysis':
+            context = {'job_id': self.get_param('job')}
+            return process_upload(self.request, Strategy.analysis_job, origin=self.origin, container_type=level, id=cont_id, context=context)
+        else:
+            return process_upload(self.request, Strategy.engine, container_type=level, id=cid, origin=self.origin)
 
     def clean_packfile_tokens(self):
         """

--- a/api/upload.py
+++ b/api/upload.py
@@ -206,14 +206,31 @@ class Upload(base.RequestHandler):
         """
         .. http:post:: /api/engine
 
-            Confirm endpoint is ready for requests
+            Default behavior:
+                Uploads a list of files sent as file1, file2, etc to a existing
+                container and updates fields of the files, the container and it's
+                parents as specified in the metadata fileformfield using the
+                engine placer class
+            When ``level`` is ``analysis``:
+                Uploads a list of files to an existing analysis object, marking
+                all files as ``output=true`` using the job-based analyses placer
+                class
 
-            :query level: container_type
-            :query id: container_id
-            :query job: job_id
+            :param level: one of ``project``, ``session``, ``acquisition``, ``analysis``
+            :type level: string
 
-            :statuscode 400: improper or missing params
-            :statuscode 402: engine uploads must be fron authorized drone
+            :param id: Container ID
+            :type id: string
+
+            :param id: Job ID
+            :type id: string
+
+            :statuscode 200: no error
+            :statuscode 400: Target container ``level`` is required
+            :statuscode 400: Level must be ``project``, ``session``, ``acquisition``, ``analysis``
+            :statuscode 400: Target container ``id`` is required
+            :statuscode 402: Uploads must be from an authorized drone
+
         """
 
         if not self.superuser_request:

--- a/test/integration_tests/test_uploads.py
+++ b/test/integration_tests/test_uploads.py
@@ -178,12 +178,12 @@ def test_acquisition_engine_upload(with_hierarchy_and_file_data, api_as_admin):
             'metadata': {'test': 'a'},
             'files':[
                 {
-                    'name': data.files.keys()[0],
+                    'name': 'one.csv',
                     'type': 'engine type 0',
                     'metadata': {'test': 'f0'}
                 },
                 {
-                    'name': data.files.keys()[1],
+                    'name': 'two.csv',
                     'type': 'engine type 1',
                     'metadata': {'test': 'f1'}
                 }
@@ -236,14 +236,14 @@ def test_session_engine_upload(with_hierarchy_and_file_data, api_as_admin):
             'subject': {'code': 'engine subject'},
             'timestamp': '2016-06-20T21:57:36+00:00',
             'metadata': {'test': 's'},
-            'files':[
+            'files': [
                 {
-                    'name': data.files.keys()[0],
+                    'name': 'one.csv',
                     'type': 'engine type 0',
                     'metadata': {'test': 'f0'}
                 },
                 {
-                    'name': data.files.keys()[1],
+                    'name': 'two.csv',
                     'type': 'engine type 1',
                     'metadata': {'test': 'f1'}
                 }
@@ -284,14 +284,14 @@ def test_project_engine_upload(with_hierarchy_and_file_data, api_as_admin):
         'project':{
             'label': 'engine project',
             'metadata': {'test': 'p'},
-            'files':[
+            'files': [
                 {
-                    'name': data.files.keys()[0],
+                    'name': 'one.csv',
                     'type': 'engine type 0',
                     'metadata': {'test': 'f0'}
                 },
                 {
-                    'name': data.files.keys()[1],
+                    'name': 'two.csv',
                     'type': 'engine type 1',
                     'metadata': {'test': 'f1'}
                 }

--- a/test/integration_tests/test_uploads.py
+++ b/test/integration_tests/test_uploads.py
@@ -330,6 +330,61 @@ def test_acquisition_file_only_engine_upload(with_hierarchy_and_file_data, api_a
         mf = find_file_in_array(v[0], a['files'])
         assert mf is not None
 
+def test_acquisition_subsequent_file_engine_upload(with_hierarchy_and_file_data, api_as_admin):
+
+    data = with_hierarchy_and_file_data
+
+    filedata_1 = {}
+    filedata_1['file1'] = ('file-one.csv', 'some,data,to,send\nanother,row,to,send\n')
+    filedata_1['metadata'] = ('', json.dumps({
+        'acquisition':{
+            'files':[
+                {
+                    'name': 'file-one.csv',
+                    'type': 'engine type 1',
+                    'metadata': {'test': 'f1'}
+                }
+            ]
+        }
+    }))
+
+    r = api_as_admin.post('/engine?level=acquisition&id='+data.acquisition, files=filedata_1)
+    assert r.ok
+
+    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    assert r.ok
+    a = json.loads(r.content)
+
+    mf = find_file_in_array('file-one.csv', a['files'])
+    assert mf is not None
+
+    filedata_2 = {}
+    filedata_2['file1'] = ('file-two.csv', 'some,data,to,send\nanother,row,to,send\n')
+    filedata_2['metadata'] = ('', json.dumps({
+        'acquisition':{
+            'files':[
+                {
+                    'name': 'file-two.csv',
+                    'type': 'engine type 1',
+                    'metadata': {'test': 'f1'}
+                }
+            ]
+        }
+    }))
+
+    r = api_as_admin.post('/engine?level=acquisition&id='+data.acquisition, files=filedata_2)
+    assert r.ok
+
+    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    assert r.ok
+    a = json.loads(r.content)
+
+    # Assert both files are still present after upload
+    mf = find_file_in_array('file-one.csv', a['files'])
+    assert mf is not None
+    mf = find_file_in_array('file-two.csv', a['files'])
+    assert mf is not None
+
 def test_acquisition_metadata_only_engine_upload(with_hierarchy_and_file_data, api_as_admin):
 
     data = with_hierarchy_and_file_data


### PR DESCRIPTION
Addresses scitran/core#159, scitran/core#160 and a few other requests made by team members.

Changes:
 - Engine uploads now use the Placer class style
 - Uploads can be made to projects, sessions, acquisitions or analyses*
 - Uploads can be files only
 - Uploads can be metadata only

*Work towards supporting uploads to multiple levels of the hierarchy at once (scitran/core#160) is being done in a separate branch 