### PR TITLE
Fix issue updating persisted config

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -5,6 +5,7 @@ import logging
 import pymongo
 import datetime
 import elasticsearch
+from . import util
 
 
 logging.basicConfig(
@@ -34,7 +35,7 @@ DEFAULT_CONFIG = {
         'api_url': 'https://localhost/api',
         'central_url': 'https://sdmc.scitran.io/api',
         'registered': False,
-        'ssl_cert': None,
+        'ssl_cert': None
     },
     'queue': {
         'max_retries': 3,
@@ -221,7 +222,7 @@ def get_config():
         db_config = db.singletons.find_one({'_id': 'config'})
         if db_config is not None:
             startup_config = copy.deepcopy(__config)
-            startup_config.update(db_config)
+            startup_config = util.deep_update(startup_config, db_config)
             # Precedence order for config is env vars -> db values -> default
             __config = apply_env_variables(startup_config)
         else:

--- a/api/download.py
+++ b/api/download.py
@@ -267,7 +267,7 @@ class Download(base.RequestHandler):
             if self.is_true('bulk'):
                 return self._bulk_preflight_archivestream(req_spec.get('files', []))
             else:
-                payload_schema_uri = util.schema_uri('input', 'download.json')
+                payload_schema_uri = validators.schema_uri('input', 'download.json')
                 validator = validators.from_schema_path(payload_schema_uri)
                 validator(req_spec, 'POST')
                 log.debug(json.dumps(req_spec, sort_keys=True, indent=4, separators=(',', ': ')))

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -487,9 +487,9 @@ class ContainerHandler(base.RequestHandler):
         return list(config.db.groups.find({'_id': {'$in': group_ids}}, ['name']))
 
     def _get_validators(self):
-        mongo_schema_uri = util.schema_uri('mongo', self.config.get('storage_schema_file'))
+        mongo_schema_uri = validators.schema_uri('mongo', self.config.get('storage_schema_file'))
         mongo_validator = validators.decorator_from_schema_path(mongo_schema_uri)
-        payload_schema_uri = util.schema_uri('input', self.config.get('payload_schema_file'))
+        payload_schema_uri = validators.schema_uri('input', self.config.get('payload_schema_file'))
         payload_validator = validators.from_schema_path(payload_schema_uri)
         return mongo_validator, payload_validator
 

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -63,9 +63,9 @@ class GroupHandler(base.RequestHandler):
             self.abort(404, 'no such Group: ' + _id)
         permchecker = groupauth.default(self, group)
         payload = self.request.json_body
-        mongo_schema_uri = util.schema_uri('mongo', 'group.json')
+        mongo_schema_uri = validators.schema_uri('mongo', 'group.json')
         mongo_validator = validators.decorator_from_schema_path(mongo_schema_uri)
-        payload_schema_uri = util.schema_uri('input', 'group.json')
+        payload_schema_uri = validators.schema_uri('input', 'group.json')
         payload_validator = validators.from_schema_path(payload_schema_uri)
         payload_validator(payload, 'PUT')
         result = mongo_validator(permchecker(self.storage.exec_op))('PUT', _id=_id, payload=payload)
@@ -78,9 +78,9 @@ class GroupHandler(base.RequestHandler):
         self._init_storage()
         permchecker = groupauth.default(self, None)
         payload = self.request.json_body
-        mongo_schema_uri = util.schema_uri('mongo', 'group.json')
+        mongo_schema_uri = validators.schema_uri('mongo', 'group.json')
         mongo_validator = validators.decorator_from_schema_path(mongo_schema_uri)
-        payload_schema_uri = util.schema_uri('input', 'group.json')
+        payload_schema_uri = validators.schema_uri('input', 'group.json')
         payload_validator = validators.from_schema_path(payload_schema_uri)
         payload_validator(payload, 'POST')
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -206,9 +206,9 @@ class ListHandler(base.RequestHandler):
                 permchecker = permchecker(self, container)
         else:
             self.abort(404, 'Element {} not found in container {}'.format(_id, storage.cont_name))
-        mongo_schema_uri = util.schema_uri('mongo', config.get('storage_schema_file'))
+        mongo_schema_uri = validators.schema_uri('mongo', config.get('storage_schema_file'))
         mongo_validator = validators.decorator_from_schema_path(mongo_schema_uri)
-        input_schema_uri = util.schema_uri('input', config.get('input_schema_file'))
+        input_schema_uri = validators.schema_uri('input', config.get('input_schema_file'))
         input_validator = validators.from_schema_path(input_schema_uri)
         keycheck = validators.key_check(mongo_schema_uri)
         return container, permchecker, storage, mongo_validator, input_validator, keycheck

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -102,9 +102,9 @@ class UserHandler(base.RequestHandler):
         user = self._get_user(_id)
         permchecker = userauth.default(self, user)
         payload = self.request.json_body
-        mongo_schema_uri = util.schema_uri('mongo', 'user.json')
+        mongo_schema_uri = validators.schema_uri('mongo', 'user.json')
         mongo_validator = validators.decorator_from_schema_path(mongo_schema_uri)
-        payload_schema_uri = util.schema_uri('input', 'user.json')
+        payload_schema_uri = validators.schema_uri('input', 'user.json')
         payload_validator = validators.from_schema_path(payload_schema_uri)
         payload_validator(payload, 'PUT')
         payload['modified'] = datetime.datetime.utcnow()
@@ -147,9 +147,9 @@ class UserHandler(base.RequestHandler):
         self._init_storage()
         permchecker = userauth.default(self)
         payload = self.request.json_body
-        mongo_schema_uri = util.schema_uri('mongo', 'user.json')
+        mongo_schema_uri = validators.schema_uri('mongo', 'user.json')
         mongo_validator = validators.decorator_from_schema_path(mongo_schema_uri)
-        payload_schema_uri = util.schema_uri('input', 'user.json')
+        payload_schema_uri = validators.schema_uri('input', 'user.json')
         payload_validator = validators.from_schema_path(payload_schema_uri)
         payload_validator(payload, 'POST')
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()

--- a/api/placer.py
+++ b/api/placer.py
@@ -128,7 +128,7 @@ class UIDPlacer(Placer):
     def check(self):
         self.requireMetadata()
 
-        payload_schema_uri = util.schema_uri('input', self.metadata_schema)
+        payload_schema_uri = validators.schema_uri('input', self.metadata_schema)
         metadata_validator = validators.from_schema_path(payload_schema_uri)
         metadata_validator(self.metadata, 'POST')
 

--- a/api/util.py
+++ b/api/util.py
@@ -1,4 +1,3 @@
-import collections
 import datetime
 import enum as baseEnum
 import errno
@@ -71,7 +70,7 @@ def deep_update(d, u):
     Adapted from http://stackoverflow.com/a/3233356
     """
     for k, v in u.iteritems():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, dict):
             r = deep_update(d.get(k, {}), v)
             d[k] = r
         else:

--- a/api/util.py
+++ b/api/util.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import enum as baseEnum
 import errno
@@ -9,7 +10,6 @@ import uuid
 import requests
 import hashlib
 
-from . import config
 MIMETYPES = [
     ('.bvec', 'text', 'bvec'),
     ('.bval', 'text', 'bval'),
@@ -65,6 +65,18 @@ def mongo_sanitize_fields(d):
     else:
         return d
 
+def deep_update(d, u):
+    """
+    Makes a deep update of dict d with dict u
+    Adapted from http://stackoverflow.com/a/3233356
+    """
+    for k, v in u.iteritems():
+        if isinstance(v, collections.Mapping):
+            r = deep_update(d.get(k, {}), v)
+            d[k] = r
+        else:
+            d[k] = u[k]
+    return d
 
 
 def user_perm(permissions, _id, site=None):
@@ -163,12 +175,6 @@ def send_json_http_exception(response, message, code):
     response.headers['Content-Type'] = 'application/json; charset=utf-8'
     response.write(content)
 
-def schema_uri(type_, schema_name):
-    return '/'.join([
-        config.get_item('site', 'api_url'),
-        'schemas',
-        type_, schema_name
-    ])
 
 class Enum(baseEnum.Enum):
     # Enum strings are prefixed by their class: "Category.classifier".

--- a/api/validators.py
+++ b/api/validators.py
@@ -27,8 +27,8 @@ def validate_data(data, schema_json, schema_type, verb, optional=False):
     if optional and data is None:
         return
 
-    schema_uri = util.schema_uri(schema_type, schema_json)
-    validator = from_schema_path(schema_uri)
+    suri = schema_uri(schema_type, schema_json)
+    validator = from_schema_path(suri)
     validator(data, verb)
 
 def _validate_json(json_data, schema, resolver):
@@ -73,6 +73,13 @@ def _resolve_schema(schema_url):
 
 def no_op(g, *args):
     return g
+
+def schema_uri(type_, schema_name):
+    return '/'.join([
+        config.get_item('site', 'api_url'),
+        'schemas',
+        type_, schema_name
+    ])
 
 def decorator_from_schema_path(schema_url):
     if schema_url is None:


### PR DESCRIPTION
Fixes #355.

Python `dict.update()` does a shallow update, so any changes the default config other than at the top level were being overwritten by the database version of the config.

Some slight refactoring was necessary in order to have a util class that was free from any local imports.