### PR TITLE
Add logging context for request including request id

### DIFF
--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -3,9 +3,6 @@ Purpose of this module is to define all the permissions checker decorators for t
 """
 
 from . import _get_access, INTEGER_ROLES
-from .. import config
-
-log = config.log
 
 
 def default_container(handler, container=None, target_parent_container=None):

--- a/api/auth/userauth.py
+++ b/api/auth/userauth.py
@@ -1,8 +1,3 @@
-from .. import config
-
-log = config.log
-
-
 def default(handler, user=None):
     def g(exec_op):
         def f(method, _id=None, query=None, payload=None, projection=None):

--- a/api/dao/consistencychecker.py
+++ b/api/dao/consistencychecker.py
@@ -4,8 +4,6 @@ do some verification against the database before allowing the operation"""
 from .. import config
 from . import APIConsistencyException
 
-log = config.log
-
 def noop(*args, **kwargs): # pylint: disable=unused-argument
     pass
 

--- a/api/files.py
+++ b/api/files.py
@@ -10,8 +10,6 @@ from . import util
 from . import config
 from . import tempdir as tempfile
 
-log = config.log
-
 DEFAULT_HASH_ALG='sha384'
 
 def move_file(path, target_path):

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -2,13 +2,10 @@ import datetime
 
 from .. import base
 from .. import util
-from .. import config
 from .. import debuginfo
 from .. import validators
 from ..auth import groupauth
 from ..dao import containerstorage
-
-log = config.log
 
 
 class GroupHandler(base.RequestHandler):

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -22,8 +22,6 @@ from ..dao import hierarchy
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
 
 
-log = config.log
-
 def initialize_list_configurations():
     """
     This configurations are used by the ListHandler class to load the storage, the permissions checker

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -5,7 +5,6 @@ import copy
 from .. import base
 from .. import config
 
-log = config.log
 
 EIGHTEEN_YEARS_IN_SEC = 18 * 365.25 * 24 * 60 * 60
 

--- a/api/handlers/schemahandler.py
+++ b/api/handlers/schemahandler.py
@@ -4,7 +4,6 @@ import json
 from .. import base
 from .. import config
 
-log = config.log
 
 class SchemaHandler(base.RequestHandler):
 

--- a/api/handlers/searchhandler.py
+++ b/api/handlers/searchhandler.py
@@ -6,7 +6,6 @@ from .. import config
 from .. import util
 from ..search import pathparser, queryprocessor, es_query
 
-log = config.log
 
 parent_container_dict = {
     'acquisitions': 'sessions',

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -13,8 +13,6 @@ from .gears import get_gears, get_gear_by_name, remove_gear, upsert_gear
 from .jobs import Job
 from .queue import Queue
 
-log = config.log
-
 
 class GearsHandler(base.RequestHandler):
 

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -10,7 +10,6 @@ from ..dao.containerutil import create_filereference_from_dictionary, create_con
 
 from .. import config
 
-log = config.log
 
 class Job(object):
     def __init__(self, name, inputs, destination=None, tags=None, attempt=1, previous_job_id=None, created=None, modified=None, state='pending', request=None, id_=None, config_=None, now=False):

--- a/api/placer.py
+++ b/api/placer.py
@@ -17,7 +17,6 @@ from .dao import containerutil, hierarchy
 from .jobs import rules
 from .types import Origin
 
-log = config.log
 
 class Placer(object):
     """
@@ -583,4 +582,3 @@ class AnalysisJobPlacer(Placer):
                 # If the original job failed, update the analysis with the job that succeeded
                 u['$set'] = {'job': self.context['job_id']}
             config.db.sessions.update_one(q, u)
-

--- a/api/request.py
+++ b/api/request.py
@@ -1,0 +1,31 @@
+import logging
+import time
+import uuid
+
+from webob.request import Request
+
+from . import config
+
+class SciTranRequest(Request):
+    """Extends webob.request.Request"""
+    def __init__(self, *args, **kwargs):
+        super(SciTranRequest, self).__init__(*args, **kwargs)
+        self.id = "{random_chars}-{timestamp}".format(
+            timestamp = str(int(time.time())),
+            random_chars = str(uuid.uuid4().hex)[:8]
+            )
+        self.logger =  get_request_logger(self.id)
+
+class RequestLoggerAdapter(logging.LoggerAdapter):
+    """A LoggerAdapter to add request_id context"""
+    def process(self, msg, kwargs):
+        context_message =  "{0} request_id={1}".format(
+            msg, self.extra['request_id']
+            )
+        return context_message, kwargs
+
+def get_request_logger(request_id):
+    """Given a request_id, produce a Logger or LoggerAdapter"""
+    extra = {"request_id":request_id}
+    logger = RequestLoggerAdapter(config.log, extra=extra)
+    return logger

--- a/api/root.py
+++ b/api/root.py
@@ -2,9 +2,6 @@ import re
 import markdown
 
 from . import base
-from . import config
-
-log = config.log
 
 class Root(base.RequestHandler):
 

--- a/bin/run-dev-osx.sh
+++ b/bin/run-dev-osx.sh
@@ -133,7 +133,7 @@ if [ "$SCITRAN_RUNTIME_UWSGI_INI" == "" ]; then
         --home "$SCITRAN_RUNTIME_PATH" \
         --wsgi-file "bin/api.wsgi" \
         --py-autoreload $AUTO_RELOAD_INTERVAL \
-        &
+        --logformat '%(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" request_id=%(request_id)' &
     UWSGI_PID=$!
 else
     uwsgi --ini "$SCITRAN_RUNTIME_UWSGI_INI" &

--- a/test/integration_tests/requirements-integration-test.txt
+++ b/test/integration_tests/requirements-integration-test.txt
@@ -7,3 +7,5 @@ pytest-watch==3.8.0
 pytest==2.8.5
 python-dateutil==1.5
 requests==2.9.1
+mock==2.0.0
+testfixtures==4.10.1

--- a/test/unit_tests/python/test_request.py
+++ b/test/unit_tests/python/test_request.py
@@ -1,0 +1,25 @@
+import unittest
+
+import mock
+from testfixtures import LogCapture
+
+import api.request
+
+class TestRequest(unittest.TestCase):
+    def setUp(self):
+        self.log_capture = LogCapture()
+        self.request = api.request.SciTranRequest({})
+
+    def tearDown(self):
+        LogCapture.uninstall_all()
+
+    def test_request_id(self):
+        self.assertEqual(len(self.request.id), 19)
+
+    def test_request_logger_adapter(self):
+        test_log_message = "test log message"
+        self.request.logger.error(test_log_message)
+        expected_log_output = "{0} request_id={1}".format(
+            test_log_message, self.request.id
+        )
+        self.log_capture.check(('scitran.api', 'ERROR', expected_log_output))


### PR DESCRIPTION
This adds a custom request object which has additional attributes "id" and "logger". logger is a LoggerAdapter which adds the request id to each message string. In the future this can be expanded to include additional per-request context information with each logging call, including extra keys when we log in JSON.  Also added a uwsgi log var for request_id so we can use that in our uwsgi logformat allowing us to match a request_id from python log messages to a message in the uwsgi access log.  uwsgi log var is optional so other webservers may be used

Example output:

```
2016-09-08 13:34:04  scitran.api  base.py  104:INFO Initialized request request_id=c88e9c98-1473359644
127.0.0.1 - - [08/Sep/2016:13:34:04 -0500] "GET /api/rules?root=true HTTP/1.1" 200 112 "-" "-" request_id=c88e9c98-1473359644
```

Fixes: #199, #451 