### PR TITLE
Make schema_path no longer user configurable

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -53,7 +53,6 @@ DEFAULT_CONFIG = {
         'db_connect_timeout': '2000',
         'db_server_selection_timeout': '3000',
         'data_path': os.path.join(os.path.dirname(__file__), '../persistent/data'),
-        'schema_path': os.path.join(os.path.dirname(os.path.abspath(__file__)), '../raml/schemas'),
         'elasticsearch_host': 'localhost:9200',
     },
 }
@@ -100,7 +99,7 @@ log.debug(str(db))
 es = elasticsearch.Elasticsearch([__config['persistent']['elasticsearch_host']])
 
 # validate the lists of json schemas
-schema_path = __config['persistent']['schema_path']
+schema_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../raml/schemas')
 
 expected_mongo_schemas = set([
     'acquisition.json',

--- a/api/handlers/schemahandler.py
+++ b/api/handlers/schemahandler.py
@@ -12,7 +12,7 @@ class SchemaHandler(base.RequestHandler):
         super(SchemaHandler, self).__init__(request, response)
 
     def get(self, schema):
-        schema_path = os.path.join(config.get_item('persistent', 'schema_path'), schema)
+        schema_path = os.path.join(config.schema_path, schema)
         try:
             with open(schema_path, 'rU') as f:
                 return json.load(f)

--- a/api/validators.py
+++ b/api/validators.py
@@ -46,7 +46,7 @@ def no_op(g, *args): # pylint: disable=unused-argument
 
 def schema_uri(type_, schema_name):
     return os.path.join(
-        config.get_item('persistent', 'schema_path'),
+        config.schema_path,
         type_,
         schema_name
     )

--- a/bin/database.py
+++ b/bin/database.py
@@ -11,7 +11,7 @@ from api import config
 from api.dao import containerutil
 from api.jobs.jobs import Job
 
-CURRENT_DATABASE_VERSION = 13 # An int that is bumped when a new schema change is made
+CURRENT_DATABASE_VERSION = 14 # An int that is bumped when a new schema change is made
 
 def get_db_version():
 
@@ -373,6 +373,11 @@ def upgrade_to_13():
         {'_id': 'config', 'persistent.schema_path': {'$exists': True}},
         {'$unset': {'persistent.schema_path': ''}})
 
+def upgrade_to_14():
+    """schema_path is no longer user configurable"""
+    config.db.singletons.find_one_and_update(
+        {'_id': 'config', 'persistent.schema_path': {'$exists': True}},
+        {'$unset': {'persistent.schema_path': ''}})
 
 def upgrade_schema():
     """
@@ -409,6 +414,8 @@ def upgrade_schema():
             upgrade_to_12()
         if db_version < 13:
             upgrade_to_13()
+        if db_version < 14:
+            upgrade_to_14()
 
     except Exception as e:
         logging.exception('Incremental upgrade of db failed')


### PR DESCRIPTION
Having schema_path be user configurable causes problems during changes, such as  PR #403.  This PR hardcodes schema_path, as there isn't a valid use case for changing it.