### PR TITLE
Adapt to new gears package naming

### DIFF
--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -11,7 +11,7 @@ from ..dao.containerutil import create_filereference_from_dictionary, create_con
 from ..dao.liststorage import AnalysesStorage
 from .jobs import Job
 from .queue import Queue
-from . import gears
+from . import gear_helpers
 
 log = config.log
 
@@ -67,7 +67,7 @@ def find_matching_conts(gear, containers, container_type):
     for c in containers:
         files = c.get('files')
         if files:
-            suggestions = gears.suggest_for_files(gear, files)
+            suggestions = gear_helpers.suggest_for_files(gear, files)
 
             # Determine if any of the inputs are ambiguous or not satisfied
             ambiguous = False # Are any of the inputs ambiguous?
@@ -135,7 +135,7 @@ def run(batch_job):
         raise APIStorageException('The batch job is not formatted correctly.')
     proposed_inputs = proposal.get('inputs', [])
     gear_name = batch_job.get('gear')
-    gear = gears.get_gear_by_name(gear_name)
+    gear = gear_helpers.get_gear_by_name(gear_name)
     config_ = batch_job.get('config')
     origin = batch_job.get('origin')
     tags = proposal.get('tags', [])

--- a/api/jobs/gear_helpers.py
+++ b/api/jobs/gear_helpers.py
@@ -1,10 +1,10 @@
 """
-Gears
+Gear Helpers
 """
 
 # import jsonschema
 from jsonschema import Draft4Validator, ValidationError
-import gear_tools
+import gears
 
 from .. import config
 from .jobs import Job
@@ -41,7 +41,7 @@ def get_gear_by_name(name):
     return gear_doc
 
 def get_invocation_schema(gear):
-    return gear_tools.derive_invocation_schema(gear['gear'])
+    return gears.derive_invocation_schema(gear['gear'])
 
 def suggest_container(gear, cont_name, cid):
     """
@@ -53,7 +53,7 @@ def suggest_container(gear, cont_name, cid):
 
     schemas = {}
     for x in gear['gear']['inputs']:
-        schema = gear_tools.isolate_file_invocation(invocation_schema, x)
+        schema = gears.isolate_file_invocation(invocation_schema, x)
         schemas[x] = Draft4Validator(schema)
 
     # It would be nice to have use a visitor here instead of manual key loops.
@@ -79,7 +79,7 @@ def suggest_for_files(gear, files):
     invocation_schema = get_invocation_schema(gear)
     schemas = {}
     for x in gear['gear']['inputs']:
-        schema = gear_tools.isolate_file_invocation(invocation_schema, x)
+        schema = gears.isolate_file_invocation(invocation_schema, x)
         schemas[x] = Draft4Validator(schema)
 
     suggested_files = {}
@@ -94,8 +94,8 @@ def suggest_for_files(gear, files):
 
 def validate_gear_config(gear, config_):
     if len(gear.get('manifest', {}).get('config', {})) > 0:
-        invocation = gear_tools.derive_invocation_schema(gear['manifest'])
-        ci = gear_tools.isolate_config_invocation(invocation)
+        invocation = gears.derive_invocation_schema(gear['manifest'])
+        ci = gears.isolate_config_invocation(invocation)
         validator = Draft4Validator(ci)
 
         try:
@@ -113,7 +113,7 @@ def validate_gear_config(gear, config_):
     return True
 
 def insert_gear(doc):
-    gear_tools.validate_manifest(doc['gear'])
+    gears.validate_manifest(doc['gear'])
 
     # This can be mongo-escaped and re-used later
     if doc.get("invocation-schema"):
@@ -146,7 +146,7 @@ def remove_gear(name):
     config.db.gears.remove({'gear.name': name})
 
 def upsert_gear(doc):
-    gear_tools.validate_manifest(doc['gear'])
+    gears.validate_manifest(doc['gear'])
 
     remove_gear(doc['gear']['name'])
     insert_gear(doc)

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -14,7 +14,7 @@ from ..web import base
 from .. import config
 from . import batch
 
-from .gears import validate_gear_config, get_gears, get_gear_by_name, get_invocation_schema, remove_gear, upsert_gear, suggest_container
+from .gear_helpers import validate_gear_config, get_gears, get_gear_by_name, get_invocation_schema, remove_gear, upsert_gear, suggest_container
 from .jobs import Job
 from .queue import Queue
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -9,7 +9,7 @@ import datetime
 
 from .. import config
 from .jobs import Job
-from .gears import get_gear_by_name
+from .gear_helpers import get_gear_by_name
 
 log = config.log
 

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -3,7 +3,7 @@ import fnmatch
 from .. import config
 from ..dao.containerutil import FileReference
 
-from . import gears
+from . import gear_helpers
 from .jobs import Job
 
 log = config.log
@@ -111,7 +111,7 @@ def queue_job_legacy(algorithm_id, input_):
     Takes a single FileReference instead of a map.
     """
 
-    gear = gears.get_gear_by_name(algorithm_id)
+    gear = gear_helpers.get_gear_by_name(algorithm_id)
 
     if len(gear['gear']['inputs']) != 1:
         raise Exception("Legacy gear enqueue attempt of " + algorithm_id + " failed: must have exactly 1 input in manifest")

--- a/bin/database.py
+++ b/bin/database.py
@@ -11,7 +11,7 @@ import sys
 from api import config
 from api.dao import containerutil
 from api.jobs.jobs import Job
-from api.jobs import gears
+from api.jobs import gear_helpers
 from api.types import Origin
 
 CURRENT_DATABASE_VERSION = 21 # An int that is bumped when a new schema change is made
@@ -497,7 +497,7 @@ def upgrade_to_18():
         gear_list = gear_doc.get('gear_list', [])
         for gear in gear_list:
             try:
-                gears.upsert_gear(gear)
+                gear_helpers.upsert_gear(gear)
             except Exception as e:
                 logging.error("")
                 logging.error("Error upgrading gear:")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ strict-rfc3339==0.7
 uwsgi==2.0.13.1
 webapp2==2.5.2
 WebOb==1.5.1
--e git://github.com/flywheel-io/gears.git@15556fef7dc98afd702595d47537346dbc8a7373#egg=gear_tools
+git+https://github.com/flywheel-io/gears.git@restructuring

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ strict-rfc3339==0.7
 uwsgi==2.0.13.1
 webapp2==2.5.2
 WebOb==1.5.1
-git+https://github.com/flywheel-io/gears.git@restructuring
+git+https://github.com/flywheel-io/gears.git@08aa428f681e42e0193a06fc6fc85fc82991e80c


### PR DESCRIPTION
I [renamed](https://github.com/flywheel-io/gears/pull/6) the flywheel/gears Python package from `gear_tools` to `gears`. This PR deals with the resulting name collision here. No functional change.

https://github.com/flywheel-io/gears/pull/6 needs to land first, and then `requirements.txt` needs to be updated before merging this.
### Review Checklist
- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
