### PR TITLE
[Do Not Merge]  [Example]  Add per-request logging context

### DIFF
--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -3,10 +3,6 @@ Purpose of this module is to define all the permissions checker decorators for t
 """
 
 from . import _get_access, INTEGER_ROLES
-from .. import config
-
-log = config.log
-
 
 def default_container(handler, container=None, target_parent_container=None):
     """

--- a/api/auth/groupauth.py
+++ b/api/auth/groupauth.py
@@ -1,7 +1,5 @@
 from . import _get_access, INTEGER_ROLES
-from .. import config
-
-log = config.log
+from ..request import get_current_request
 
 
 def default(handler, group=None):
@@ -41,8 +39,9 @@ def list_permission_checker(handler, uid=None):
                         query['roles'] = {'$elemMatch': {'_id': handler.uid, 'access': 'admin'}}
                     else:
                         query['roles._id'] = handler.uid
-            log.debug(query)
-            log.debug(projection)
+            request = get_current_request()
+            request.logger.debug(query)
+            request.logger.debug(projection)
             return exec_op(method, query=query, projection=projection)
         return f
     return g

--- a/api/auth/listauth.py
+++ b/api/auth/listauth.py
@@ -5,11 +5,8 @@ Purpose of this module is to define all the permissions checker decorators for t
 
 import sys
 
-from .. import config
 from . import _get_access, INTEGER_ROLES
-
-log = config.log
-
+from ..request import get_current_request
 
 def default_sublist(handler, container):
     """
@@ -75,7 +72,8 @@ def permissions_sublist(handler, container):
     access = _get_access(handler.uid, handler.user_site, container)
     def g(exec_op):
         def f(method, _id, query_params = None, payload = None, exclude_params=None):
-            log.debug(query_params)
+            request = get_current_request()
+            request.logger.debug(query_params)
             if method in ['GET', 'DELETE']  and query_params.get('_id') == handler.uid and query_params.get('site') == handler.user_site:
                 return exec_op(method, _id, query_params, payload, exclude_params)
             elif access >= INTEGER_ROLES['admin']:

--- a/api/auth/userauth.py
+++ b/api/auth/userauth.py
@@ -1,8 +1,3 @@
-from .. import config
-
-log = config.log
-
-
 def default(handler, user=None):
     def g(exec_op):
         def f(method, _id=None, query=None, payload=None, projection=None):

--- a/api/base.py
+++ b/api/base.py
@@ -15,19 +15,17 @@ from .types import Origin
 from . import validators
 from .dao import APIConsistencyException, APIConflictException, APINotFoundException
 
-log = config.log
-
 class RequestHandler(webapp2.RequestHandler):
 
     json_schema = None
 
     def __init__(self, request=None, response=None): # pylint: disable=super-init-not-called
+        """Set uid, source_site, public_request, and superuser"""
         self.initialize(request, response)
         self.debug = config.get_item('core', 'insecure')
-
-        # set uid, source_site, public_request, and superuser
         self.uid = None
         self.source_site = None
+
         drone_request = False
 
         user_agent = self.request.headers.get('User-Agent', '')
@@ -101,6 +99,10 @@ class RequestHandler(webapp2.RequestHandler):
 
         self.set_origin(drone_request)
 
+    def initialize(self, request, response):
+        super(RequestHandler, self).initialize(request, response)
+        request.logger.info("Initialized request")
+
     def authenticate_user_api_key(self, key):
         """
         AuthN for user accounts via api key. Calls self.abort on failure.
@@ -129,10 +131,10 @@ class RequestHandler(webapp2.RequestHandler):
 
         if cached_token:
             uid = cached_token['uid']
-            log.debug('looked up cached token in %dms', ((datetime.datetime.utcnow() - timestamp).total_seconds() * 1000.))
+            self.request.logger.debug('looked up cached token in %dms', ((datetime.datetime.utcnow() - timestamp).total_seconds() * 1000.))
         else:
             uid = self.validate_oauth_token(access_token, timestamp)
