### PR TITLE
Fix propagation bug related to missing s

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -107,7 +107,7 @@ def propagate_changes(cont_name, _id, query, update):
         config.db.acquisitions.update_many(acquisition_q, update)
 
     elif cont_name == 'sessions':
-        query['sessions'] = _id
+        query['session'] = _id
         config.db.acquisitions.update_many(query, update)
     else:
         raise ValueError('changes can only be propagated from group, project or session level')

--- a/test/integration_tests/test_propagation.py
+++ b/test/integration_tests/test_propagation.py
@@ -61,18 +61,18 @@ def test_public_propagation_from_project(with_hierarchy, data_builder, api_as_ad
     """
     data = with_hierarchy
 
-    payload = json.dumps({'public': True})
+    payload = json.dumps({'public': False})
     r = api_as_admin.put('/projects/' + data.project, data=payload)
     assert r.ok
 
     r = api_as_admin.get('/projects/' + data.project)
-    assert r.ok and json.loads(r.content)['public']
+    assert r.ok and not json.loads(r.content)['public']
 
     r = api_as_admin.get('/sessions/' + data.session)
-    assert r.ok and json.loads(r.content)['public']
+    assert r.ok and not json.loads(r.content)['public']
 
     r = api_as_admin.get('/acquisitions/' + data.acquisition)
-    assert r.ok and json.loads(r.content)['public']
+    assert r.ok and not json.loads(r.content)['public']
 
 def test_public_and_archived_propagation_from_project(with_hierarchy, data_builder, api_as_admin):
     """
@@ -104,15 +104,15 @@ def test_public_propagation_from_session(with_hierarchy, data_builder, api_as_ad
     """
     data = with_hierarchy
 
-    payload = json.dumps({'public': True})
+    payload = json.dumps({'archived': True})
     r = api_as_admin.put('/sessions/' + data.session, data=payload)
     assert r.ok
 
     r = api_as_admin.get('/sessions/' + data.session)
-    assert r.ok and json.loads(r.content)['public']
+    assert r.ok and json.loads(r.content)['archived']
 
     r = api_as_admin.get('/acquisitions/' + data.acquisition)
-    assert r.ok and json.loads(r.content)['public']
+    assert r.ok and json.loads(r.content)['archived']
 
 def test_set_public_acquisition(with_hierarchy, data_builder, api_as_admin):
     """


### PR DESCRIPTION
Fixes #367.

There was a mistype between `session` and `sessions` in the propagation query for acquisitions.

I also fixed the propagation tests that should have caught this. The tests were showing a false positive due to `public` not being a propagated property from the session level. 