### PR TITLE
Gear config followup - Add Analysis File Suggestion

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -23,8 +23,24 @@ class ContainerStorage(object):
         self.use_object_id = use_object_id
         self.dbc = config.db[cont_name]
 
-    def get_container(self, _id):
-        return self._get_el(_id)
+    def get_container(self, _id, projection=None, get_children=False):
+        cont = self._get_el(_id, projection)
+
+        if get_children:
+            # TODO: This needs to exist in one place, not several
+            child_map = {
+                'groups':   'projects',
+                'projects': 'sessions',
+                'sessions': 'acquisitions'
+            }
+
+            child_name = child_map.get(self.cont_name)
+            if not child_name:
+                raise ValueError('Children can only be listed from group, project or session level')
+            else:
+                query = {cont_name: _id}
+                ContainerStorage(child_name, True)._get_all_el(query, projection)
+
 
     def exec_op(self, action, _id=None, payload=None, query=None, user=None,
                 public=False, projection=None, recursive=False, r_payload=None,  # pylint: disable=unused-argument

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -72,18 +72,18 @@ def get_container(cont_name, _id):
         '_id': _id,
     })
 
-def get_children(cont_name, _id):
+def get_children(cont_name, _id, projection=None):
     """
     Given a container name and id, return all children of that object in the hierarchy
     """
     cid = bson.ObjectId(_id)
     if cont_name == 'session':
-        return config.db.acquisitions.find({'session': cid})
+        return config.db.acquisitions.find({'session': cid}, projection)
     elif cont_name == 'project':
-        return config.db.sessions.find({'project': cid})
+        return config.db.sessions.find({'project': cid}, projection)
     elif cont_name == 'group':
         # groups do not use ObjectIds
-        return config.db.projects.find({'group':_id})
+        return config.db.projects.find({'group':_id}, projection)
     else:
         raise ValueError('Children can only be listed from group, project or session level')
 

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -72,21 +72,6 @@ def get_container(cont_name, _id):
         '_id': _id,
     })
 
-def get_children(cont_name, _id, projection=None):
-    """
-    Given a container name and id, return all children of that object in the hierarchy
-    """
-    cid = bson.ObjectId(_id)
-    if cont_name == 'session':
-        return config.db.acquisitions.find({'session': cid}, projection)
-    elif cont_name == 'project':
-        return config.db.sessions.find({'project': cid}, projection)
-    elif cont_name == 'group':
-        # groups do not use ObjectIds
-        return config.db.projects.find({'group':_id}, projection)
-    else:
-        raise ValueError('Children can only be listed from group, project or session level')
-
 def propagate_changes(cont_name, _id, query, update):
     """
     Propagates changes down the heirarchy tree.

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -8,7 +8,7 @@ import gear_tools
 
 from .. import config
 from .jobs import Job
-from ..dao.containerstorage import inflate_container
+from ..dao.containerstorage import ContainerStorage
 
 log = config.log
 
@@ -57,12 +57,12 @@ def get_gear_by_name(name):
 def get_invocation_schema(gear):
     return gear_tools.derive_invocation_schema(gear['manifest'])
 
-def suggest_container(gear, cr):
+def suggest_container(gear, cont_name, cid):
     """
     Given a container reference, suggest files that would work well for each input on a gear.
     """
 
-    root = inflate_container(cr)
+    root = ContainerStorage(cont_name, True).get_container(cid, projection={'permissions':0}, get_children=True)
     invocation_schema = get_invocation_schema(gear)
 
     schemas = {}

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -71,11 +71,20 @@ def suggest_container(gear, cont_name, cid):
         schemas[x] = Draft4Validator(schema)
 
     # It would be nice to have use a visitor here instead of manual key loops.
-    for acq in root['acquisitions']:
+    for acq in root.get('acquisitions', []):
         for f in acq.get('files', []):
             f['suggested'] = {}
             for x in schemas:
                 f['suggested'][x] = schemas[x].is_valid(f)
+
+    for analysis in root.get('analyses',{}):
+        files = analysis.get('files', [])
+        files[:] = [x for x in files if x.get('output')]
+        for f in files:
+            f['suggested'] = {}
+            for x in schemas:
+                f['suggested'][x] = schemas[x].is_valid(f)
+        analysis['files'] = files
 
     return root
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -61,7 +61,7 @@ class GearHandler(base.RequestHandler):
             cr.check_access(self.uid, 'ro')
 
         gear = get_gear_by_name(_id)
-        return suggest_container(gear, cr)
+        return suggest_container(gear, cont_name+'s', cid)
 
     def post(self, _id):
         """Upsert an entire gear document."""


### PR DESCRIPTION
`api/gears/<gear-id>/suggest/session/<session-id>` will now also return analyses with suggestion blocks in the file objects. This is the union of #483 and #488.

If we only want to return analyses file suggestions for certain gear categories, that can be accommodated. Returning for all gears currently. @lmperry, would a there be a usecase for running non-analyses gears on analysis output?


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
