### PR TITLE
Add MGH data type

### DIFF
--- a/api/filetypes.json
+++ b/api/filetypes.json
@@ -5,6 +5,7 @@
     "parrec":       [ ".parrec.zip", ".par-rec.zip" ],
     "gephysio":     [ ".gephysio.zip" ],
     "MATLAB data":  [ ".mat" ],
+    "MGH data":     [ ".mgh", ".mgz", ".mgh.gz" ],
     "nifti":        [ ".nii.gz", ".nii" ],
     "pfile":        [ ".7.gz", ".7" ],
     "PsychoPy data":  [ ".psydat" ],


### PR DESCRIPTION
This adds the filetype association for MGH data.

https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat