### PR TITLE
Increase coverage of api/placer.py

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -638,9 +638,6 @@ class AnalysesHandler(ListHandler):
             self.abort(400, 'ticket not for this resource')
         return ticket
 
-    def put(self, *args, **kwargs):
-        raise NotImplementedError("an analysis can't be modified")
-
     def post(self, cont_name, list_name, **kwargs):
         """
         Default behavior:

--- a/api/placer.py
+++ b/api/placer.py
@@ -49,19 +49,19 @@ class Placer(object):
         """
         Run any pre-processing checks. Expected to throw on error.
         """
-        raise NotImplementedError()
+        raise NotImplementedError() # pragma: no cover
 
     def process_file_field(self, field, file_attrs):
         """"
         Process a single file field.
         """
-        raise NotImplementedError()
+        raise NotImplementedError() # pragma: no cover
 
     def finalize(self):
         """
         Run any post-processing work. Expected to return output for the callee.
         """
-        raise NotImplementedError()
+        raise NotImplementedError() # pragma: no cover
 
     def requireTarget(self):
         """

--- a/raml/schemas/definitions/subject.json
+++ b/raml/schemas/definitions/subject.json
@@ -31,7 +31,13 @@
 
               "code":             {"$ref":"#/definitions/code"},
               "tags":             {"$ref":"#/definitions/tags"},
-              "info":             {"$ref":"#/definitions/info"}
+              "info":             {"$ref":"#/definitions/info"},
+              "files":{
+                  "type":"array",
+                  "items":{
+                      "allOf":[{"$ref":"../definitions/file.json#/definitions/file-input"}]
+                  }
+              }
             },
             "additionalProperties": false
         },

--- a/test/integration_tests/python/test_uploads.py
+++ b/test/integration_tests/python/test_uploads.py
@@ -413,8 +413,12 @@ def test_analysis_upload(with_gear, with_hierarchy, as_user):
     })
     assert r.ok
 
+    # try to create analysis+job w/ missing analysis/job info
+    r = as_user.post('/sessions/' + data.session + '/analyses', params={'job': 'true'}, json={})
+    assert r.status_code == 400
+
     # create session analysis (job) using acquisition's file as input
