### PR TITLE
allow the info field to be null in a request

### DIFF
--- a/raml/schemas/definitions/container.json
+++ b/raml/schemas/definitions/container.json
@@ -6,7 +6,7 @@
         "public":       {"type": "boolean"},
         "archived":     {"type": "boolean"},
         "label":        {"type": "string", "minLength": 1, "maxLength": 256},
-        "info":     {"type": "object"},
+        "info":     {"type": ["object", "null"]},
         "uid":          {"type":"string"},
         "timestamp":    {"type": ["string", "null"], "format": "date-time"},
         "timezone":     {"type": "string"}

--- a/raml/schemas/mongo/container.json
+++ b/raml/schemas/mongo/container.json
@@ -12,6 +12,6 @@
         "archived":     {"type": "boolean"},
         "label":        {"type": "string"},
         "tags":         {"type": "array", "items": {"type": "string"}},
-        "info":         {"type": "object"}
+        "info":         {"type": ["object", "null"]}
     }
 }


### PR DESCRIPTION
with this change it is possible to delete the info field completely

@nagem @gsfr was there a reason not to allow this?
