### PR TITLE
Update run-tests-docker.sh with optional linter and -b flag

### DIFF
--- a/test/bin/lint.sh
+++ b/test/bin/lint.sh
@@ -5,11 +5,17 @@ set -eu
 unset CDPATH
 cd "$( dirname "${BASH_SOURCE[0]}" )/../.."
 
+echo "Checking for files with DOS encoding:"
+(! git ls-files | xargs file | grep -I "with CRLF line terminators")
+
+echo "Checking for files with windows-style newlines:"
+(! git ls-files | xargs grep -I $'\r')
+
 echo "Running pylint ..."
 # TODO: Enable Refactor and Convention reports
-pylint --reports=no --disable=C,R "$@"
+pylint --reports=no --disable=C,R api
 
 #echo
 #
 #echo "Running pep8 ..."
-#pep8 --max-line-length=150 --ignore=E402 "$@"
+#pep8 --max-line-length=150 --ignore=E402 api

--- a/test/bin/run-tests-docker.sh
+++ b/test/bin/run-tests-docker.sh
@@ -57,7 +57,7 @@ clean_up () {
 trap clean_up EXIT
 
 if [[ $( docker images "$IMAGE_NAME_SCITRAN_CORE" | tail -n +2 ) == "" ]]; then
-  echo "scitran-core image not found.  Building"
+  echo "$IMAGE_NAME_SCITRAN_CORE image not found.  Building"
   BUILD_IMAGE="true"
 fi
 

--- a/test/bin/run-tests-docker.sh
+++ b/test/bin/run-tests-docker.sh
@@ -4,34 +4,80 @@ set -e
 unset CDPATH
 cd "$( dirname "${BASH_SOURCE[0]}" )/../.."
 
-IMAGE_NAME_SCITRAN_CORE=scitran-core
+IMAGE_NAME_SCITRAN_CORE="scitran-core:run-tests"
 IMAGE_NAME_MONGO=mongo
-CONTAINER_NAME_MONGO=some-mongo
+CONTAINER_NAME_MONGO=scitran-core-test-mongo
+CONTAINER_NAME_SCITRAN_CORE=scitran-core-test-uwsgi
+
+
+USAGE="
+    Run scitran-core tests using docker
+\n
+    Usage:\n
+    \n
+    --help: print help and exit\n
+    -b, --build-image: Rebuild scitran-core base image\n
+    -L, --no-lint: Skip linter\n
+
+"
+
+SCITRAN_RUN_LINT="true"
+BUILD_IMAGE="false"
+
+while [ "$#" -gt 0 ]; do
+    key="$1"
+    case $key in
+        --help)
+        echo -e $USAGE >&2
+        exit 1
+        ;;
+        -b|--build-image)
+        BUILD_IMAGE="true"
+        ;;
+        -L|--no-lint)
+        SCITRAN_RUN_LINT="false"
+        ;;
+        *)
+        echo "Invalid option: $key" >&2
+        echo -e $USAGE >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
+
 
 clean_up () {
-  # Stop and remove mongo container
+  # Copy coverage file to host for possible further reporting
+  docker cp "$CONTAINER_NAME_SCITRAN_CORE":/var/scitran/code/api/.coverage .coverage || true
+  # Stop and remove containers
   docker rm -v -f "$CONTAINER_NAME_MONGO"
+  docker rm -v -f "$CONTAINER_NAME_SCITRAN_CORE"
 }
 trap clean_up EXIT
 
