### PR TITLE
Add file type for Philips PAR/REC format

### DIFF
--- a/api/files.py
+++ b/api/files.py
@@ -249,6 +249,7 @@ FILE_EXTENSIONS = [
     {'bval':         [ '.bval', '.bvals' ]},
     {'bvec':         [ '.bvec', '.bvecs' ]},
     {'dicom':        [ '.dcm', '.dcm.zip', '.dicom.zip' ]},
+    {'parrec':       [ '.parrec.zip', '.par-rec.zip' ]},
     {'gephysio':     [ '.gephysio.zip' ]},
     {'nifti':        [ '.nii.gz', '.nii' ]},
     {'pfile':        [ '.7.gz', '.7' ]},


### PR DESCRIPTION
Having Philips PAR/REC files in the system with their own format `parrec` will allow specific classifiers and converters to be used on them.