### PR TITLE
Allow analysis files from session to be used as input in other analyses

### DIFF
--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -5,6 +5,7 @@ from ..auth import INTEGER_ROLES
 
 CONT_TYPES = ['acquisition', 'analysis', 'collection', 'group', 'project', 'session']
 
+
 def getPerm(name):
     return INTEGER_ROLES[name]
 
@@ -44,33 +45,35 @@ class ContainerReference(object):
     def __init__(self, type, id):
         if type not in CONT_TYPES:
             raise Exception('Container type must be one of {}'.format(CONT_TYPES))
+        if type == 'analysis':
+            self.__class__ = AnalysisReference
 
         if not isinstance(type, basestring):
             raise Exception('Container type must be of type str')
         if not isinstance(id, basestring):
             raise Exception('Container id must be of type str')
 
-        self.type = type
-        self.id   = id
+        self.type   = type
+        self.id     = id
 
     @classmethod
     def from_dictionary(cls, d):
         return cls(
             type = d['type'],
-            id   = d['id']
+            id = d['id']
         )
 
     @classmethod
     def from_filereference(cls, fr):
         return cls(
             type = fr.type,
-            id   = fr.id
+            id = fr.id
         )
 
     def get(self):
         result = config.db[self.type + 's'].find_one({'_id': bson.ObjectId(self.id)})
         if result is None:
-            raise Exception("No such " + self.type + " " + self.id + " in database")
+            raise Exception('No such {} {} in database'.format(self.type, self.id))
         return result
 
     def find_file(self, filename):
@@ -80,13 +83,34 @@ class ContainerReference(object):
                 return f
         return None
 
+    def file_uri(self, filename):
+        return '/' + self.type + 's/' + self.id + '/files/' + filename
+
     def check_access(self, userID, perm_name):
         perm = getPerm(perm_name)
         for p in self.get()['permissions']:
             if p['_id'] == userID and getPerm(p['access']) > perm:
                 return
 
-        raise Exception("User " + userID + " does not have " + perm_name + " access to " + self.type + " " + self.id)
+        raise Exception('User {} does not have {} access to {} {}'.format(userID, perm_name, self.type, self.id))
+
+class AnalysisReference(ContainerReference):
+    # pylint: disable=redefined-builtin
+    # TODO: refactor to resolve pylint warning
+
+    def get(self):
+        result = config.db.sessions.find_one({'analyses._id': self.id}, {'permissions':1, 'analyses': {'$elemMatch': {'_id': self.id}}})
+        if result is None or result.get('analyses') is None:
+            raise Exception('No such analysis {} in database'.format(self.id))
+        analysis = result['analyses'][0]
+        analysis['permissions'] = result['permissions']
+        analysis['session_id'] = result['_id']
+        return analysis
+
+    def file_uri(self, filename):
+        analysis = self.get()
+        return '/sessions/' + str(analysis['session_id']) + '/analyses/' + self.id + '/files/' + filename
+
 
 class FileReference(ContainerReference):
     # pylint: disable=redefined-builtin
@@ -100,9 +124,10 @@ class FileReference(ContainerReference):
     def from_dictionary(cls, d):
         return cls(
             type = d['type'],
-            id   = d['id'],
+            id = d['id'],
             name = d['name']
         )
+
 
 def create_filereference_from_dictionary(d):
     return FileReference.from_dictionary(d)

--- a/api/dao/liststorage.py
+++ b/api/dao/liststorage.py
@@ -254,7 +254,7 @@ class AnalysesStorage(ListStorage):
             if next_job is None:
                 break
             job = Job.load(next_job)
-        if job.id_ != analysis['job']:
+        if job.id_ != str(analysis['job']):
             # Update analysis if job has changed
             # Remove old inputs and replace with new job inputs
             # (In practice these should never change)

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -709,6 +709,7 @@ class AnalysesHandler(ListHandler):
             contref = create_containerreference_from_filereference(fileref)
             file_ = contref.find_file(fileref.name)
             if file_:
+                file_.pop('output', None) # If file was from an analysis
                 file_['input'] = True
                 files.append(file_)
         analysis['files'] = files

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -214,7 +214,7 @@ class Job(object):
 
             r['inputs'].append({
                 'type': 'scitran',
-                'uri': '/' + i.type + 's/' + i.id + '/files/' + i.name,
+                'uri': i.file_uri(i.name),
                 'location': '/flywheel/v0/input/' + input_name,
             })
 


### PR DESCRIPTION
Only supported for session level analyses. Gear-based analyses are also (currently) only allowed at the session level so this doesn't restrict actions any further than they already are.

How the analyses are created hasn't change, for an example (using an analysis level file):

```
POST /api/sessions/57d1f3cbd73ca10011ff0ee5/analyses?job=true HTTP/1.1
Content-Type: application/json

{
    "analysis": {
        "label": "Megan Analysis 1"
    },
    "job" : {
        "gear": "gear-name",
        "inputs": {
            "not-a-dicom": {
                "type": "analysis",
                "id": "57d1fb632ab3a500241cbe78",
                "name" : "8892_1_1_localizer_montage.zip"
            }
        },
        "tags": ["analysis"]
    }
}
```