### PR TITLE
Increase coverage of api/jobs/handlers.py

### DIFF
--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -225,7 +225,8 @@ class Job(object):
                 {
                     'type': 'http',
                     'uri': gear['exchange']['rootfs-url'],
-                    'vu': 'vu0:x-' + gear['exchange']['rootfs-hash']
+                    'vu': 'vu0:x-' + gear['exchange']['rootfs-hash'],
+                    'location': '/',
                 }
             ],
             'target': {

--- a/raml/resources/gears.raml
+++ b/raml/resources/gears.raml
@@ -28,7 +28,7 @@ get:
           application/json:
             example: !include ../examples/gear_full.json
   delete:
-      description: Delete a gear (not recommended)
-      responses:
-        200:
-          description: Gear was deleted
+    description: Delete a gear (not recommended)
+    responses:
+      200:
+        description: Gear was deleted

--- a/raml/resources/gears.raml
+++ b/raml/resources/gears.raml
@@ -7,12 +7,19 @@ get:
   uriParameters:
     GearName:
       type: string
-      description: Id of the gear to interact with
+      description: Name of the gear to interact with
   post:
     description: |
       Create or update a gear.
       If no existing gear is found, one will be created
       Otherwise, the specified gear will be updated
+
+/{GearId}:
+  description: Interact with a specific gear
+  uriParameters:
+    GearId:
+      type: string
+      description: Id of the gear to interact with
   get:
     description: Retrieve details about a specific gear
     responses:

--- a/raml/schemas/definitions/job.json
+++ b/raml/schemas/definitions/job.json
@@ -5,6 +5,7 @@
     "_id": {"$ref":"../definitions/objectid.json#"},
     "id": {"$ref":"../definitions/objectid.json#"},
     "gear_id": {"type":"string"},
+    "previous_job_id": {"type":"string"},
     "inputs-property-type":{"type":"string"},
     "inputs-property-id":{"type":"string"},
     "inputs-property-name":{"type":"string"},

--- a/raml/schemas/output/job-list.json
+++ b/raml/schemas/output/job-list.json
@@ -7,6 +7,7 @@
       "_id":{"$ref":"../definitions/job.json#/definitions/id"},
       "origin":{"$ref":"../definitions/job.json#/definitions/origin"},
       "gear_id":{"$ref":"../definitions/job.json#/definitions/gear_id"},
+      "previous_job_id":{"$ref":"../definitions/job.json#/definitions/previous_job_id"},
       "inputs":{"$ref":"../definitions/job.json#/definitions/inputs-array"},
       "destination":{"$ref":"../definitions/job.json#/definitions/destination"},
       "tags":{"$ref":"../definitions/job.json#/definitions/tags"},

--- a/raml/schemas/output/job-next.json
+++ b/raml/schemas/output/job-next.json
@@ -5,6 +5,7 @@
     "_id":{"$ref":"../definitions/job.json#/definitions/id"},
     "origin":{"$ref":"../definitions/job.json#/definitions/origin"},
     "gear_id":{"$ref":"../definitions/job.json#/definitions/gear_id"},
+    "previous_job_id":{"$ref":"../definitions/job.json#/definitions/previous_job_id"},
     "inputs":{"$ref":"../definitions/job.json#/definitions/inputs-array"},
     "destination":{"$ref":"../definitions/job.json#/definitions/destination"},
     "tags":{"$ref":"../definitions/job.json#/definitions/tags"},

--- a/raml/schemas/output/job.json
+++ b/raml/schemas/output/job.json
@@ -5,6 +5,7 @@
     "id":{"$ref":"../definitions/job.json#/definitions/id"},
     "origin":{"$ref":"../definitions/job.json#/definitions/origin"},
     "gear_id":{"$ref":"../definitions/job.json#/definitions/gear_id"},
+    "previous_job_id":{"$ref":"../definitions/job.json#/definitions/previous_job_id"},
     "inputs":{"$ref":"../definitions/job.json#/definitions/inputs-object"},
     "destination":{"$ref":"../definitions/job.json#/definitions/destination"},
     "tags":{"$ref":"../definitions/job.json#/definitions/tags"},

--- a/test/integration_tests/abao/abao_test_hooks.js
+++ b/test/integration_tests/abao/abao_test_hooks.js
@@ -83,6 +83,7 @@ hooks.skip("POST /projects/{ProjectId}/recalc -> 200")
 
 // Porting to python as per #600
 hooks.skip("POST /jobs/add -> 200")
+hooks.skip("PUT /jobs/{JobId} -> 200")
 hooks.skip("GET /gears/{GearId} -> 200")
 hooks.skip("GET /sessions/{SessionId}/jobs -> 200")
 
@@ -127,13 +128,6 @@ hooks.before("GET /jobs/{JobId}/config.json -> 200", function(test, done) {
     done();
 });
 
-
-hooks.before("PUT /jobs/{JobId} -> 200", function(test, done) {
-    test.request.params = {
-        JobId: job_id
-    };
-    done();
-});
 
 hooks.before("POST /jobs/{JobId}/retry -> 200", function(test, done) {
     test.request.params = {

--- a/test/integration_tests/abao/abao_test_hooks.js
+++ b/test/integration_tests/abao/abao_test_hooks.js
@@ -83,7 +83,7 @@ hooks.skip("POST /projects/{ProjectId}/recalc -> 200")
 
 // Porting to python as per #600
 hooks.skip("POST /jobs/add -> 200")
-hooks.skip("GET /gears/{GearName} -> 200")
+hooks.skip("GET /gears/{GearId} -> 200")
 hooks.skip("GET /sessions/{SessionId}/jobs -> 200")
 
 // Cannot be ran due to gear IDs being used as per #
@@ -91,7 +91,7 @@ hooks.skip("POST /sessions/{SessionId}/analyses -> 200")
 hooks.skip("GET /sessions/{SessionId}/analyses/{AnalysisId} -> 200")
 hooks.skip("DELETE /sessions/{SessionId}/analyses/{AnalysisId} -> 200")
 // Related, ref #696
-hooks.skip("DELETE /gears/{GearName} -> 200")
+hooks.skip("DELETE /gears/{GearId} -> 200")
 
 
 hooks.before("POST /login -> 200", function(test, done) {
@@ -214,27 +214,6 @@ hooks.before("GET /users/{UserId}/projects -> 200", function(test, done) {
 hooks.before("GET /users/{UserId}/sessions -> 200", function(test, done) {
     test.request.params = {
         UserId: "admin@user.com"
-    };
-    done();
-});
-
-hooks.before("GET /gears/{GearName} -> 200", function(test, done) {
-    test.request.params = {
-        GearName: gear_name
-    };
-    done();
-});
-
-hooks.before("POST /gears/{GearName} -> 200", function(test, done) {
-    test.request.params = {
-        GearName: gear_name
-    };
-    done();
-});
-
-hooks.before("GET /gears/{GearName} -> 200", function(test, done) {
-    test.request.params = {
-        GearName: gear_name
     };
     done();
 });

--- a/test/integration_tests/python/basics.py
+++ b/test/integration_tests/python/basics.py
@@ -66,3 +66,20 @@ def as_user(base_url_session):
         _apiAsUser = s
 
     return _apiAsUser
+
+
+_apiAsPublic = None
+
+@pytest.fixture(scope="module")
+def as_public(base_url_session):
+
+    global _apiAsPublic
+
+    # Create one session and reuse it.
+    if _apiAsPublic is None:
+
+        s = base_url_session()
+
+        _apiAsPublic = s
+
+    return _apiAsPublic

--- a/test/integration_tests/python/states.py
+++ b/test/integration_tests/python/states.py
@@ -42,3 +42,45 @@ def with_hierarchy_and_file_data(with_hierarchy):
     fixture_data = with_hierarchy
     fixture_data.files = files
     return fixture_data
+
+
+@pytest.fixture
+def with_gear(request, as_admin):
+    gear_name = 'test-gear'
+    r = as_admin.post('/gears/' + gear_name, json={
+        'category': 'converter',
+        'gear': {
+            'inputs': {
+                'wat': {
+                    'base': 'file',
+                    'type': { 'enum': [ 'wat' ] }
+                }
+            },
+            'maintainer': 'Example',
+            'description': 'Example',
+            'license': 'BSD-2-Clause',
+            'author': 'Example',
+            'url': 'https://example.example',
+            'label': 'wat',
+            'flywheel': '0',
+            'source': 'https://example.example',
+            'version': '0.0.1',
+            'config': {},
+            'name': gear_name
+        },
+        'exchange': {
+            'git-commit': 'aex',
+            'rootfs-hash': 'sha384:oy',
+            'rootfs-url': 'https://example.example'
+        }
+    })
+    assert r.ok
+    gear_id = r.json()['_id']
+
+    def teardown_db():
+        r = as_admin.delete('/gears/' + gear_id)
+        assert r.ok
+
+    request.addfinalizer(teardown_db)
+
+    return gear_id

--- a/test/integration_tests/python/states.py
+++ b/test/integration_tests/python/states.py
@@ -1,10 +1,12 @@
 # Various wholesale app states that might be useful in your tests
 
+import copy
 import time
+
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def with_hierarchy(api_as_admin, bunch, request, data_builder):
     group =         data_builder.create_group('test_prop_' + str(int(time.time() * 1000)))
     project =       data_builder.create_project(group)
@@ -44,36 +46,62 @@ def with_hierarchy_and_file_data(with_hierarchy):
     return fixture_data
 
 
-@pytest.fixture
+test_gear = {
+    'category': 'converter',
+    'gear': {
+        'inputs': {
+            'any text file <= 100 KB': {
+                'base': 'file',
+                'name': { 'pattern': '^.*.txt$' },
+                'size': { 'maximum': 100000 }
+            }
+        },
+        'maintainer': 'Example',
+        'description': 'Example',
+        'license': 'BSD-2-Clause',
+        'author': 'Example',
+        'url': 'https://example.example',
+        'label': 'wat',
+        'flywheel': '0',
+        'source': 'https://example.example',
+        'version': '0.0.1',
+        'config': {},
+    },
+    'exchange': {
+        'git-commit': 'aex',
+        'rootfs-hash': 'sha384:oy',
+        'rootfs-url': 'https://example.example'
+    }
+}
+
+
+@pytest.fixture(scope='module')
 def with_gear(request, as_admin):
     gear_name = 'test-gear'
-    r = as_admin.post('/gears/' + gear_name, json={
-        'category': 'converter',
-        'gear': {
-            'inputs': {
-                'wat': {
-                    'base': 'file',
-                    'type': { 'enum': [ 'wat' ] }
-                }
-            },
-            'maintainer': 'Example',
-            'description': 'Example',
-            'license': 'BSD-2-Clause',
-            'author': 'Example',
-            'url': 'https://example.example',
-            'label': 'wat',
-            'flywheel': '0',
-            'source': 'https://example.example',
-            'version': '0.0.1',
-            'config': {},
-            'name': gear_name
-        },
-        'exchange': {
-            'git-commit': 'aex',
-            'rootfs-hash': 'sha384:oy',
-            'rootfs-url': 'https://example.example'
-        }
-    })
+    gear_data = copy.deepcopy(test_gear)
+    gear_data['gear']['name'] = gear_name
+
+    r = as_admin.post('/gears/' + gear_name, json=gear_data)
+    assert r.ok
+    gear_id = r.json()['_id']
+
+    def teardown_db():
+        r = as_admin.delete('/gears/' + gear_id)
+        assert r.ok
+
+    request.addfinalizer(teardown_db)
+
+    return gear_id
+
+
+@pytest.fixture(scope='module')
+def with_invalid_gear(request, as_admin):
+    gear_name = 'invalid-test-gear'
+    gear_data = copy.deepcopy(test_gear)
+    gear_data['gear']['name'] = gear_name
+    gear_data['gear']['custom'] = {'flywheel': {'invalid': True}}
+
+    r = as_admin.post('/gears/' + gear_name, json=gear_data)
     assert r.ok
     gear_id = r.json()['_id']
 

--- a/test/integration_tests/python/test_batch.py
+++ b/test/integration_tests/python/test_batch.py
@@ -1,0 +1,83 @@
+import json
+import logging
+
+
+log = logging.getLogger(__name__)
+sh = logging.StreamHandler()
+log.addHandler(sh)
+
+
+def test_batch(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin):
+    data = with_hierarchy
+    gear = with_gear
+    invalid_gear = with_invalid_gear
+
+    # get all
+    r = as_user.get('/batch')
+    assert r.ok
+
+    # get all w/o enforcing permissions
+    r = as_admin.get('/batch')
+    assert r.ok
+
+    # try to create batch without gear_id/targets
+    r = as_admin.post('/batch', json={})
+    assert r.status_code == 400
+
+    # try to create batch with different target container types
+    r = as_admin.post('/batch', json={
+        'gear_id': gear,
+        'targets': [
+            {'type': 'session', 'id': 'test-session-id'},
+            {'type': 'acquisition', 'id': 'test-acquisition-id'},
+        ],
+    })
+    assert r.status_code == 400
+
+    # try to create batch using an invalid gear
+    r = as_admin.post('/batch', json={
+        'gear_id': invalid_gear,
+        'targets': [{'type': 'session', 'id': 'test-session-id'}],
+    })
+    assert r.status_code == 400
+
+    # create a batch
+    r = as_admin.post('/acquisitions/' + data.acquisition + '/files', files={
+        'file': ('test.txt', 'test\ncontent\n')
+    })
+    assert r.ok
+
+    r = as_admin.post('/batch', json={
+        'gear_id': gear,
+        'targets': [
+            {'type': 'acquisition', 'id': data.acquisition},
+        ],
+        'target_context': {'type': 'session', 'id': data.session}
+    })
+    assert r.ok
+    batch_id = r.json()['_id']
+
+    # get batch
+    r = as_admin.get('/batch/' + batch_id)
+    assert r.ok
+    assert r.json()['state'] == 'pending'
+
+    # try to cancel non-launched batch
+    r = as_admin.post('/batch/' + batch_id + '/cancel')
+    assert r.status_code == 400
+
+    # run batch
+    r = as_admin.post('/batch/' + batch_id + '/run')
+    assert r.ok
+    r = as_admin.get('/batch/' + batch_id)
+    assert r.json()['state'] == 'launched'
+
+    # try to run non-pending batch
+    r = as_admin.post('/batch/' + batch_id + '/run')
+    assert r.status_code == 400
+
+    # cancel batch
+    r = as_admin.post('/batch/' + batch_id + '/cancel')
+    assert r.ok
+    r = as_admin.get('/batch/' + batch_id)
+    assert r.json()['state'] == 'cancelled'

--- a/test/integration_tests/python/test_gears.py
+++ b/test/integration_tests/python/test_gears.py
@@ -49,6 +49,10 @@ def test_gear_add(as_admin):
     r = as_admin.get('/gears/basic')
     assert not r.ok
 
+    r = as_admin.delete('/gears/' + _id)
+    assert r.ok
+
+
 def test_gear_add_versioning(as_admin):
 
     # Add 0.0.1
@@ -184,38 +188,70 @@ def test_gear_add_versioning(as_admin):
 
 
 def test_gear_add_invalid(as_admin):
-    # Try to add invalid gear
+    # try to add invalid gear - missing name
+    r = as_admin.post('/gears/test_gear', json={})
+    assert r.status_code == 400
+
+    # try to add invalid gear - manifest validation error
     r = as_admin.post('/gears/test_gear', json={
-        "category": "converter",
-        "input": { },
-        "name": "test_gear",
-        "manifest": {
+        "gear": { "name": "test_gear" }
+    })
+    assert r.status_code == 400
+
+    # try to add invalid gear - manifest validation error of non-root-level key
+    r = as_admin.post('/gears/test_gear', json={
+        "gear": {
+            "author": "Example",
+            "config": {"invalid": "config"},
+            "description": "Example",
+            "inputs": {"invalid": "inputs"},
+            "label": "Example",
+            "license": "BSD-2-Clause",
             "name": "test_gear",
-            "inputs": {
-                "any text file <= 100 KB": {
-                    "base": "file",
-                    "name": {
-                        "pattern": "^.*.txt$"
-                    },
-                    "size": {
-                        "maximum": 100000
-                    }
-                }
-            },
-            "description": "A gear to test the API",
-            "license": "Other",
-            "author": "",
-            "url": "https://unknown.example",
-            "label": "An exported gear",
-            "source": "https://unknown.example",
-            "config": {
-                "two-digit multiple of ten": {
-                    "exclusiveMaximum": True,
-                    "type": "number",
-                    "multipleOf": 10,
-                    "maximum": 100
-                }
-            }
+            "source": "https://example.example",
+            "url": "https://example.example",
+            "version": "0.0.0"
         }
     })
     assert r.status_code == 400
+
+
+def test_gear_access(with_gear, as_public, as_user):
+    gear = with_gear
+
+    # test login required
+    r = as_public.get('/gears')
+    assert r.status_code == 403
+
+    r = as_public.get('/gears/' + gear)
+    assert r.status_code == 403
+
+    r = as_public.get('/gears/' + gear + '/invocation')
+    assert r.status_code == 403
+
+    r = as_public.get('/gears/' + gear + '/suggest/test-container/test-id')
+    assert r.status_code == 403
+
+    # test superuser required
+    r = as_user.post('/gears/test-gear', json={'test': 'payload'})
+    assert r.status_code == 403
+
+    r = as_user.delete('/gears/test-gear')
+    assert r.status_code == 403
+
+
+def test_gear_invocation_and_suggest(with_gear, with_hierarchy, as_user, as_admin):
+    data = with_hierarchy
+    gear = with_gear
+
+    # test invocation
+    r = as_admin.get('/gears/' + gear + '/invocation')
+    assert r.ok
+
+    # test suggest
+    r = as_admin.get('/gears/' + gear + '/suggest/session/' + data.session)
+    assert r.ok
+
+    # test suggest permission
+    r = as_user.get('/gears/' + gear + '/suggest/session/' + data.session)
+    assert r.ok

--- a/test/integration_tests/python/test_jobs.py
+++ b/test/integration_tests/python/test_jobs.py
@@ -28,9 +28,10 @@ def test_jobs_access(as_user):
     assert r.status_code == 403
 
 
-def test_jobs(with_gear, with_hierarchy, as_user, as_admin):
-    gear = with_gear
+def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin):
     data = with_hierarchy
+    gear = with_gear
+    invalid_gear = with_invalid_gear
 
     job1 = {
         'gear_id': gear,
@@ -73,21 +74,11 @@ def test_jobs(with_gear, with_hierarchy, as_user, as_admin):
     assert r.ok
 
     # add job with invalid gear
-    r = as_admin.get('/gears/' + gear)
-    assert r.ok
-    invalid_gear = r.json()
-    del invalid_gear['_id']
-    invalid_gear['gear']['name'] = 'invalid'
-    invalid_gear['gear']['custom'] = {'flywheel': {'invalid': True}}
-    invalid_gear_id = as_admin.post('/gears/invalid', json=invalid_gear).json()['_id']
-
     job3 = deepcopy(job2)
-    job3['gear_id'] = invalid_gear_id
+    job3['gear_id'] = invalid_gear
 
     r = as_user.post('/jobs/add', json=job3)
     assert r.status_code == 400
-
-    as_admin.delete('/gears/' + invalid_gear_id)
 
     # get next job - with nonexistent tag
     r = as_admin.get('/jobs/next?tags=fake-tag')

--- a/test/integration_tests/python/test_jobs.py
+++ b/test/integration_tests/python/test_jobs.py
@@ -1,0 +1,105 @@
+import json
+import logging
+from copy import deepcopy
+
+
+log = logging.getLogger(__name__)
+sh = logging.StreamHandler()
+log.addHandler(sh)
+
+
+def test_jobs_access(as_user):
+    r = as_user.get('/jobs')
+    assert r.status_code == 403
+
+    r = as_user.get('/jobs/next')
+    assert r.status_code == 403
+
+    r = as_user.get('/jobs/stats')
+    assert r.status_code == 403
+
+    r = as_user.post('/jobs/reap')
+    assert r.status_code == 403
+
+    r = as_user.get('/jobs/test-job')
+    assert r.status_code == 403
+
+    r = as_user.get('/jobs/test-job/config.json')
+    assert r.status_code == 403
+
+
+def test_jobs(with_gear, with_hierarchy, as_user, as_admin):
+    gear = with_gear
+    data = with_hierarchy
+
+    job1 = {
+        'gear_id': gear,
+        'inputs': {
+            'dicom': {
+                'type': 'acquisition',
+                'id': data.acquisition,
+                'name': 'test.zip'
+            }
+        },
+        'config': { 'two-digit multiple of ten': 20 },
+        'destination': {
+            'type': 'acquisition',
+            'id': data.acquisition
+        },
+        'tags': [ 'test-tag' ]
+    }
+
+    # add job with explicit destination
+    r = as_user.post('/jobs/add', json=job1)
+    assert r.ok
+    job1_id = r.json()['_id']
+
+    # get job
+    r = as_admin.get('/jobs/' + job1_id)
+    assert r.ok
+
+    # get job config
+    r = as_admin.get('/jobs/' + job1_id + '/config.json')
+    assert r.ok
+
+    # try to update job (user may only cancel)
+    r = as_user.put('/jobs/' + job1_id, json={'test': 'invalid'})
+    assert r.status_code == 403
+
+    # add job with implicit destination
+    job2 = deepcopy(job1)
+    del job2['destination']
+    r = as_user.post('/jobs/add', json=job2)
+    assert r.ok
+
+    # add job with invalid gear
+    r = as_admin.get('/gears/' + gear)
+    assert r.ok
+    invalid_gear = r.json()
+    del invalid_gear['_id']
+    invalid_gear['gear']['name'] = 'invalid'
+    invalid_gear['gear']['custom'] = {'flywheel': {'invalid': True}}
+    invalid_gear_id = as_admin.post('/gears/invalid', json=invalid_gear).json()['_id']
+
+    job3 = deepcopy(job2)
+    job3['gear_id'] = invalid_gear_id
+
+    r = as_user.post('/jobs/add', json=job3)
+    assert r.status_code == 400
+
+    as_admin.delete('/gears/' + invalid_gear_id)
+
+    # get next job - with nonexistent tag
+    r = as_admin.get('/jobs/next?tags=fake-tag')
+    assert r.status_code == 400
+
+    # get next job - without tags
+    r = as_admin.get('/jobs/next')
+    assert r.status_code == 200
+
+    # retry job
+    r = as_admin.put('/jobs/' + job1_id, json={'state': 'failed'})
+    assert r.ok
+
+    r = as_user.post('/jobs/' + job1_id + '/retry')
+    assert r.ok

--- a/test/integration_tests/python/test_rules.py
+++ b/test/integration_tests/python/test_rules.py
@@ -1,0 +1,14 @@
+import json
+import logging
+
+log = logging.getLogger(__name__)
+sh = logging.StreamHandler()
+log.addHandler(sh)
+
+
+def test_rule_access(as_user):
+    r = as_user.get('/rules')
+    assert r.status_code == 403
+
+    r = as_user.post('/rules', json={'test': 'rule'})
+    assert r.status_code == 403

--- a/test/integration_tests/python/test_uploads.py
+++ b/test/integration_tests/python/test_uploads.py
@@ -44,47 +44,6 @@ def with_group_and_file_data(api_as_admin, data_builder, bunch, request):
     fixture_data.files = files
     return fixture_data
 
-@pytest.fixture()
-def with_gear(as_admin, request):
-    gear_name = 'test-gear'
-    r = as_admin.post('/gears/' + gear_name, json={
-        'category': 'converter',
-        'gear': {
-            'inputs': {
-                'wat': {
-                    'base': 'file',
-                    'type': { 'enum': [ 'wat' ] }
-                }
-            },
-            'maintainer': 'Example',
-            'description': 'Example',
-            'license': 'BSD-2-Clause',
-            'author': 'Example',
-            'url': 'https://example.example',
-            'label': 'wat',
-            'flywheel': '0',
-            'source': 'https://example.example',
-            'version': '0.0.1',
-            'config': {},
-            'name': gear_name
-        },
-        'exchange': {
-            'git-commit': 'aex',
-            'rootfs-hash': 'sha384:oy',
-            'rootfs-url': 'https://example.example'
-        }
-    })
-    assert r.ok
-    gear_id = r.json()['_id']
-
-    def teardown_db():
-        r = as_admin.delete('/gears/' + gear_id)
-        assert r.ok
-
-    request.addfinalizer(teardown_db)
-
-    return gear_id
-
 
 def test_uid_upload(with_group_and_file_data, api_as_admin):
     data = with_group_and_file_data


### PR DESCRIPTION
Closes #683

8 LOC left in api/jobs/handlers.py (97%)
- 5L Permission handling (that'll be faster to handle globally in #702): 244, 351, 354, 416-417
- 2L Checks that seemed unreachable (maybe obsolete or useful for compatibility?): 166, 222
- 1L That I would rather solve later with additional fixture(s) (need a session w/o acquisitions): 340

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
