### PR TITLE
Don't read metadata form field as file

### DIFF
--- a/api/upload.py
+++ b/api/upload.py
@@ -86,7 +86,9 @@ def process_upload(request, strategy, container_type=None, id_=None, origin=None
     # Browsers, when sending a multipart upload, will send files with field name "file" (if sinuglar)
     # or "file1", "file2", etc (if multiple). Following this convention is probably a good idea.
     # Here, we accept any
-    file_fields = [x for x in form if form[x].filename is not None]
+
+    # Non-file form fields may have an empty string as filename, check for 'falsy' values
+    file_fields = [x for x in form if form[x].filename]
 
     # TODO: Change schemas to enabled targeted uploads of more than one file.
     # Ref docs from placer.TargetedPlacer for details.


### PR DESCRIPTION
Something in the cgi form field logic changed and non-file form fields were given `''` as filenames instead of `None`, which caused failures when `metadata` is sent when uploading. 

🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md

