### PR TITLE
Fix malformed timestamps

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -355,6 +355,8 @@ def _update_hierarchy(container, container_type, metadata):
         session_obj = None
         if session.keys():
             session['modified'] = now
+            if session.get('timestamp'):
+                session['timestamp'] = dateutil.parser.parse(session['timestamp'])
             session_obj = _update_container_nulls({'_id': container['session']},  session, 'sessions')
         if session_obj is None:
             session_obj = get_container('session', container['session'])

--- a/bin/database.py
+++ b/bin/database.py
@@ -436,7 +436,10 @@ def upgrade_schema():
         while db_version < CURRENT_DATABASE_VERSION:
             db_version += 1
             upgrade_script = 'upgrade_to_'+str(db_version)
-            globals().get(upgrade_script)()
+            globals()[upgrade_script]()
+    except KeyError as e:
+        logging.exception('Attempted to upgrade using script that does not exist: {}'.format(e))
+        sys.exit(1)
     except Exception as e:
         logging.exception('Incremental upgrade of db failed')
         sys.exit(1)

--- a/bin/database.py
+++ b/bin/database.py
@@ -447,18 +447,19 @@ def upgrade_schema():
         config.db.singletons.update_one({'_id': 'version'}, {'$set': {'database': CURRENT_DATABASE_VERSION}})
         sys.exit(0)
 
-try:
-    if len(sys.argv) > 1:
-        if sys.argv[1] == 'confirm_schema_match':
-            confirm_schema_match()
-        elif sys.argv[1] == 'upgrade_schema':
-            upgrade_schema()
+if __name__ == '__main__':
+    try:
+        if len(sys.argv) > 1:
+            if sys.argv[1] == 'confirm_schema_match':
+                confirm_schema_match()
+            elif sys.argv[1] == 'upgrade_schema':
+                upgrade_schema()
+            else:
+                logging.error('Unknown method name given as argv to database.py')
+                sys.exit(1)
         else:
-            logging.error('Unknown method name given as argv to database.py')
+            logging.error('No method name given as argv to database.py')
             sys.exit(1)
-    else:
-        logging.error('No method name given as argv to database.py')
+    except Exception as e:
+        logging.exception('Unexpected error in database.py')
         sys.exit(1)
-except Exception as e:
-    logging.exception('Unexpected error in database.py')
-    sys.exit(1)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 # Development packages
 coverage==4.0.3
 coveralls==1.1
+mock==2.0.0
 nose==1.3.7
 PasteScript==2.0.2
 pylint==1.5.3

--- a/test/unit_tests/test_db_upgrade.py
+++ b/test/unit_tests/test_db_upgrade.py
@@ -1,0 +1,51 @@
+import pytest
+
+from mock import Mock, patch
+
+from bin import database
+from api import config
+
+CDV = database.CURRENT_DATABASE_VERSION
+
+def test_all_upgrade_scripts_exist():
+    for i in range(1, CDV):
+        script_name = 'upgrade_to_{}'.format(i)
+        assert hasattr(database, script_name)
+
+def test_CDV_was_bumped():
+    script_name = 'upgrade_to_{}'.format(CDV+1)
+    assert hasattr(database, script_name) is False
+
+
+@patch('api.config.get_version', Mock(return_value={'database': 5}))
+def test_get_db_version_from_config():
+    assert database.get_db_version() == 5
+
+
+@pytest.fixture(scope='function')
+def database_mock_setup():
+    setattr(config.db.singletons, 'update_one', Mock())
+    for i in range(1, CDV):
+        script_name = 'upgrade_to_{}'.format(i)
+        setattr(database, script_name, Mock())
+
+@patch('bin.database.get_db_version', Mock(return_value=0))
+def test_all_upgrade_scripts_ran(database_mock_setup):
+    with pytest.raises(SystemExit):
+        database.upgrade_schema()
+    for i in range(1, CDV):
+        script_name = 'upgrade_to_{}'.format(i)
+        assert getattr(database, script_name).called
+
+@patch('bin.database.get_db_version', Mock(return_value=CDV-4))
+def test_necessary_upgrade_scripts_ran(database_mock_setup):
+    with pytest.raises(SystemExit):
+        database.upgrade_schema()
+    # Assert the necessary scripts were called
+    for i in range(CDV-3, CDV):
+        script_name = 'upgrade_to_{}'.format(i)
+        assert getattr(database, script_name).called
+    # But not the scripts before it
+    for i in range(1, CDV-4):
+        script_name = 'upgrade_to_{}'.format(i)
+        assert getattr(database, script_name).called is False


### PR DESCRIPTION
This should cover all our bases for malformed timestamps in acquisitions and sessions. Amends db update `9` which only covered blank strings.