### PR TITLE
Add initial support for user API keys

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -198,6 +198,7 @@ routes = [
     webapp2_extras.routes.PathPrefixRoute(r'/api/users', [
         webapp2.Route(r'/self',                                 userhandler.UserHandler, handler_method='self', methods=['GET']),
         webapp2.Route(r'/self/avatar',                          userhandler.UserHandler, handler_method='self_avatar', methods=['GET']),
+        webapp2.Route(r'/self/key',                             userhandler.UserHandler, handler_method='generate_api_key',methods=['POST']),
         webapp2.Route(_format(r'/<_id:{user_id_re}>'),          userhandler.UserHandler, name='user'),
         webapp2.Route(_format(r'/<uid:{user_id_re}>/groups'),   grouphandler.GroupHandler, handler_method='get_all', methods=['GET'], name='groups'),
         webapp2.Route(_format(r'/<uid:{user_id_re}>/avatar'),   userhandler.UserHandler, handler_method='avatar', methods=['GET'], name='avatar'),

--- a/api/base.py
+++ b/api/base.py
@@ -45,7 +45,7 @@ class RequestHandler(webapp2.RequestHandler):
         if access_token:
             if access_token.startswith('scitran-user '):
                 # User (API key) authentication
-                key = access_token.split()[0]
+                key = access_token.split()[1]
                 self.uid = self.authenticate_user_api_key(key)
             elif access_token.startswith('scitran-drone '):
                 # Drone (API key) authentication
@@ -110,7 +110,8 @@ class RequestHandler(webapp2.RequestHandler):
         Returns the user's UID.
         """
 
-        uid = config.db.users.find_one({'api_key.key': key})
+        user = config.db.users.find_one({'api_key.key': key})
+        uid = user.get('_id')
 
         if uid:
             timestamp = datetime.datetime.utcnow()

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -1,7 +1,7 @@
 import base64
 import datetime
 import pymongo
-import uuid
+import os
 
 from .. import base
 from .. import util
@@ -228,9 +228,8 @@ class UserHandler(base.RequestHandler):
         self._init_storage()
         if not self.uid:
             self.abort(400, 'no user is logged in')
-        generated_key = base64.urlsafe_b64encode(str(uuid.uuid4()))
+        generated_key = base64.urlsafe_b64encode(os.urandom(42))
         now = datetime.datetime.utcnow()
-        # Fix last used to unset somehow with containerstorage in the way
         payload = {'api_key': {'key': generated_key, 'created': now, 'last_used': None}}
         result = self.storage.exec_op('PUT', _id=self.uid, payload=payload)
         if result.modified_count == 1:

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -236,7 +236,7 @@ class UserHandler(base.RequestHandler):
         if result.modified_count == 1:
             return {'key': generated_key}
         else:
-            self.abort(404, 'New key for user {} not generated'.format(_id))
+            self.abort(404, 'New key for user {} not generated'.format(self.uid))
 
     def _get_user(self, _id):
         user = self.storage.get_container(_id)

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -1,5 +1,7 @@
+import base64
 import datetime
 import pymongo
+import uuid
 
 from .. import base
 from .. import util
@@ -21,12 +23,7 @@ class UserHandler(base.RequestHandler):
         self._init_storage()
         user = self._get_user(_id)
         permchecker = userauth.default(self, user)
-        projection = []
-        if self.is_true('remotes'):
-            projection += ['remotes']
-        if self.is_true('status'):
-            projection += ['status']
-        result = permchecker(self.storage.exec_op)('GET', _id, projection=projection or None)
+        result = permchecker(self.storage.exec_op)('GET', _id, projection={'api_key': 0} or None)
         if result is None:
             self.abort(404, 'User does not exist')
         return result
@@ -44,7 +41,7 @@ class UserHandler(base.RequestHandler):
     def get_all(self):
         self._init_storage()
         permchecker = userauth.list_permission_checker(self)
-        result = permchecker(self.storage.exec_op)('GET', projection={'preferences': False})
+        result = permchecker(self.storage.exec_op)('GET', projection={'preferences': 0, 'api_key': 0})
         if result is None:
             self.abort(404, 'Not found')
         return result
@@ -226,6 +223,20 @@ class UserHandler(base.RequestHandler):
             self.redirect(str(default), code=307)
         else:
             self.abort(404, 'no avatar')
+
+    def generate_api_key(self):
+        self._init_storage()
+        if not self.uid:
+            self.abort(400, 'no user is logged in')
+        generated_key = base64.urlsafe_b64encode(str(uuid.uuid4()))
+        now = datetime.datetime.utcnow()
+        # Fix last used to unset somehow with containerstorage in the way
+        payload = {'api_key': {'key': generated_key, 'created': now, 'last_used': None}}
+        result = self.storage.exec_op('PUT', _id=self.uid, payload=payload)
+        if result.modified_count == 1:
+            return {'key': generated_key}
+        else:
+            self.abort(404, 'New key for user {} not generated'.format(_id))
 
     def _get_user(self, _id):
         user = self.storage.get_container(_id)

--- a/api/schemas/mongo/user.json
+++ b/api/schemas/mongo/user.json
@@ -31,7 +31,17 @@
     "preferences":      {
                           "title": "Preferences",
                           "type": "object"
-                        }
+                        },
+    "api_keys":         {
+                          "type": "object",
+                          "properties": {
+                              "key":            {"type": "string"},
+                              "created":        {},
+                              "last_used":      {}
+                          },
+                          "additionalProperties": false
+    }
+
   },
   "additionalProperties": false,
   "required":["_id", "firstname", "lastname", "created", "modified", "root"]


### PR DESCRIPTION
**Request new/replacement API key**
A user will not have an API key until they request one. If the user wishes to revoke their existing API key, they may do so by requesting a new one at this endpoint.

***Request***
```
POST /api/users/self/key HTTP/1.1
Content-Type: application/json
(empty request body)
```
***Response***
```
{
  "key": "uCmHDCnNdej9WbLiv_T0VnrbWzMP_-02czad6M7f2A_3cdx4l2V9RbRO"
}
```

**Use API key in a request**
Authorization header expects `scitran-user` and the API key delimitated by a ` `(space) character. The API key information will only be returned via the `api/users/self` endpoint, never by `api/users/` or `api/users/<uid>` even with super-user requests.

***Request***
```
GET /api/users/self HTTP/1.1
Content-Type: application/json
Authorization: scitran-user uCmHDCnNdej9WbLiv_T0VnrbWzMP_-02czad6M7f2A_3cdx4l2V9RbRO
```
***Response***
`last_used` will be `null` when the key has not been used yet. 
```
{
  "api_key": {
    "last_used": "2016-08-08T16:36:11.548000+00:00",
    "key": "uCmHDCnNdej9WbLiv_T0VnrbWzMP_-02czad6M7f2A_3cdx4l2V9RbRO",
    "created": "2016-08-08T16:27:15.539000+00:00"
  },
  "firstname": "Example",
 ...
```