### PR TITLE
Set config.log.propagate to False

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -14,6 +14,7 @@ logging.basicConfig(
     level=logging.DEBUG,
 )
 log = logging.getLogger('scitran.api')
+log.propagate = False
 
 logging.getLogger('MARKDOWN').setLevel(logging.WARNING) # silence Markdown library
 logging.getLogger('requests').setLevel(logging.WARNING) # silence Requests library


### PR DESCRIPTION
Currently our logging setup duplicates messages.  This is because propagate is set to True by default on python logger objects.  This causes messages sent to the logger to propagate up and in our case hit the root logger which is configured to also log to stderr.  https://docs.python.org/2/library/logging.html#logging.Logger.propagate