### PR TITLE
Wechat update

### DIFF
--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -245,9 +245,9 @@ class WechatOAuthProvider(AuthProvider):
         else:
             user = config.db.users.find_one({'wechat.openid': openid})
         if not user:
-            raise APIUnknownUserException('User {} will need to be added to the system before managing data.'.format(uid))
+            raise APIUnknownUserException('User {} will need to be added to the system before managing data.'.format(user['_id']))
         if user.get('disabled', False) is True:
-            raise APIUnknownUserException('User {} is disabled.'.format(uid))
+            raise APIUnknownUserException('User {} is disabled.'.format(user['_id']))
 
         return user['_id']
 

--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -42,9 +42,9 @@ class AuthProvider(object):
     def ensure_user_exists(self, uid):
         user = config.db.users.find_one({'_id': uid})
         if not user:
-            raise APIUnknownUserException('User {} does not exist.'.format(uid))
+            raise APIUnknownUserException('User {} will need to be added to the system before managing data.'.format(uid))
         if user.get('disabled', False) is True:
-            raise APIUnknownUserException('User {} is disabled'.format(uid))
+            raise APIUnknownUserException('User {} is disabled.'.format(uid))
 
     def set_user_gravatar(self, uid, email):
         if email and uid:
@@ -220,11 +220,11 @@ class WechatOAuthProvider(AuthProvider):
         if registration_code:
             user = config.db.users.find_one({'wechat.registration_code': registration_code})
             if user is None:
-                raise APIUnknownUserException('Invalid or expired registration code.')
+                raise APIUnknownUserException('Invalid or expired registration link.')
 
             # Check to make sure there is not already a user with this wechat openid:
             if config.db.users.find({'wechat.openid': openid}).count() > 0:
-                raise APIUnknownUserException('User already registred with this Wechat OpenID.')
+                raise APIUnknownUserException('Another user is already registred with this Wechat OpenID.')
             update = {
                 '$set': {
                     'wechat.openid': openid
@@ -237,9 +237,9 @@ class WechatOAuthProvider(AuthProvider):
         else:
             user = config.db.users.find_one({'wechat.openid': openid})
         if not user:
-            raise APIUnknownUserException('User not registered.')
+            raise APIUnknownUserException('User {} will need to be added to the system before managing data.'.format(uid))
         if user.get('disabled', False) is True:
-            raise APIUnknownUserException('User {} is disabled'.format(user['_id']))
+            raise APIUnknownUserException('User {} is disabled.'.format(uid))
 
         return user['_id']
 

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -87,9 +87,9 @@ class RequestHandler(webapp2.RequestHandler):
         else:
             user = config.db.users.find_one({'_id': self.uid}, ['root', 'disabled'])
             if not user:
-                self.abort(402, 'user ' + self.uid + ' does not exist')
+                raise APIUnknownUserException('User {} will need to be added to the system before managing data.'.format(uid))
             if user.get('disabled', False) is True:
-                self.abort(402, 'user account ' + self.uid + ' is disabled')
+                raise APIUnknownUserException('User {} is disabled.'.format(uid))
             if user.get('root'):
                 self.user_is_admin = True
             else:

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -87,9 +87,9 @@ class RequestHandler(webapp2.RequestHandler):
         else:
             user = config.db.users.find_one({'_id': self.uid}, ['root', 'disabled'])
             if not user:
-                raise APIUnknownUserException('User {} will need to be added to the system before managing data.'.format(uid))
+                raise APIUnknownUserException('User {} will need to be added to the system before managing data.'.format(self.uid))
             if user.get('disabled', False) is True:
-                raise APIUnknownUserException('User {} is disabled.'.format(uid))
+                raise APIUnknownUserException('User {} is disabled.'.format(self.uid))
             if user.get('root'):
                 self.user_is_admin = True
             else:


### PR DESCRIPTION
Fixes #693 

Also adds proper messages to `402` status code errors that can be displayed to users without modification.

@dpuccetti all messages will be available in the key `message` in the `402` responses. For display, I would print:

> Contact Site Administrator - {message}

Possible messages include:
>User {user} will need to be added to the system before managing data.
>User {user} is disabled.
>Invalid or expired registration link.
>Another user is already registred with this Wechat OpenID.

Also logs the error to the log database in the `access_log` collection like so:
```
{
    "_id" : ObjectId("58c89888d6e0ad0033736e5a"),
    "conflicts" : [ 
        "existing.wechat.user@email.email"
    ],
    "timestamp" : ISODate("2017-03-15T01:27:36.218Z"),
    "attempted_user" : "user.conflict.attempt@email.email",
    "access_type" : "user_conflict"
}
```
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
