### PR TITLE
Set additionalProperties to false in schema defs

### DIFF
--- a/api/base.py
+++ b/api/base.py
@@ -270,7 +270,7 @@ class RequestHandler(webapp2.RequestHandler):
         if isinstance(exception, webapp2.HTTPException):
             code = exception.code
         elif isinstance(exception, validators.InputValidationException):
-            code = 400
+            code = 422
             log.warn(str(exception))
         elif isinstance(exception, APIConsistencyException):
             code = 400

--- a/raml/schemas/definitions/job.json
+++ b/raml/schemas/definitions/job.json
@@ -67,5 +67,6 @@
       "_id": {
         "type": "string"
       }
-    }
+    },
+    "additionalProperties": false
 }

--- a/raml/schemas/definitions/user-output.json
+++ b/raml/schemas/definitions/user-output.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref":"user.json#",
+  "additionalProperties":{
+    "created":{"type":"string"},
+    "modified":{"type":"string"}
+  },
+  "required":[
+     "_id", "firstname", "lastname",
+     "root", "email", "created", "modified"
+   ]
+}

--- a/raml/schemas/definitions/user.json
+++ b/raml/schemas/definitions/user.json
@@ -38,5 +38,6 @@
                           "type": "object"
                         }
     },
-    "type":"object"
+    "type":"object",
+    "additionalProperties": false
 }

--- a/raml/schemas/output/user-list.json
+++ b/raml/schemas/output/user-list.json
@@ -2,6 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
   "items": {
-    "$ref":"../definitions/user.json#"
+    "$ref":"../definitions/user-output.json#"
   }
 }

--- a/raml/schemas/output/user.json
+++ b/raml/schemas/output/user.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref":"../definitions/user.json#"
+  "$ref":"../definitions/user-output.json#"
 }

--- a/test/integration_tests/abao/abao_test_hooks.js
+++ b/test/integration_tests/abao/abao_test_hooks.js
@@ -22,7 +22,7 @@ hooks.skip("POST /upload/uid-match -> 402");
 // Should 422 for JSON not matching schema
 // After this is fixed, add "validates-json-body" trait
 // to all endpoints which validate a json body
-hooks.skip("POST /users -> 422");
+// hooks.skip("POST /users -> 422");
 
 // Should 404
 hooks.skip("GET /jobs/{JobId} -> 404");

--- a/test/integration_tests/python/test_errors.py
+++ b/test/integration_tests/python/test_errors.py
@@ -18,7 +18,7 @@ def test_extra_param(api_as_admin):
     })
 
     r = api_as_admin.post('/projects', data=bad_payload)
-    assert r.status_code == 400
+    assert r.status_code == 422
 
     r = api_as_admin.get('/projects')
     assert r.ok

--- a/test/integration_tests/python/test_tags.py
+++ b/test/integration_tests/python/test_tags.py
@@ -49,7 +49,7 @@ def test_tags(with_a_group_and_a_project, api_as_admin):
     # Add too long tag and verify
     payload = json.dumps({'value': too_long_tag})
     r = api_as_admin.post(tags_path, data=payload)
-    assert r.status_code == 400
+    assert r.status_code == 422
 
     # Attempt to update tag, returns 404
     payload = json.dumps({'value': new_tag})


### PR DESCRIPTION
When I separated the user schema into a user definition I added additionalProperties in the wrong place so it was not taking effect.  Everywhere properties is specified, additionalProperties must be specified in the same document or it will default to True.  This also required creating a separate user-output definition for the output schemas to share, because the keys "created" and "modified" are not shared by input schemas.  There is no way to add properties when referencing a schema.  For an explanation of that topic, see http://stackoverflow.com/questions/22689900/json-schema-allof-with-additionalproperties 