### PR TITLE
Add stats endpoint for colls/projs

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -125,7 +125,6 @@ class ContainerStorage(object):
         result = self.dbc.find(query, projection)
         return list(result)
 
-
 class GroupStorage(ContainerStorage):
 
     def _create_el(self, payload):

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -117,17 +117,6 @@ class CollectionsHandler(ContainerHandler):
                 result = containerutil.get_stats(result, 'collections')
         return results
 
-    def _add_results_counts(self, results):
-        session_counts = config.db.acquisitions.aggregate([
-            {'$match': {'collections': {'$in': [collection['_id'] for collection in results]}}},
-            {'$unwind': "$collections"},
-            {'$group': {'_id': "$collections", 'sessions': {'$addToSet': "$session"}}}
-            ])
-        session_counts = {coll['_id']: len(coll['sessions']) for coll in session_counts}
-        for coll in results:
-            coll['session_count'] = session_counts.get(coll['_id'], 0)
-
-
     def curators(self):
         curator_ids = list(set((c['curator'] for c in self.get_all('collections'))))
         return list(config.db.users.find({'_id': {'$in': curator_ids}}, ['firstname', 'lastname']))

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -3,7 +3,7 @@ import datetime
 
 from .. import config
 from ..auth import containerauth, always_ok
-from ..dao import containerstorage
+from ..dao import containerstorage, containerutil
 from ..dao import APIStorageException
 
 from .containerhandler import ContainerHandler
@@ -112,8 +112,9 @@ class CollectionsHandler(ContainerHandler):
         if results is None:
             self.abort(404, 'Element not found in collection {}'.format(self.storage.cont_name))
         self._filter_all_permissions(results, self.uid, self.user_site)
-        if self.is_true('counts'):
-            self._add_results_counts(results)
+        for result in results:
+            if self.is_true('stats'):
+                result = containerutil.get_stats(result, 'collections')
         return results
 
     def _add_results_counts(self, results):

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -301,6 +301,8 @@ class ContainerHandler(base.RequestHandler):
             result = self.handle_origin(result)
             if cont_name == 'sessions':
                 result = self.handle_analyses(result)
+            if self.is_true('stats'):
+                result = containerutil.get_stats(result, cont_name)
 
         return results
 


### PR DESCRIPTION
`api/projects` and `api/collections`, when called with the query param `stats=true` will add 3 new fields to each object in the response:
`session_count`
`subject_count`
`attachment_count`


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md

