### PR TITLE
remove "id":"#" from schemas/input/download.json

### DIFF
--- a/api/schemas/input/download.json
+++ b/api/schemas/input/download.json
@@ -1,5 +1,4 @@
 {
-    "id": "#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions": {
         "filterDefinition": {


### PR DESCRIPTION
RAML API Workbench threw an error parsing the $ref's in download.json schema.  I believe the reason is the documents "id" parameter is set to "#" .  "id" needs to be a valid URI.    "id" does not need to be specified, and if id is not specified a ref that starts with "#" will reference the current document, so setting "id":"#" seems wrong to me.   http://json-schema.org/latest/json-schema-core.html#anchor27   EDIT:  From that link:  "This URI MUST be normalized, and SHOULD NOT be an empty fragment (#) or the empty URI."