-            log.debug('looked up remote token in %dms', ((datetime.datetime.utcnow() - timestamp).total_seconds() * 1000.))
+            self.request.logger.debug('looked up remote token in %dms', ((datetime.datetime.utcnow() - timestamp).total_seconds() * 1000.))
 
             # Cache the token for future requests
             config.db.authtokens.replace_one({'_id': access_token}, {'uid': uid, 'timestamp': timestamp}, upsert=True)
@@ -153,7 +155,7 @@ class RequestHandler(webapp2.RequestHandler):
             err_msg = 'Invalid OAuth2 token.'
             site_id = config.get_item('site', 'id')
             headers = {'WWW-Authenticate': 'Bearer realm="{}", error="invalid_token", error_description="{}"'.format(site_id, err_msg)}
-            log.warn('{} Request headers: {}'.format(err_msg, str(self.request.headers.items())))
+            self.request.logger.warning('{} Request headers: {}'.format(err_msg, str(self.request.headers.items())))
             self.abort(401, err_msg, headers=headers)
 
         identity = json.loads(r.content)
@@ -271,7 +273,7 @@ class RequestHandler(webapp2.RequestHandler):
             code = exception.code
         elif isinstance(exception, validators.InputValidationException):
             code = 400
-            log.warn(str(exception))
+            self.request.logger.warning(str(exception))
         elif isinstance(exception, APIConsistencyException):
             code = 400
         elif isinstance(exception, APINotFoundException):
@@ -285,7 +287,7 @@ class RequestHandler(webapp2.RequestHandler):
 
         if code == 500:
             tb = traceback.format_exc()
-            log.error(tb)
+            self.request.logger.error(tb)
 
         util.send_json_http_exception(self.response, str(exception), code)
 
@@ -295,7 +297,7 @@ class RequestHandler(webapp2.RequestHandler):
         site_id = config.get_item('site', 'id')
         target_site = self.get_param('site', site_id)
         if target_site == site_id:
-            log.debug('from %s %s %s %s %s', self.source_site, self.uid, self.request.method, self.request.path, str(self.request.GET.mixed()))
+            self.request.logger.debug('from %s %s %s %s %s', self.source_site, self.uid, self.request.method, self.request.path, str(self.request.GET.mixed()))
             return super(RequestHandler, self).dispatch()
         else:
             if not site_id:
@@ -317,7 +319,7 @@ class RequestHandler(webapp2.RequestHandler):
             params = self.request.GET.mixed()
             if 'user' in params: del params['user']
             del params['site']
-            log.debug(' for %s %s %s %s %s', target_site, self.uid, self.request.method, self.request.path, str(self.request.GET.mixed()))
+            self.request.logger.debug(' for %s %s %s %s %s', target_site, self.uid, self.request.method, self.request.path, str(self.request.GET.mixed()))
             target_uri = target['api_uri'] + self.request.path.split('/api')[1]
             r = requests.request(
                     self.request.method,
@@ -342,5 +344,5 @@ class RequestHandler(webapp2.RequestHandler):
                 'validator': detail.validator,
                 'validator_value': detail.validator_value,
             }
-        log.warning(str(self.uid) + ' ' + str(code) + ' ' + str(detail))
+        self.request.logger.warning(str(self.uid) + ' ' + str(code) + ' ' + str(detail))
         webapp2.abort(code, detail=detail, **kwargs)