-    r = as_user.post('/sessions/' + data.session + '/analyses?job=true', json={
+    r = as_user.post('/sessions/' + data.session + '/analyses', params={'job': 'true'}, json={
         'analysis': { 'label': 'test analysis job' },
         'job': {
             'gear_id': gear,

--- a/test/integration_tests/python/test_uploads.py
+++ b/test/integration_tests/python/test_uploads.py
@@ -14,10 +14,26 @@ log.addHandler(sh)
 def with_group_and_file_data(api_as_admin, data_builder, bunch, request):
     group_id = 'test_group_' + str(int(time.time() * 1000))
     data_builder.create_group(group_id)
-    file_names = ['proj.csv', 'ses.csv', 'acq.csv']
     files = {}
-    for i, name in enumerate(file_names):
-        files['file' + str(i+1)] = (name, 'some,data,to,send\nanother,row,to,send\n')
+    for i, cont in enumerate(['project', 'subject', 'session', 'acquisition', 'unused']):
+        files['file' + str(i+1)] = (cont + '.csv', 'some,data,to,send\nanother,row,to,send\n')
+    files['metadata'] = {
+        'group': {'_id': group_id},
+        'project': {
+            'label': 'test_project',
+            'files': [{'name': 'project.csv'}]
+        },
+        'session': {
+            'subject': {
+                'code': 'test_subject_code',
+                'files': [{'name': 'subject.csv'}]
+            },
+            'files': [{'name': 'session.csv'}]
+        },
+        'acquisition': {
+            'files': [{'name': 'acquisition.csv'}]
+        }
+    }
 
     def teardown_db():
         r = api_as_admin.get('/groups/{}/projects'.format(group_id))
@@ -40,111 +56,36 @@ def with_group_and_file_data(api_as_admin, data_builder, bunch, request):
     request.addfinalizer(teardown_db)
 
     fixture_data = bunch.create()
-    fixture_data.group_id = group_id
     fixture_data.files = files
     return fixture_data
 
 
 def test_uid_upload(with_group_and_file_data, api_as_admin):
     data = with_group_and_file_data
-    metadata = {
-        'group':{
-            '_id': data.group_id
-        },
-        'project':{
-            'label':'test_project',
-            'files':[
-                {
-                    'name':data.files.keys()[0]
-                }
-            ]
-        },
-        'session':{
-            'uid':'test_session_uid',
-            'files':[
-                {
-                    'name':data.files.keys()[1]
-                }
-            ],
-            'subject': {'code': 'test_subject'}
-        },
-        'acquisition':{
-            'uid':'test_acquisition_uid',
-            'files':[
-                {
-                    'name':data.files.keys()[2]
-                }
-            ]
-        }
-    }
-    metadata = json.dumps(metadata)
-    data.files['metadata'] = ('', metadata)
+    metadata = data.files['metadata']
+    metadata['session']['uid'] = 'test_session_uid'
+    metadata['acquisition']['uid'] = 'test_acquisition_uid'
 
+    # try to uid-upload w/o metadata
+    del data.files['metadata']
+    r = api_as_admin.post('/upload/uid', files=data.files)
+    assert r.status_code == 500
+
+    # uid-upload files
+    data.files['metadata'] = ('', json.dumps(metadata))
     r = api_as_admin.post('/upload/uid', files=data.files)
     assert r.ok
 
 
 def test_label_upload(with_group_and_file_data, api_as_admin):
     data = with_group_and_file_data
-    metadata = {
-        'group':{
-            '_id': data.group_id
-        },
-        'project':{
-            'label':'test_project',
-            'files':[
-                {
-                    'name':data.files.keys()[0]
-                }
-            ]
-        },
-        'session':{
-            'label':'test_session',
-            'files':[
-                {
-                    'name':data.files.keys()[1]
-                }
-            ],
-            'subject': {'code': 'test_subject'}
-        },
-        'acquisition':{
-            'label':'test_acquisition',
-            'files':[
-                {
-                    'name':data.files.keys()[2]
-                }
-            ]
-        }
-    }
-    metadata = json.dumps(metadata)
-    data.files['metadata'] = ('', metadata)
+    metadata = data.files['metadata']
+    metadata['session']['label'] = 'test_session_label'
+    metadata['acquisition']['label'] = 'test_acquisition_label'
 
+    # label-upload files
+    data.files['metadata'] = ('', json.dumps(metadata))
     r = api_as_admin.post('/upload/label', files=data.files)
-    assert r.ok
-    assert r.json() == []
-
-    data.files['metadata'] = metadata
-    r = api_as_admin.post('/upload/label', files=data.files)
-    assert r.status_code == 400
-
-    # NOTE this adds api/placer.py coverage for lines 177-185
-    # need info on why that wasn't covered with 1st request in this test
-    single_file_data = {
-        'file': ('acq.csv', 'some,data,to,send\nanother,row,to,send\n'),
-        'metadata': ('', json.dumps({
-            'group': {'_id': data.group_id},
-            'project': {'label': 'test_project'},
-            'session': {
-                'label': 'test_session',
-                'subject': {'code': 'test_subject'}
-            },
-            'acquisition': {
-                'label': 'test_acquisition',
-                'files': [{'name': 'acq.csv'}]
-            }
-        }))
-    }
-    r = api_as_admin.post('/upload/label', files=single_file_data)
     assert r.ok
 
 


### PR DESCRIPTION
Closes #689 

```
Name             Stmts   Miss  Cover   Missing
------------------------------------------------------------------
api/placer.py      325     37    89%   71, 242-259, 272, 285, 293-296, 318, 375, 387, 533, 617-618, 629, 636-638, 652-657
```

- 71: "too much effort"
- 242-259: compatibility code - to be removed soon
- 272, 285, 293-296: too much effort
- 318, 375: not sure how they're reachable (see listhandler.py:526)
- 533: not sure how it's reachable (session meta may not include timestamp, see raml/schemas/input/packfile.json)
- 617-EOF: effort + would be helpful to talk through analysis/analysisjob placing in detail in the future

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
