### PR TITLE
Load build info into db with dockerized version

### DIFF
--- a/docker/build-info-load.py
+++ b/docker/build-info-load.py
@@ -1,0 +1,12 @@
+"""
+Loads the build info into the version document in the database.
+"""
+import json
+import os
+import pymongo
+db_uri = os.getenv('SCITRAN_PERSISTENT_DB_URI')
+db = pymongo.MongoClient(db_uri).get_default_database()
+
+with open('/version.json') as f:
+    build = json.load(f)
+db.singletons.find_one_and_update({"_id": "version"}, {'$set' : {'build' : build}})

--- a/docker/uwsgi-entrypoint.sh
+++ b/docker/uwsgi-entrypoint.sh
@@ -39,6 +39,7 @@ fi
 
 if [ "$1" = 'uwsgi' ]; then
 
+	python /var/scitran/code/api/docker/build-info-load.py
 	exec gosu ${RUNAS_USER} "$@"
 fi
 


### PR DESCRIPTION
Example resolution of #639 

@nagem Let's discuss this approach of loading build info into the DB vs. doing something where the code serves this same info directly. The disadvantage to persisting this in the database, is that it can be possible for it to be out of sync with the code serving it.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
