### PR TITLE
remove __pycache__ directory

### DIFF
--- a/test/bin/run-integration-tests.sh
+++ b/test/bin/run-integration-tests.sh
@@ -33,6 +33,11 @@ SCITRAN_PERSISTENT_DB_URI="$MONGODB_URI" \
   python "bin/bootstrap-dev.py" \
   "test/integration_tests/bootstrap-test-accounts.json"
 
+# Remove __pycache__ directory for issue with __file__ attribute
+# Due to running the tests on the host creating bytecode files
+# Which have a mismatched __file__ attribute when loaded in docker container
+rm -rf test/integration_tests/python/__pycache__
+
 BASE_URL="$SCITRAN_SITE_API_URL" \
     MONGO_PATH="$MONGODB_URI" \
     py.test --cov=api --cov-append test/integration_tests/python

--- a/test/bin/run-unit-tests.sh
+++ b/test/bin/run-unit-tests.sh
@@ -11,4 +11,9 @@ echo "Checking for files with windows style newline:"
 ! find * -path "runtime" -prune -o -path "persistent" -prune -o -type f \
   -exec grep -rI $'\r' {} \+
 
+# Remove __pycache__ directory for issue with __file__ attribute
+# Due to running the tests on the host creating bytecode files
+# Which have a mismatched __file__ attribute when loaded in docker container
+rm -rf test/unit_tests/python/__pycache__
+
 PYTHONPATH="$( pwd )"  py.test --cov=api --cov-append test/unit_tests/python


### PR DESCRIPTION
Remove `__pycache__` directory before tests to fix __file__ mismatch issue with pytest