### PR TITLE
Load job result before returning on /jobs/next

### DIFF
--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -190,7 +190,7 @@ class Queue(object):
         if result is None:
             raise Exception('Marked job as running but could not generate and save formula')
 
-        return result
+        return Job.load(result)
 
     @staticmethod
     def search(containers, states=None, tags=None):


### PR DESCRIPTION
Fixes #705.