--- a/api/dao/consistencychecker.py
+++ b/api/dao/consistencychecker.py
@@ -4,8 +4,6 @@ do some verification against the database before allowing the operation"""
 from .. import config
 from . import APIConsistencyException
 
-log = config.log
-
 def noop(*args, **kwargs): # pylint: disable=unused-argument
     pass
 

--- a/api/debuginfo.py
+++ b/api/debuginfo.py
@@ -1,7 +1,3 @@
-from . import config
-
-log = config.log
-
 child_containers = {
     'projects': 'sessions',
     'sessions': 'acquisitions',
@@ -52,4 +48,3 @@ def _add_di(handler, cont_name, response):
             'group_details',
             _id=response['group'],
             _full=True) + '?' + handler.request.query_string
-

--- a/api/download.py
+++ b/api/download.py
@@ -11,9 +11,6 @@ from . import config
 from . import util
 from . import validators
 
-log = config.log
-
-
 def _filter_check(property_filter, property_values):
     minus = set(property_filter.get('-', []))
     plus = set(property_filter.get('+', []))
@@ -220,7 +217,7 @@ class Download(base.RequestHandler):
                 total_size, file_cnt = _append_targets(targets, acq, prefix, total_size, file_cnt, req_spec['optional'], data_path, req_spec.get('filters'))
 
         if len(targets) > 0:
-            log.debug(json.dumps(targets, sort_keys=True, indent=4, separators=(',', ': ')))
+            self.request.logger.debug(json.dumps(targets, sort_keys=True, indent=4, separators=(',', ': ')))
             filename = arc_prefix + '_' + datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S') + '.tar'
             ticket = util.download_ticket(self.request.client_addr, 'batch', targets, filename, total_size)
             config.db.downloads.insert_one(ticket)
@@ -285,6 +282,6 @@ class Download(base.RequestHandler):
                 payload_schema_uri = validators.schema_uri('input', 'download.json')
                 validator = validators.from_schema_path(payload_schema_uri)
                 validator(req_spec, 'POST')
-                log.debug(json.dumps(req_spec, sort_keys=True, indent=4, separators=(',', ': ')))
+                self.request.logger.debug(json.dumps(req_spec, sort_keys=True, indent=4, separators=(',', ': ')))
 
                 return self._preflight_archivestream(req_spec, collection=self.get_param('collection'))

--- a/api/files.py
+++ b/api/files.py
@@ -10,8 +10,6 @@ from . import util
 from . import config
 from . import tempdir as tempfile
 
-log = config.log
-
 DEFAULT_HASH_ALG='sha384'
 
 def move_file(path, target_path):

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -8,9 +8,6 @@ from ..dao import APIStorageException
 
 from .containerhandler import ContainerHandler
 
-log = config.log
-
-
 class CollectionsHandler(ContainerHandler):
     # pylint: disable=arguments-differ
 
@@ -36,7 +33,7 @@ class CollectionsHandler(ContainerHandler):
         mongo_validator, payload_validator = self._get_validators()
 
         payload = self.request.json_body
-        log.debug(payload)
+        self.request.logger.debug(payload)
         payload_validator(payload, 'POST')
         payload['permissions'] = [{
             '_id': self.uid,
@@ -89,7 +86,7 @@ class CollectionsHandler(ContainerHandler):
             elif item['level'] == 'acquisition':
                 acq_ids += [item_id]
         operator = '$addToSet' if contents['operation'] == 'add' else '$pull'
-        log.info(' '.join(['collection', _id, operator, str(acq_ids)]))
+        self.request.logger.info(' '.join(['collection', _id, operator, str(acq_ids)]))
         if not bson.ObjectId.is_valid(_id):
             self.abort(400, 'not a valid object id')
         config.db.acquisitions.update_many({'_id': {'$in': acq_ids}}, {operator: {'collections': bson.ObjectId(_id)}})
@@ -151,8 +148,8 @@ class CollectionsHandler(ContainerHandler):
                 ])
         query = {'_id': {'$in': [ar['_id'] for ar in agg_res]}}
         projection = self.container_handler_configurations['sessions']['list_projection']
-        log.debug(query)
-        log.debug(projection)
+        self.request.logger.debug(query)
+        self.request.logger.debug(projection)
         sessions = list(config.db.sessions.find(query, projection))
         self._filter_all_permissions(sessions, self.uid, self.user_site)
         if self.is_true('measurements'):

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -14,9 +14,6 @@ from ..types import Origin
 from ..jobs.queue import Queue
 from ..jobs.jobs import Job
 
-log = config.log
-
-
 class ContainerHandler(base.RequestHandler):
     """
     This class handle operations on a generic container
@@ -369,7 +366,7 @@ class ContainerHandler(base.RequestHandler):
         mongo_validator, payload_validator = self._get_validators()
 
         payload = self.request.json_body
