### PR TITLE
Tolerate invalid gear data during v22 upgrade

### DIFF
--- a/api/dao/liststorage.py
+++ b/api/dao/liststorage.py
@@ -292,7 +292,7 @@ class AnalysesStorage(ListStorage):
 
         # Config manifest check
         gear = get_gear(gear_id)
-        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+        if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             raise APIConflictException('Gear marked as invalid, will not run!')
         validate_gear_config(gear, job.get('config'))
 

--- a/api/dao/liststorage.py
+++ b/api/dao/liststorage.py
@@ -8,6 +8,7 @@ from . import APIStorageException, APIConflictException
 from .containerstorage import SessionStorage, AcquisitionStorage
 from .containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
 from ..jobs.jobs import Job
+from ..jobs.gears import validate_gear_config, get_gear
 
 log = config.log
 
@@ -288,6 +289,12 @@ class AnalysesStorage(ListStorage):
             tags.append('analysis')
 
         gear_id = job['gear_id']
+
+        # Config manifest check
+        gear = get_gear(gear_id)
+        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+            raise APIConflictException('Gear marked as invalid, will not run!')
+        validate_gear_config(gear, job.get('config'))
 
         destination = create_containerreference_from_dictionary({'type': 'analysis', 'id': analysis['_id']})
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -165,7 +165,7 @@ class JobsHandler(base.RequestHandler):
 
         # Config manifest check
         gear = get_gear(gear_id)
-        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+        if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             self.abort(400, 'Gear marked as invalid, will not run!')
         validate_gear_config(gear, config_)
 
@@ -314,7 +314,7 @@ class BatchHandler(base.RequestHandler):
         if not gear_id or not targets:
             self.abort(400, 'A gear name and list of target containers is required.')
         gear = get_gear(gear_id)
-        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+        if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             self.abort(400, 'Gear marked as invalid, will not run!')
         validate_gear_config(gear, config_)
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -165,6 +165,8 @@ class JobsHandler(base.RequestHandler):
 
         # Config manifest check
         gear = get_gear(gear_id)
+        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+            self.abort(400, 'Gear marked as invalid, will not run!')
         validate_gear_config(gear, config_)
 
         job = Job(gear_id, inputs, destination=destination, tags=tags, config_=config_, now=now_flag, attempt=attempt_n, previous_job_id=previous_job_id, origin=self.origin)
@@ -312,6 +314,8 @@ class BatchHandler(base.RequestHandler):
         if not gear_id or not targets:
             self.abort(400, 'A gear name and list of target containers is required.')
         gear = get_gear(gear_id)
+        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+            self.abort(400, 'Gear marked as invalid, will not run!')
         validate_gear_config(gear, config_)
 
         container_ids = []

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -187,6 +187,11 @@ class Job(object):
         return d
 
     def insert(self):
+        """
+        Warning: this will not stop you from inserting a job for a gear that has gear.custom.flywheel.invald set to true.
+
+        """
+
         if self.id_ is not None:
             raise Exception('Cannot insert job that has already been inserted')
 
@@ -211,6 +216,9 @@ class Job(object):
         gear: map
             A gear_list map from the gears table.
         """
+
+        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+            raise Exception('Gear marked as invalid, will not run!')
 
         r = {
             'inputs': [

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -217,7 +217,7 @@ class Job(object):
             A gear_list map from the gears table.
         """
 
-        if gear.get('custom', {}).get('flywheel', {}).get('invalid', False):
+        if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             raise Exception('Gear marked as invalid, will not run!')
 
         r = {

--- a/bin/database.py
+++ b/bin/database.py
@@ -772,7 +772,7 @@ def upgrade_to_22():
 
         upgraded += 1
         if upgraded % 1000 == 0:
-            logging.info('  Processed ' + str(upgraded) + ' jobs of ' + str(maximum) + '...')
+            logging.info('  Processed ' + str(upgraded) + ' batch of ' + str(maximum) + '...')
 
 
     logging.info('Upgrade v22, complete.')


### PR DESCRIPTION
This will allow the database to proceed with invalid job records, creating empty gear documents when no such referenced document exists. The empty gears have `custom.flywheel.invalid` set to true, and will be disallowed from entering into the jobs queue.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
