### PR TITLE
Fix nodejs install for install-dev-osx.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 /runtime
 bootstrap.json
 .cache
-.coverage
+.coverage*
 coverage.xml

--- a/bin/install-dev-osx.sh
+++ b/bin/install-dev-osx.sh
@@ -78,9 +78,13 @@ fi
 
 # Install Node.js
 if [ ! -f "$SCITRAN_RUNTIME_PATH/bin/node" ]; then
-    echo "Installing Node.js"
+    echo "Installing nodejs"
     NODE_URL="https://nodejs.org/dist/v6.4.0/node-v6.4.0-darwin-x64.tar.gz"
-    curl $NODE_URL | tar xz -C $VIRTUAL_ENV --strip-components 1
+    node_source_dir=`mktemp -d`
+    curl "$NODE_URL" | tar xz -C "$node_source_dir"
+    mv $node_source_dir/node-v6.4.0-darwin-x64/bin/* "$SCITRAN_RUNTIME_PATH/bin"
+    mv $node_source_dir/node-v6.4.0-darwin-x64/lib/* "$SCITRAN_RUNTIME_PATH/lib"
+    rm -rf "$node_source_dir"
 fi
 
 


### PR DESCRIPTION
Sending the npm tarball directly to tar and using --strip-components causes npm to not be properly installed.  This means the test dependencies are installed using the system npm, polluting the systems node_modules.  Not sure why tar doesn't work, possibly due to symlink.  Reverting to temporary directory method with this PR.


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md