-        log.debug(payload)
+        self.request.logger.debug(payload)
         #validate the input payload
         payload_validator(payload, 'POST')
         # Load the parent container in which the new container will be created

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -2,14 +2,10 @@ import datetime
 
 from .. import base
 from .. import util
-from .. import config
 from .. import debuginfo
 from .. import validators
 from ..auth import groupauth
 from ..dao import containerstorage
-
-log = config.log
-
 
 class GroupHandler(base.RequestHandler):
 

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -21,9 +21,6 @@ from ..dao import APIStorageException
 from ..dao import hierarchy
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
 
-
-log = config.log
-
 def initialize_list_configurations():
     """
     This configurations are used by the ListHandler class to load the storage, the permissions checker

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -5,8 +5,6 @@ import copy
 from .. import base
 from .. import config
 
-log = config.log
-
 EIGHTEEN_YEARS_IN_SEC = 18 * 365.25 * 24 * 60 * 60
 
 class APIReportException(Exception):

--- a/api/handlers/schemahandler.py
+++ b/api/handlers/schemahandler.py
@@ -4,8 +4,6 @@ import json
 from .. import base
 from .. import config
 
-log = config.log
-
 class SchemaHandler(base.RequestHandler):
 
     def __init__(self, request=None, response=None):

--- a/api/handlers/searchhandler.py
+++ b/api/handlers/searchhandler.py
@@ -6,8 +6,6 @@ from .. import config
 from .. import util
 from ..search import pathparser, queryprocessor, es_query
 
-log = config.log
-
 parent_container_dict = {
     'acquisitions': 'sessions',
     'sessions': 'projects',

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -11,8 +11,6 @@ from ..auth import userauth
 from ..dao import containerstorage
 from ..dao import noop, APIStorageException
 
-log = config.log
-
 
 class UserHandler(base.RequestHandler):
 
@@ -50,7 +48,7 @@ class UserHandler(base.RequestHandler):
         # Check for authZ before cleaning up user permissions
         permchecker(noop)('DELETE', _id)
         self._cleanup_user_permissions(user.get('_id'))
-        log.debug('2')
+        self.request.logger.debug('2')
         result = self.storage.exec_op('DELETE', _id)
         if result.deleted_count == 1:
             return {'deleted': result.deleted_count}

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -3,9 +3,8 @@ Gears
 """
 
 from .. import config
+from ..request import get_current_request
 from .jobs import Job
-
-log = config.log
 
 # For now, gears are in a singleton, prefixed by a key
 SINGLETON_KEY = 'gear_list'
@@ -56,7 +55,8 @@ def insert_gear(doc):
     )
 
     if config.get_item('queue', 'prefetch'):