+if [[ $( docker images "$IMAGE_NAME_SCITRAN_CORE" | tail -n +2 ) == "" ]]; then
+  echo "scitran-core image not found.  Building"
+  BUILD_IMAGE="true"
+fi
+
+if [ "$BUILD_IMAGE" == "true" ]; then
+  docker build -t "$IMAGE_NAME_SCITRAN_CORE" .
+fi
 
 # Sub-shell the test steps to make the functionality of the trap execution explicit
 (
-# Build the docker image
-docker build -t "$IMAGE_NAME_SCITRAN_CORE" .
-
 # Launch Mongo isinstance
 docker run --name "$CONTAINER_NAME_MONGO" -d "$IMAGE_NAME_MONGO"
 
 # Execute tests
 docker run \
-  --rm \
-  --name scitran-core-tester \
+  --name "$CONTAINER_NAME_SCITRAN_CORE"\
   -e "SCITRAN_PERSISTENT_DB_URI=mongodb://$CONTAINER_NAME_MONGO:27017/scitran" \
+  -e "SCITRAN_RUN_LINT=$SCITRAN_RUN_LINT" \
   --link "$CONTAINER_NAME_MONGO" \
   -v $(pwd):/var/scitran/code/api \
   --entrypoint bash \
   "$IMAGE_NAME_SCITRAN_CORE" \
     /var/scitran/code/api/test/bin/run-tests-ubuntu.sh
-
 )

--- a/test/bin/run-tests-ubuntu.sh
+++ b/test/bin/run-tests-ubuntu.sh
@@ -4,7 +4,11 @@ set -e
 unset CDPATH
 cd "$( dirname "${BASH_SOURCE[0]}" )/../.."
 
-./test/bin/lint.sh api
+SCITRAN_RUN_LINT=${SCITRAN_RUN_LINT:-"true"}
+
+if [ "$SCITRAN_RUN_LINT" == "true" ]; then
+    ./test/bin/lint.sh api
+fi
 
 ./test/bin/run-unit-tests.sh
 

--- a/test/bin/run-unit-tests.sh
+++ b/test/bin/run-unit-tests.sh
@@ -3,14 +3,6 @@ set -e
 unset CDPATH
 cd "$( dirname "${BASH_SOURCE[0]}" )/../.."
 
-echo "Checking for files with DOS encoding:"
-! find * -path "runtime" -prune -o -path "persistent" -prune -o \
-  -type f -exec file {} \; | grep -I "with CRLF line terminators"
-
-echo "Checking for files with windows style newline:"
-! find * -path "runtime" -prune -o -path "persistent" -prune -o -type f \
-  -exec grep -rI $'\r' {} \+
-
 # Remove __pycache__ directory for issue with __file__ attribute
 # Due to running the tests on the host creating bytecode files
 # Which have a mismatched __file__ attribute when loaded in docker container

--- a/test/bin/setup-integration-tests-ubuntu.sh
+++ b/test/bin/setup-integration-tests-ubuntu.sh
@@ -5,19 +5,12 @@ cd "$( dirname "${BASH_SOURCE[0]}" )/../.."
 
 pip install -U -r "test/integration_tests/requirements-integration-test.txt"
 
-
-node_source_dir=`mktemp -d`
-curl https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x64.tar.gz | tar xz -C "$node_source_dir"
+NODE_URL="https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x64.tar.gz"
 
 if [ -z "$VIRTUAL_ENV" ]; then
-    sudo mv $node_source_dir/node-v6.4.0-linux-x64/bin/* /usr/local/bin
-    sudo mv $node_source_dir/node-v6.4.0-linux-x64/lib/* /usr/local/lib
-    sudo npm install -g git+https://github.com/flywheel-io/abao.git#better-jsonschema-ref
+    curl $NODE_URL | sudo tar xz -C /usr/local --strip-components 1
     sudo npm install -g test/integration_tests
 else
-    mv $node_source_dir/node-v6.4.0-linux-x64/bin/* "$VIRTUAL_ENV/bin"
-    mv $node_source_dir/node-v6.4.0-linux-x64/lib/* "$VIRTUAL_ENV/lib"
-    rm -rf "$node_source_dir"
-    npm config set prefix "$VIRTUAL_ENV"
+    curl $NODE_URL | tar xz -C $VIRTUAL_ENV --strip-components 1
     npm install -g test/integration_tests
 fi


### PR DESCRIPTION
Update run-tests-docker.sh with optional linter (-L) and image build (-b) flags

Also updates the npm install for integration tests to be more efficient

Relates to #493 but does not duplicate setup-integration-tests-ubuntu.sh into Dockerfile for caching purposes

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md

