### PR TITLE
Add multi-file-gear rule matching

### DIFF
--- a/api/placer.py
+++ b/api/placer.py
@@ -90,7 +90,7 @@ class Placer(object):
 
         # Update the DB
         if info is not None:
-            hierarchy.upsert_fileinfo(self.container_type, self.id_, info)
+            self.container = hierarchy.upsert_fileinfo(self.container_type, self.id_, info)
 
             # Queue any jobs as a result of this upload
             rules.create_jobs(config.db, self.container, self.container_type, info)


### PR DESCRIPTION
This small change to gear rules allows a gear to have multiple files automatically selected by type. To use this feature, simply add a `match` key to the rule mapping gear input name to file type:

```json
"match": {
	"bval": "bval",
	"bvec": "bvec",
	"diffusion": "nifti"
}
```
