### PR TITLE
Metadata from upload endpoints should only set null fields

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -345,8 +345,7 @@ def _update_container_nulls(base_query, update, container_type):
 
     bulk = config.db[coll_name].initialize_unordered_bulk_op()
 
-    if (update.get('metadata') is not None and
-       (cont.get('metadata') is None or cont.get('metadata',{}).keys == 0)):
+    if update.get('metadata') and not cont.get('metadata'):
         # If we are trying to update metadata fields and the container metadata does not exist or is empty,
         # metadata can all be updated at once for efficiency
         m_update = util.mongo_sanitize_fields(update.pop('metadata'))

--- a/test/integration_tests/test_uploads.py
+++ b/test/integration_tests/test_uploads.py
@@ -198,20 +198,23 @@ def test_acquisition_engine_upload(with_hierarchy_and_file_data, api_as_admin):
     r = api_as_admin.get('/projects/' + data.project)
     assert r.ok
     p = json.loads(r.content)
-    assert p['label'] == metadata['project']['label']
+    # Engine metadata should not replace existing fields
+    assert p['label'] != metadata['project']['label']
     assert cmp(p['metadata'], metadata['project']['metadata']) == 0
 
     r = api_as_admin.get('/sessions/' + data.session)
     assert r.ok
     s = json.loads(r.content)
-    assert s['label'] == metadata['session']['label']
+    # Engine metadata should not replace existing fields
+    assert s['label'] != metadata['session']['label']
     assert cmp(s['metadata'], metadata['session']['metadata']) == 0
     assert s['subject']['code'] == metadata['session']['subject']['code']
 
     r = api_as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok
     a = json.loads(r.content)
-    assert a['label'] == metadata['acquisition']['label']
+    # Engine metadata should not replace existing fields
+    assert a['label'] != metadata['acquisition']['label']
     a_timestamp = dateutil.parser.parse(a['timestamp'])
     m_timestamp = dateutil.parser.parse(metadata['acquisition']['timestamp'])
     assert a_timestamp == m_timestamp
@@ -258,13 +261,15 @@ def test_session_engine_upload(with_hierarchy_and_file_data, api_as_admin):
     r = api_as_admin.get('/projects/' + data.project)
     assert r.ok
     p = json.loads(r.content)
-    assert p['label'] == metadata['project']['label']
+    # Engine metadata should not replace existing fields
+    assert p['label'] != metadata['project']['label']
     assert cmp(p['metadata'], metadata['project']['metadata']) == 0
 
     r = api_as_admin.get('/sessions/' + data.session)
     assert r.ok
     s = json.loads(r.content)
-    assert s['label'] == metadata['session']['label']
+    # Engine metadata should not replace existing fields
+    assert s['label'] != metadata['session']['label']
     assert cmp(s['metadata'], metadata['session']['metadata']) == 0
     assert s['subject']['code'] == metadata['session']['subject']['code']
     s_timestamp = dateutil.parser.parse(s['timestamp'])
@@ -306,7 +311,8 @@ def test_project_engine_upload(with_hierarchy_and_file_data, api_as_admin):
     r = api_as_admin.get('/projects/' + data.project)
     assert r.ok
     p = json.loads(r.content)
-    assert p['label'] == metadata['project']['label']
+    # Engine metadata should not replace existing fields
+    assert p['label'] != metadata['project']['label']
     assert cmp(p['metadata'], metadata['project']['metadata']) == 0
 
     for f in p['files']:
@@ -413,20 +419,23 @@ def test_acquisition_metadata_only_engine_upload(with_hierarchy_and_file_data, a
     r = api_as_admin.get('/projects/' + data.project)
     assert r.ok
     p = json.loads(r.content)
-    assert p['label'] == metadata['project']['label']
+    # Engine metadata should not replace existing fields
+    assert p['label'] != metadata['project']['label']
     assert cmp(p['metadata'], metadata['project']['metadata']) == 0
 
     r = api_as_admin.get('/sessions/' + data.session)
     assert r.ok
     s = json.loads(r.content)
-    assert s['label'] == metadata['session']['label']
+    # Engine metadata should not replace existing fields
+    assert s['label'] != metadata['session']['label']
     assert cmp(s['metadata'], metadata['session']['metadata']) == 0
     assert s['subject']['code'] == metadata['session']['subject']['code']
 
     r = api_as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok
     a = json.loads(r.content)
-    assert a['label'] == metadata['acquisition']['label']
+    # Engine metadata should not replace existing fields
+    assert a['label'] != metadata['acquisition']['label']
     a_timestamp = dateutil.parser.parse(a['timestamp'])
     m_timestamp = dateutil.parser.parse(metadata['acquisition']['timestamp'])
     assert a_timestamp == m_timestamp


### PR DESCRIPTION
Closes #359

Notes about efficiency/concurrency:
 - Pulling the doc into python, doing the update in code, and then using one db `update` was considered but not chosen as there is no (current) way in our architecture to lock a document
 - Using an unordered bulk request limits network traffic to mongo and also allows mongo to make its own optimizations with the update set
 - If an installation is using WiredTiger (available in mongo 3.0), document-level locks are available and will be used. Without WiredTiger, mongo will use a collection-level lock for this update. 
 - If the update includes metadata and the metadata field on the target container does not exist or is empty, the entirety of the metadata field is set at once for efficiency (thanks for the idea @ryansanford). This is to address DICOM headers coming in from gear output causing hundreds of update calls for each metadata field. 