-        log.info('Queuing prefetch job for gear ' + doc['name'])
+        request = get_current_request()
+        request.logger.info('Queuing prefetch job for gear ' + doc['name'])
 
         job = Job(doc['name'], {}, destination={}, tags=['prefetch'], request={
             'inputs': [

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -13,9 +13,6 @@ from .gears import get_gears, get_gear_by_name, remove_gear, upsert_gear
 from .jobs import Job
 from .queue import Queue
 
-log = config.log
-
-
 class GearsHandler(base.RequestHandler):
 
     """Provide /gears API routes."""

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -10,8 +10,6 @@ from ..dao.containerutil import create_filereference_from_dictionary, create_con
 
 from .. import config
 
-log = config.log
-
 class Job(object):
     def __init__(self, name, inputs, destination=None, tags=None, attempt=1, previous_job_id=None, created=None, modified=None, state='pending', request=None, id_=None, config_=None, now=False):
         """

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -2,12 +2,10 @@ import fnmatch
 
 from .. import config
 from ..dao.containerutil import FileReference
+from ..request import get_current_request
 
 from . import gears
 from .jobs import Job
-
-log = config.log
-
 
 #
 # {
@@ -45,7 +43,8 @@ def get_base_rules():
     return rule_doc.get('rule_list', [])
 
 def _log_file_key_error(file_, container, error):
-    log.warning('file ' + file_.get('name', '?') + ' in container ' + str(container.get('_id', '?')) + ' ' + error)
+    request = get_current_request()
+    request.logger.warning('file ' + file_.get('name', '?') + ' in container ' + str(container.get('_id', '?')) + ' ' + error)
 
 def eval_match(match_type, match_param, file_, container):
     """

--- a/api/placer.py
+++ b/api/placer.py
@@ -17,8 +17,6 @@ from .dao import containerutil, hierarchy
 from .jobs import rules
 from .types import Origin
 
-log = config.log
-
 class Placer(object):
     """
     Interface for a placer, which knows how to process files and place them where they belong - on disk and database.
@@ -583,4 +581,3 @@ class AnalysisJobPlacer(Placer):
                 # If the original job failed, update the analysis with the job that succeeded
                 u['$set'] = {'job': self.context['job_id']}
             config.db.sessions.update_one(q, u)
-

--- a/api/request.py
+++ b/api/request.py
@@ -1,0 +1,44 @@
+import logging
+import threading
+import time
+import uuid
+
+from webob.request import Request
+
+from . import config
+
+# Make a thread-local variable to store the current request
+threadLocal = threading.local()
+threadLocal.current_request = None
+
+def set_current_request(request):
+    if threadLocal.current_request is not None and request is not None:
+        raise ValueError("Attempted to overwrite current request")
+    threadLocal.current_request = request
+
+def get_current_request():
+    return threadLocal.current_request
+
+class SciTranRequest(Request):
+    """Extends webob.request.Request"""
+    def __init__(self, *args, **kwargs):
+        super(SciTranRequest, self).__init__(*args, **kwargs)
+        self.id = "{random_chars}-{timestamp}".format(
+            timestamp = str(int(time.time())),
+            random_chars = str(uuid.uuid4().hex)[:8]
+            )
+        self.logger =  get_request_logger(self.id)
+
+class RequestLoggerAdapter(logging.LoggerAdapter):
+    """A LoggerAdapter to add request_id context"""
+    def process(self, msg, kwargs):
+        context_message =  "{0} request_id={1}".format(
+            msg, self.extra['request_id']
+            )
+        return context_message, kwargs
+
+def get_request_logger(request_id):
+    """Given a request_id, produce a Logger or LoggerAdapter"""
+    extra = {"request_id":request_id}
+    logger = RequestLoggerAdapter(config.log, extra=extra)
+    return logger

--- a/api/root.py
+++ b/api/root.py
@@ -2,9 +2,6 @@ import re
 import markdown
 
 from . import base
-from . import config
-
-log = config.log
 
 class Root(base.RequestHandler):
 

--- a/api/search/queryprocessor.py
+++ b/api/search/queryprocessor.py
@@ -4,8 +4,7 @@ from . import (
     es_query, add_filter_from_list, add_filter
 )
 from .. import config
-
-log = config.log
+from ..request import get_current_request
 
 querygraph = {
     'acquisitions': {
@@ -84,17 +83,18 @@ class SearchContainer(object):
             filter_on_field = source[:-1] if source != 'collections' else source
             list_ids = source_results.keys()
         self.query = add_filter_from_list(self.query, filter_on_field, list_ids)
+        request = get_current_request()
         if self.results is not None:
             updated_results = {}
-            log.debug('{} {} {}'.format(self.cont_name, list_ids, filter_on_field))
+            request.logger.debug('{} {} {}'.format(self.cont_name, list_ids, filter_on_field))
             for _id, r in self.results.items():
                 # if we are not filtering on the _id we need to get the _source
                 doc = r if filter_on_field == '_id' else r['_source']
-                log.debug('{} {}'.format(self.cont_name, doc.get(filter_on_field, [])))
+                request.logger.debug('{} {}'.format(self.cont_name, doc.get(filter_on_field, [])))
                 if self._to_set(doc.get(filter_on_field, [])).intersection(list_ids):
                     updated_results[_id] = r
             self.results = updated_results
-            log.debug('{} {}'.format(self.cont_name, self.results))
+            request.logger.debug('{} {}'.format(self.cont_name, self.results))
         else:
             self.results = self._exec_query(self.query)
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -8,10 +8,9 @@ from . import base
 from . import config
 from . import files
 from . import placer as pl
+from .request import get_current_request
 from . import util
 from .dao import hierarchy
-
-log = config.log
 
 Strategy = util.Enum('Strategy', {
     'targeted'    : pl.TargetedPlacer,      # Upload N files to a container.
@@ -193,9 +192,10 @@ class Upload(base.RequestHandler):
             'modified': {'$lt': datetime.datetime.utcnow() - datetime.timedelta(hours=1)},
         })
 
+        request = get_current_request()
         removed = result.deleted_count
         if removed > 0:
-            log.info('Removed ' + str(removed) + ' expired packfile tokens')
+            request.logger.info('Removed ' + str(removed) + ' expired packfile tokens')
 
         # Next, find token directories and remove any that don't map to a token.
 
@@ -225,7 +225,7 @@ class Upload(base.RequestHandler):
                 pass
 
             if result is None:
-                log.info('Cleaning expired token directory ' + token)
+                request.logger.info('Cleaning expired token directory ' + token)
                 shutil.rmtree(path)
                 cleaned += 1
 

--- a/api/validators.py
+++ b/api/validators.py
@@ -4,8 +4,7 @@ import jsonschema
 import os
 
 from . import config
-
-log = config.log
+from .request import get_current_request
 
 class InputValidationException(Exception):
     pass
@@ -58,7 +57,8 @@ def decorator_from_schema_path(schema_url):
     def g(exec_op):
         def validator(method, **kwargs):
             payload = kwargs['payload']
-            log.debug(payload)
+            request = get_current_request()
+            request.logger.debug(payload)
             if method == 'PUT' and schema.get('required'):
                 _schema = copy.copy(schema)
                 _schema.pop('required')
@@ -109,7 +109,8 @@ def key_check(schema_url):
     if schema_url is None:
         return no_op
     schema, _ = _resolve_schema(schema_url)
-    log.debug(schema)
+    request = get_current_request()
+    request.logger.debug(schema)
     if schema.get('key_fields') is None:
         return no_op
     def g(exec_op):

--- a/test/integration_tests/requirements-integration-test.txt
+++ b/test/integration_tests/requirements-integration-test.txt
@@ -7,3 +7,5 @@ pytest-watch==3.8.0
 pytest==2.8.5
 python-dateutil==1.5
 requests==2.9.1
+mock==2.0.0
+testfixtures==4.10.1

--- a/test/unit_tests/python/test_request.py
+++ b/test/unit_tests/python/test_request.py
@@ -1,0 +1,31 @@
+import unittest
+
+import mock
+from testfixtures import LogCapture
+
+import api.request
+
+class TestRequest(unittest.TestCase):
+    def setUp(self):
+        self.log_capture = LogCapture()
+        self.request = api.request.SciTranRequest({})
+        api.request.set_current_request(self.request)
+
+    def tearDown(self):
+        api.request.set_current_request(None)
+        LogCapture.uninstall_all()
+
+    def test_request_logger_adapter(self):
+        request = api.request.get_current_request()
+        self.assertTrue(self.request is request)
+        self.assertEqual(len(request.id), 19)
+        test_log_message = "test log message"
+        request.logger.error(test_log_message)
+        expected_log_output = "{0} request_id={1}".format(
+            test_log_message, request.id
+        )
+        self.log_capture.check(('scitran.api', 'ERROR', expected_log_output))
+
+    def test_setting_request_error(self):
+        with self.assertRaises(ValueError):
+            api.request.set_current_request(mock.MagicMock())


### PR DESCRIPTION
This adds a custom request object which has additional attributes "id" and "logger".  logger is a LoggerAdapter which adds the request id to each message string.  In the future this can be expanded to include additional per-request context information with each logging call, including extra keys when we log in JSON.  Also added a thread local request context which can be accessed globally via set_current_request and get_current_request

Example output:
```
2016-09-08 11:09:46 scitran.api base.py  105:INFO Initialized request request_id=0935954b-1473350986
```

Fixes: #199, #451 