### PR TITLE
Ported tests from fixture api_as_admin to as_admin

### DIFF
--- a/test/integration_tests/python/basics.py
+++ b/test/integration_tests/python/basics.py
@@ -1,85 +1,34 @@
-# New test fixtures!
-#
-# The intention is to slowly build these up until we like them, then port the tests to them and replace parts of conftest.py
+import os
 
 import pytest
 import requests
 
-# The request Session object has no support for a base URL; this is a subclass to embed one.
-# Dynamically generated via a pytest fixture so that we can use the upstream fixtures.
-@pytest.fixture(scope="module")
-def base_url_session(base_url):
-    class BaseUrlSession(requests.Session):
-        def request(self, method, url, params=None, data=None, headers=None, cookies=None, files=None, auth=None, timeout=None, allow_redirects=True, proxies=None, hooks=None, stream=None, verify=None, cert=None, json=None):
 
-            url = base_url + url
+class BaseUrlSession(requests.Session):
+    def __init__(self, *args, **kwargs):
+        super(BaseUrlSession, self).__init__(*args, **kwargs)
+        self.base_url = os.environ.get('BASE_URL', 'http://localhost:8080/api')
 
-            return super(BaseUrlSession, self).request(method, url, params, data, headers, cookies, files, auth, timeout, allow_redirects, proxies, hooks, stream, verify, cert, json)
-
-    return BaseUrlSession
+    def request(self, method, url, **kwargs):
+        return super(BaseUrlSession, self).request(method, self.base_url + url, **kwargs)
 
 
-_apiAsAdmin = None
-
-# A replacement for the RequestsAccessor class. Less boilerplate, no kwarg fiddling.
-# This has the added benefit of re-using HTTP connections, which might speed up our testing considerably.
-#
-# Ref: http://stackoverflow.com/a/34491383
-@pytest.fixture(scope="module")
-def as_admin(base_url_session):
-
-    global _apiAsAdmin
-
-    # Create one session and reuse it.
-    if _apiAsAdmin is None:
-
-        s = base_url_session()
-
-        s.headers.update({
-            "Authorization":"scitran-user XZpXI40Uk85eozjQkU1zHJ6yZHpix+j0mo1TMeGZ4dPzIqVPVGPmyfeK"
-        })
-        s.params.update({
-            "root": "true"
-        })
-
-        _apiAsAdmin = s
-
-    return _apiAsAdmin
+@pytest.fixture(scope='session')
+def as_admin():
+    session = BaseUrlSession()
+    session.headers.update({'Authorization': 'scitran-user XZpXI40Uk85eozjQkU1zHJ6yZHpix+j0mo1TMeGZ4dPzIqVPVGPmyfeK'})
+    session.params.update({'root': 'true'})
+    return session
 
 
-_apiAsUser = None
-
-@pytest.fixture(scope="module")
-def as_user(base_url_session):
-
-    global _apiAsUser
-
-    # Create one session and reuse it.
-    if _apiAsUser is None:
-
-        s = base_url_session()
-
-        s.headers.update({
-            "Authorization":"scitran-user XZpXI40Uk85eozjQkU1zHJ6yZHpix+j0mo1TMeGZ4dPzIqVPVGPmyfeK"
-        })
-
-        _apiAsUser = s
-
-    return _apiAsUser
+@pytest.fixture(scope='session')
+def as_user():
+    session = BaseUrlSession()
+    session.headers.update({'Authorization': 'scitran-user XZpXI40Uk85eozjQkU1zHJ6yZHpix+j0mo1TMeGZ4dPzIqVPVGPmyfeK'})
+    return session
 
 
-_apiAsPublic = None
-
-@pytest.fixture(scope="module")
-def as_public(base_url_session):
-
-    global _apiAsPublic
-
-    # Create one session and reuse it.
-    if _apiAsPublic is None:
-
-        s = base_url_session()
-
-        _apiAsPublic = s
-
-    return _apiAsPublic
+# use function scope to enable customizing session w/o affecting other tests
+@pytest.fixture(scope='function')
+def as_public():
+    return BaseUrlSession()

--- a/test/integration_tests/python/states.py
+++ b/test/integration_tests/python/states.py
@@ -7,7 +7,7 @@ import pytest
 
 
 @pytest.fixture(scope='module')
-def with_hierarchy(api_as_admin, bunch, request, data_builder):
+def with_hierarchy(as_admin, bunch, request, data_builder):
     group =         data_builder.create_group('test_prop_' + str(int(time.time() * 1000)))
     project =       data_builder.create_project(group)
     session =       data_builder.create_session(project)

--- a/test/integration_tests/python/test_access_log.py
+++ b/test/integration_tests/python/test_access_log.py
@@ -15,7 +15,7 @@ log.addHandler(sh)
 
 
 @pytest.fixture()
-def with_session_and_file_data(api_as_admin, bunch, request, data_builder):
+def with_session_and_file_data(as_admin, bunch, request, data_builder):
     group =         data_builder.create_group('test_upload_' + str(int(time.time() * 1000)))
     project =       data_builder.create_project(group)
     session =       data_builder.create_session(project)
@@ -40,7 +40,7 @@ def with_session_and_file_data(api_as_admin, bunch, request, data_builder):
     return fixture_data
 
 @pytest.fixture()
-def with_session_and_file_data_and_db_failure(api_as_admin, bunch, request, data_builder, access_log_db):
+def with_session_and_file_data_and_db_failure(as_admin, bunch, request, data_builder, access_log_db):
     group =         data_builder.create_group('test_upload_' + str(int(time.time() * 1000)))
     project =       data_builder.create_project(group)
     session =       data_builder.create_session(project)
@@ -77,7 +77,7 @@ def with_session_and_file_data_and_db_failure(api_as_admin, bunch, request, data
     return fixture_data
 
 
-def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log_db):
+def test_access_log_succeeds(with_session_and_file_data, as_user, access_log_db):
     data = with_session_and_file_data
 
     ###
@@ -91,7 +91,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
         'code': 'XZpXI40Uk85eozjQkU1zHJ6yZHpix+j0mo1TMeGZ4dPzIqVPVGPmyfeK'
     })
 
-    r = api_as_user.post('/login', data=payload)
+    r = as_user.post('/login', data=payload)
     assert r.ok
 
     log_records_count_after = access_log_db.access_log.count({})
@@ -107,7 +107,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
     log_records_count_before = access_log_db.access_log.count({})
 
-    r = api_as_user.post('/logout')
+    r = as_user.post('/logout')
     assert r.ok
 
     log_records_count_after = access_log_db.access_log.count({})
@@ -123,7 +123,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
     log_records_count_before = access_log_db.access_log.count({})
 
-    r = api_as_user.get('/sessions/' + data.session)
+    r = as_user.get('/sessions/' + data.session)
     assert r.ok
 
     log_records_count_after = access_log_db.access_log.count({})
@@ -142,7 +142,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
     subject = {'subject': {'code': 'Test subject code'}}
     subject_update = json.dumps(subject)
 
-    r = api_as_user.put('/sessions/' + data.session, data=subject_update)
+    r = as_user.put('/sessions/' + data.session, data=subject_update)
     assert r.ok
 
 
@@ -152,7 +152,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
     log_records_count_before = access_log_db.access_log.count({})
 
-    r = api_as_user.get('/sessions/' + data.session + '/subject')
+    r = as_user.get('/sessions/' + data.session + '/subject')
     assert r.ok
 
     log_records_count_after = access_log_db.access_log.count({})
@@ -166,7 +166,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
 
     # Upload files
-    r = api_as_user.post('/projects/' + data.project + '/files', files=data.files)
+    r = as_user.post('/projects/' + data.project + '/files', files=data.files)
     assert r.ok
 
 
@@ -176,7 +176,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
     log_records_count_before = access_log_db.access_log.count({})
 
-    r = api_as_user.get('/projects/' + data.project + '/files/one.csv')
+    r = as_user.get('/projects/' + data.project + '/files/one.csv')
     assert r.ok
 
     file_ = r.raw.read(10)
@@ -197,12 +197,12 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
     log_records_count_before = access_log_db.access_log.count({})
 
-    r = api_as_user.get('/projects/' + data.project + '/files/one.csv?ticket=')
+    r = as_user.get('/projects/' + data.project + '/files/one.csv?ticket=')
     assert r.ok
 
     ticket_id = json.loads(r.content)['ticket']
 
-    r = api_as_user.get('/projects/' + data.project + '/files/one.csv?ticket=' + ticket_id)
+    r = as_user.get('/projects/' + data.project + '/files/one.csv?ticket=' + ticket_id)
     assert r.ok
 
     file_ = r.raw.read(10)
@@ -224,7 +224,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
     log_records_count_before = access_log_db.access_log.count({})
 
-    r = api_as_user.get('/projects/' + data.project + '/files/one.csv/info')
+    r = as_user.get('/projects/' + data.project + '/files/one.csv/info')
     assert r.ok
     file_info = json.loads(r.content)
     assert file_info['name'] == 'one.csv'
@@ -244,7 +244,7 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
     log_records_count_before = access_log_db.access_log.count({})
 
-    r = api_as_user.delete('/projects/' + data.project + '/files/one.csv')
+    r = as_user.delete('/projects/' + data.project + '/files/one.csv')
     assert r.ok
 
     log_records_count_after = access_log_db.access_log.count({})
@@ -257,21 +257,21 @@ def test_access_log_succeeds(with_session_and_file_data, api_as_user, access_log
 
 
 
-def test_access_log_fails(with_session_and_file_data_and_db_failure, api_as_user, access_log_db):
+def test_access_log_fails(with_session_and_file_data_and_db_failure, as_user, access_log_db):
     data = with_session_and_file_data_and_db_failure
 
     # Upload files
-    r = api_as_user.post('/projects/' + data.project + '/files', files=data.files)
+    r = as_user.post('/projects/' + data.project + '/files', files=data.files)
     assert r.ok
 
     ###
     # Test file delete request fails and does not delete file
     ###
 
-    r = api_as_user.delete('/projects/' + data.project + '/files/one.csv')
+    r = as_user.delete('/projects/' + data.project + '/files/one.csv')
     assert r.status_code == 500
 
-    r = api_as_user.get('/projects/' + data.project)
+    r = as_user.get('/projects/' + data.project)
     assert r.ok
     project = json.loads(r.content)
     assert len(project.get('files', [])) == 1

--- a/test/integration_tests/python/test_collection.py
+++ b/test/integration_tests/python/test_collection.py
@@ -7,30 +7,30 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 
 
-def test_collections(api_as_user, single_project_session_acquisition_tree):
+def test_collections(as_user, single_project_session_acquisition_tree):
     data = single_project_session_acquisition_tree
 
-    my_collection_id = create_collection(api_as_user)
-    get_collection(api_as_user, my_collection_id)
-    add_session_to_collection(api_as_user, data.sid, my_collection_id)
+    my_collection_id = create_collection(as_user)
+    get_collection(as_user, my_collection_id)
+    add_session_to_collection(as_user, data.sid, my_collection_id)
 
-    r = api_as_user.get('/acquisitions/' + data.aid)
+    r = as_user.get('/acquisitions/' + data.aid)
     collections = json.loads(r.content)['collections']
     assert my_collection_id in collections
 
-    delete_collection(api_as_user, my_collection_id)
+    delete_collection(as_user, my_collection_id)
 
-    r = api_as_user.get('/collections/' + my_collection_id)
+    r = as_user.get('/collections/' + my_collection_id)
     assert r.status_code == 404
 
-    r = api_as_user.get('/acquisitions/' + data.aid)
+    r = as_user.get('/acquisitions/' + data.aid)
     collections = json.loads(r.content)['collections']
     assert my_collection_id not in collections
 
 
 # This fixture sets up a single project->session->acquisition hierarchy in the db
 @pytest.fixture(scope="module")
-def single_project_session_acquisition_tree(api_as_admin, request, bunch, data_builder):
+def single_project_session_acquisition_tree(as_admin, request, bunch, data_builder):
 
     pid = data_builder.create_project('scitran')
     sid = data_builder.create_session(pid)

--- a/test/integration_tests/python/test_containers.py
+++ b/test/integration_tests/python/test_containers.py
@@ -9,7 +9,7 @@ log.addHandler(sh)
 
 
 @pytest.fixture(scope="module")
-def with_two_groups(api_as_admin, bunch, request, data_builder):
+def with_two_groups(as_admin, bunch, request, data_builder):
     group_1 = data_builder.create_group('test_group_' + str(int(time.time() * 1000)))
     group_2 = data_builder.create_group('test_group_' + str(int(time.time() * 1000)))
 
@@ -29,25 +29,25 @@ def with_two_groups(api_as_admin, bunch, request, data_builder):
 # Add it to a group
 # Switch the project to the second group
 # Delete the project
-def test_switching_project_between_groups(with_two_groups, data_builder, api_as_user):
+def test_switching_project_between_groups(with_two_groups, data_builder, as_user):
     data = with_two_groups
 
     pid = data_builder.create_project(data.group_1)
-    assert api_as_user.get('/projects/' + pid).ok
-    r = api_as_user.get('/groups/' + data.group_1 + '/projects')
+    assert as_user.get('/projects/' + pid).ok
+    r = as_user.get('/groups/' + data.group_1 + '/projects')
     print json.loads(r.content)
 
     payload = json.dumps({'group': with_two_groups.group_2})
-    r = api_as_user.put('/projects/' + pid, data=payload)
+    r = as_user.put('/projects/' + pid, data=payload)
     assert r.ok
 
-    r = api_as_user.get('/projects/' + pid)
+    r = as_user.get('/projects/' + pid)
     assert r.ok and json.loads(r.content)['group'] == data.group_2
 
     data_builder.delete_project(pid)
 
 
-def test_switching_session_between_projects(with_two_groups, data_builder, api_as_user):
+def test_switching_session_between_projects(with_two_groups, data_builder, as_user):
     data = with_two_groups
 
     project_1_id = data_builder.create_project(data.group_1)
@@ -55,10 +55,10 @@ def test_switching_session_between_projects(with_two_groups, data_builder, api_a
     session_id = data_builder.create_session(project_1_id)
 
     payload = json.dumps({'project': project_2_id})
-    r = api_as_user.put('/sessions/' + session_id, data=payload)
+    r = as_user.put('/sessions/' + session_id, data=payload)
     assert r.ok
 
-    r = api_as_user.get('/sessions/' + session_id)
+    r = as_user.get('/sessions/' + session_id)
     assert r.ok and json.loads(r.content)['project'] == project_2_id
 
     data_builder.delete_session(session_id)
@@ -66,7 +66,7 @@ def test_switching_session_between_projects(with_two_groups, data_builder, api_a
     data_builder.delete_project(project_2_id)
 
 
-def test_switching_acquisition_between_projects(with_two_groups, data_builder, api_as_user):
+def test_switching_acquisition_between_projects(with_two_groups, data_builder, as_user):
     data = with_two_groups
 
     project_id = data_builder.create_project(data.group_1)
@@ -75,10 +75,10 @@ def test_switching_acquisition_between_projects(with_two_groups, data_builder, a
     acquisition_id = data_builder.create_acquisition(session_1_id)
 
     payload = json.dumps({'session': session_2_id})
-    r = api_as_user.put('/acquisitions/' + acquisition_id, data=payload)
+    r = as_user.put('/acquisitions/' + acquisition_id, data=payload)
     assert r.ok
 
-    r = api_as_user.get('/acquisitions/' + acquisition_id)
+    r = as_user.get('/acquisitions/' + acquisition_id)
     assert r.ok and json.loads(r.content)['session'] == session_2_id
 
     data_builder.delete_acquisition(acquisition_id)

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -12,7 +12,7 @@ log.addHandler(sh)
 
 
 @pytest.fixture()
-def with_a_download_available(api_as_admin, data_builder, bunch, request):
+def with_a_download_available(as_admin, data_builder, bunch, request):
     file_name = "test.csv"
     group_id = 'test_group_' + str(int(time.time() * 1000))
 
@@ -33,17 +33,17 @@ def with_a_download_available(api_as_admin, data_builder, bunch, request):
     # facilitate download filter tests:
     # acquisition: [], session: ['plus'], project: ['plus', 'minus']
     files['metadata'] = ('', json.dumps(metadata))
-    api_as_admin.post('/acquisitions/' + acquisition_id + '/files', files=files)
+    as_admin.post('/acquisitions/' + acquisition_id + '/files', files=files)
     files['metadata'] = ('', json.dumps(dict(tags=['plus'], **metadata)))
-    api_as_admin.post('/sessions/' + session_id + '/files', files=files)
+    as_admin.post('/sessions/' + session_id + '/files', files=files)
     files['metadata'] = ('', json.dumps(dict(tags=['plus', 'minus'], **metadata)))
-    api_as_admin.post('/projects/' + project_id + '/files', files=files)
+    as_admin.post('/projects/' + project_id + '/files', files=files)
 
     def teardown_download():
-        api_as_admin.delete('/acquisitions/' + acquisition_id)
-        api_as_admin.delete('/sessions/' + session_id)
-        api_as_admin.delete('/projects/' + project_id)
-        api_as_admin.delete('/groups/' + group_id)
+        as_admin.delete('/acquisitions/' + acquisition_id)
+        as_admin.delete('/sessions/' + session_id)
+        as_admin.delete('/projects/' + project_id)
+        as_admin.delete('/groups/' + group_id)
 
     request.addfinalizer(teardown_download)
 
@@ -55,16 +55,16 @@ def with_a_download_available(api_as_admin, data_builder, bunch, request):
     return fixture_data
 
 
-def test_download(with_a_download_available, api_as_user, db):
+def test_download(with_a_download_available, as_user, db):
     data = with_a_download_available
     missing_object_id = '000000000000000000000000'
 
     # Try to download w/ nonexistent ticket
-    r = api_as_user.get('/download', params={'ticket': missing_object_id})
+    r = as_user.get('/download', params={'ticket': missing_object_id})
     assert r.status_code == 404
 
     # Retrieve a ticket for a batch download
-    r = api_as_user.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'filters': [{'tags': {
             '-': ['minus'],
@@ -80,7 +80,7 @@ def test_download(with_a_download_available, api_as_user, db):
     ticket = r.json()['ticket']
 
     # Perform the download
-    r = api_as_user.get('/download', params={'ticket': ticket})
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.ok
 
     tar_file = cStringIO.StringIO(r.content)
@@ -97,11 +97,11 @@ def test_download(with_a_download_available, api_as_user, db):
         {'$set': {'ip': '0.0.0.0'}})
     assert update_result.modified_count == 1
 
-    r = api_as_user.get('/download', params={'ticket': ticket})
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.status_code == 400
 
     # Try to retrieve a ticket referencing nonexistent containers
-    r = api_as_user.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'nodes': [
             {'level': 'project', '_id': missing_object_id},
@@ -113,24 +113,24 @@ def test_download(with_a_download_available, api_as_user, db):
 
     # Try to retrieve ticket for bulk download w/ invalid container name
     # (not project|session|acquisition)
-    r = api_as_user.post('/download', params={'bulk': 'true'}, json={
+    r = as_user.post('/download', params={'bulk': 'true'}, json={
         'files': [{'container_name': 'subject', 'container_id': missing_object_id, 'filename': 'nosuch.csv'}]
     })
     assert r.status_code == 400
 
     # Try to retrieve ticket for bulk download referencing nonexistent file
-    r = api_as_user.post('/download', params={'bulk': 'true'}, json={
+    r = as_user.post('/download', params={'bulk': 'true'}, json={
         'files': [{'container_name': 'project', 'container_id': data.project_id, 'filename': 'nosuch.csv'}]
     })
     assert r.status_code == 404
 
     # Retrieve ticket for bulk download
-    r = api_as_user.post('/download', params={'bulk': 'true'}, json={
+    r = as_user.post('/download', params={'bulk': 'true'}, json={
         'files': [{'container_name': 'project', 'container_id': data.project_id, 'filename': data.file_name}]
     })
     assert r.ok
     ticket = r.json()['ticket']
 
     # Perform the download using symlinks
-    r = api_as_user.get('/download', params={'ticket': ticket, 'symlinks': 'true'})
+    r = as_user.get('/download', params={'ticket': ticket, 'symlinks': 'true'})
     assert r.ok

--- a/test/integration_tests/python/test_errors.py
+++ b/test/integration_tests/python/test_errors.py
@@ -7,7 +7,7 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 
 
-def test_extra_param(api_as_admin):
+def test_extra_param(as_admin):
     label = 'SciTran/testing_' + str(int(time.time() * 1000))
 
     bad_payload = json.dumps({
@@ -17,10 +17,10 @@ def test_extra_param(api_as_admin):
         'extra_param': 'some_value'
     })
 
-    r = api_as_admin.post('/projects', data=bad_payload)
+    r = as_admin.post('/projects', data=bad_payload)
     assert r.status_code == 400
 
-    r = api_as_admin.get('/projects')
+    r = as_admin.get('/projects')
     assert r.ok
     projects = json.loads(r.content)
     filtered_projects = filter(lambda e: e['label'] == label, projects)

--- a/test/integration_tests/python/test_groups.py
+++ b/test/integration_tests/python/test_groups.py
@@ -8,22 +8,22 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 
 
-def test_groups(api_as_admin, data_builder):
+def test_groups(as_admin, data_builder):
     group_id = 'test_group_' + str(int(time.time() * 1000))
 
     # Cannot find a non-existant group
-    r = api_as_admin.get('/groups/' + group_id)
+    r = as_admin.get('/groups/' + group_id)
     assert r.status_code == 404
 
     data_builder.create_group(group_id)
 
     # Able to find new group
-    r = api_as_admin.get('/groups/' + group_id)
+    r = as_admin.get('/groups/' + group_id)
     assert r.ok
 
     # Able to change group name
     payload = json.dumps({'name': 'Test group'})
-    r = api_as_admin.put('/groups/' + group_id, data=payload)
+    r = as_admin.put('/groups/' + group_id, data=payload)
     assert r.ok
 
     data_builder.delete_group(group_id)

--- a/test/integration_tests/python/test_notes.py
+++ b/test/integration_tests/python/test_notes.py
@@ -8,40 +8,40 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 
 
-def test_notes(with_a_group_and_a_project, api_as_user):
+def test_notes(with_a_group_and_a_project, as_user):
     data = with_a_group_and_a_project
     notes_path = '/projects/' + data.project_id + '/notes'
 
     # Add a note
     new_note = json.dumps({'text': 'test note'})
-    r = api_as_user.post(notes_path, data=new_note)
+    r = as_user.post(notes_path, data=new_note)
     assert r.ok
 
     # Verify note is present in project
-    r = api_as_user.get('/projects/' + data.project_id)
+    r = as_user.get('/projects/' + data.project_id)
     assert r.ok
     project = json.loads(r.content)
     assert len(project['notes']) == 1
 
     note_id = project['notes'][0]['_id']
     note_path = '/projects/' + data.project_id + '/notes/' + note_id
-    r = api_as_user.get(note_path)
+    r = as_user.get(note_path)
     assert r.ok and json.loads(r.content)['_id'] == note_id
 
     # Modify note
     modified_note = json.dumps({'text': 'modified test note'})
-    r = api_as_user.put(note_path, data=modified_note)
+    r = as_user.put(note_path, data=modified_note)
     assert r.ok
 
     # Verify modified note
-    r = api_as_user.get(note_path)
+    r = as_user.get(note_path)
     assert r.ok and json.loads(r.content)['text'] == 'modified test note'
 
     # Delete note
-    r = api_as_user.delete(note_path)
+    r = as_user.delete(note_path)
     assert r.ok
 
-    r = api_as_user.get(note_path)
+    r = as_user.get(note_path)
     assert r.status_code == 404
 
 

--- a/test/integration_tests/python/test_permissions.py
+++ b/test/integration_tests/python/test_permissions.py
@@ -8,7 +8,7 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 
 
-def test_permissions(with_a_group_and_a_project, api_as_admin):
+def test_permissions(with_a_group_and_a_project, as_admin):
     data = with_a_group_and_a_project
     permissions_path = '/projects/' + data.project_id + '/permissions'
     user_1_local_path = permissions_path + '/local/' + data.user_1
@@ -16,7 +16,7 @@ def test_permissions(with_a_group_and_a_project, api_as_admin):
     user_2_another_path = permissions_path + '/another/' + data.user_2
 
     # GET is not allowed for general permissions path
-    r = api_as_admin.get(permissions_path)
+    r = as_admin.get(permissions_path)
     assert r.status_code == 405
 
     # Add permissions for user 1
@@ -25,11 +25,11 @@ def test_permissions(with_a_group_and_a_project, api_as_admin):
         'site': 'local',
         'access': 'ro'
     })
-    r = api_as_admin.post(permissions_path, data=payload)
+    r = as_admin.post(permissions_path, data=payload)
     assert r.ok
 
     # Verify permissions for user 1
-    r = api_as_admin.get(user_1_local_path)
+    r = as_admin.get(user_1_local_path)
     assert r.ok
     content = json.loads(r.content)
     assert content['_id'] == data.user_1
@@ -40,7 +40,7 @@ def test_permissions(with_a_group_and_a_project, api_as_admin):
     payload = json.dumps({
         'access': 'admin'
     })
-    r = api_as_admin.put(user_1_local_path, data=payload)
+    r = as_admin.put(user_1_local_path, data=payload)
     assert r.ok
 
     # Add user 2 to have ro access
@@ -49,25 +49,25 @@ def test_permissions(with_a_group_and_a_project, api_as_admin):
         'site': 'local',
         'access': 'ro'
     })
-    r = api_as_admin.post(permissions_path, data=payload)
+    r = as_admin.post(permissions_path, data=payload)
     assert r.ok
 
     # Attempt to change user 2's id to user 1
     payload = json.dumps({
         '_id': data.user_1
     })
-    r = api_as_admin.put(user_2_local_path, data=payload)
+    r = as_admin.put(user_2_local_path, data=payload)
     assert r.status_code == 404
 
     # Change user 2's site
     payload = json.dumps({
         'site': 'another'
     })
-    r = api_as_admin.put(user_2_local_path, data=payload)
+    r = as_admin.put(user_2_local_path, data=payload)
     assert r.ok
 
     # Verify user 2's site changed
-    r = api_as_admin.get(user_2_another_path)
+    r = as_admin.get(user_2_another_path)
     assert r.ok
     content = json.loads(r.content)
     assert content['_id'] == data.user_2
@@ -75,9 +75,9 @@ def test_permissions(with_a_group_and_a_project, api_as_admin):
     assert content['access'] == 'ro'
 
     # Delete user 2
-    r = api_as_admin.delete(user_2_another_path)
+    r = as_admin.delete(user_2_another_path)
     assert r.ok
 
     # Ensure user 2 is gone
-    r = api_as_admin.get(user_2_another_path)
+    r = as_admin.get(user_2_another_path)
     assert r.status_code == 404

--- a/test/integration_tests/python/test_propagation.py
+++ b/test/integration_tests/python/test_propagation.py
@@ -9,7 +9,7 @@ log.addHandler(sh)
 
 
 # Test changing propagated properties
-def test_archived_propagation_from_project(with_hierarchy, data_builder, api_as_admin):
+def test_archived_propagation_from_project(with_hierarchy, data_builder, as_admin):
     """
     Tests:
       - 'archived' is a propagated property
@@ -20,19 +20,19 @@ def test_archived_propagation_from_project(with_hierarchy, data_builder, api_as_
     data = with_hierarchy
 
     payload = json.dumps({'archived': True})
-    r = api_as_admin.put('/projects/' + data.project, data=payload)
+    r = as_admin.put('/projects/' + data.project, data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     assert r.ok and json.loads(r.content)['archived']
 
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     assert r.ok and json.loads(r.content)['archived']
 
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok and json.loads(r.content)['archived']
 
-def test_public_propagation_from_project(with_hierarchy, data_builder, api_as_admin):
+def test_public_propagation_from_project(with_hierarchy, data_builder, as_admin):
     """
     Tests:
       - 'public' is a propagated property
@@ -40,19 +40,19 @@ def test_public_propagation_from_project(with_hierarchy, data_builder, api_as_ad
     data = with_hierarchy
 
     payload = json.dumps({'public': False})
-    r = api_as_admin.put('/projects/' + data.project, data=payload)
+    r = as_admin.put('/projects/' + data.project, data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     assert r.ok and not json.loads(r.content)['public']
 
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     assert r.ok and not json.loads(r.content)['public']
 
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok and not json.loads(r.content)['public']
 
-def test_public_and_archived_propagation_from_project(with_hierarchy, data_builder, api_as_admin):
+def test_public_and_archived_propagation_from_project(with_hierarchy, data_builder, as_admin):
     """
     Tests:
       - set logic for setting all of the propagated properties
@@ -60,22 +60,22 @@ def test_public_and_archived_propagation_from_project(with_hierarchy, data_build
     data = with_hierarchy
 
     payload = json.dumps({'public': False, 'archived': False})
-    r = api_as_admin.put('/projects/' + data.project, data=payload)
+    r = as_admin.put('/projects/' + data.project, data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     content = json.loads(r.content)
     assert r.ok and content['public'] == False and content['archived'] == False
 
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     content = json.loads(r.content)
     assert r.ok and content['public'] == False and content['archived'] == False
 
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     content = json.loads(r.content)
     assert r.ok and content['public'] == False and content['archived'] == False
 
-def test_public_propagation_from_session(with_hierarchy, data_builder, api_as_admin):
+def test_public_propagation_from_session(with_hierarchy, data_builder, as_admin):
     """
     Tests:
       - propagation works from a session level
@@ -83,16 +83,16 @@ def test_public_propagation_from_session(with_hierarchy, data_builder, api_as_ad
     data = with_hierarchy
 
     payload = json.dumps({'archived': True})
-    r = api_as_admin.put('/sessions/' + data.session, data=payload)
+    r = as_admin.put('/sessions/' + data.session, data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     assert r.ok and json.loads(r.content)['archived']
 
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok and json.loads(r.content)['archived']
 
-def test_set_public_acquisition(with_hierarchy, data_builder, api_as_admin):
+def test_set_public_acquisition(with_hierarchy, data_builder, as_admin):
     """
     Tests:
       - setting a propagated property on an acquisition does not attempt to propagate (would hit Exception)
@@ -100,12 +100,12 @@ def test_set_public_acquisition(with_hierarchy, data_builder, api_as_admin):
     data = with_hierarchy
 
     payload = json.dumps({'archived': True})
-    r = api_as_admin.put('/acquisitions/' + data.acquisition, data=payload)
+    r = as_admin.put('/acquisitions/' + data.acquisition, data=payload)
     assert r.ok
 
 
 # Test propagation of project permission changes
-def test_add_and_remove_user_for_project_permissions(with_hierarchy, data_builder, api_as_admin):
+def test_add_and_remove_user_for_project_permissions(with_hierarchy, data_builder, as_admin):
     """
     Tests:
       - changing permissions at a project level triggers propagation
@@ -124,66 +124,66 @@ def test_add_and_remove_user_for_project_permissions(with_hierarchy, data_builde
 
     # Add user to project permissions
     payload = json.dumps({'_id': user_id, 'access': 'admin', 'site': 'local'})
-    r = api_as_admin.post('/projects/' + data.project + '/permissions', data=payload)
+    r = as_admin.post('/projects/' + data.project + '/permissions', data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user
 
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user
 
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user
 
     # Modify user permissions
     payload = json.dumps({'access': 'rw', '_id': user_id})
-    r = api_as_admin.put('/projects/' + data.project + '/permissions/local/' + user_id, data=payload)
+    r = as_admin.put('/projects/' + data.project + '/permissions/local/' + user_id, data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user is not None and user['access'] == 'rw'
 
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user is not None and user['access'] == 'rw'
 
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user is not None and user['access'] == 'rw'
 
     # Remove user from project permissions
-    r = api_as_admin.delete('/projects/' + data.project + '/permissions/local/' + user_id, data=payload)
+    r = as_admin.delete('/projects/' + data.project + '/permissions/local/' + user_id, data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user is None
 
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user is None
 
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     perms = json.loads(r.content)['permissions']
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user is None
 
 
 # Test tag pool renaming and deletion
-def test_add_rename_remove_group_tag(with_hierarchy, data_builder, api_as_admin):
+def test_add_rename_remove_group_tag(with_hierarchy, data_builder, as_admin):
     """
     Tests:
       - propagation from the group level
@@ -198,47 +198,47 @@ def test_add_rename_remove_group_tag(with_hierarchy, data_builder, api_as_admin)
 
     # Add tag to hierarchy
     payload = json.dumps({'value': tag})
-    r = api_as_admin.post('/groups/' + data.group + '/tags', data=payload)
+    r = as_admin.post('/groups/' + data.group + '/tags', data=payload)
     assert r.ok
-    r = api_as_admin.post('/projects/' + data.project + '/tags', data=payload)
+    r = as_admin.post('/projects/' + data.project + '/tags', data=payload)
     assert r.ok
-    r = api_as_admin.post('/sessions/' + data.session + '/tags', data=payload)
+    r = as_admin.post('/sessions/' + data.session + '/tags', data=payload)
     assert r.ok
-    r = api_as_admin.post('/acquisitions/' + data.acquisition + '/tags', data=payload)
+    r = as_admin.post('/acquisitions/' + data.acquisition + '/tags', data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/groups/' + data.group)
+    r = as_admin.get('/groups/' + data.group)
     assert r.ok and tag in json.loads(r.content)['tags']
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     assert r.ok and tag in json.loads(r.content)['tags']
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     assert r.ok and tag in json.loads(r.content)['tags']
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok and tag in json.loads(r.content)['tags']
 
     # Rename tag
     payload = json.dumps({'value': tag_renamed})
-    r = api_as_admin.put('/groups/' + data.group + '/tags/' + tag, data=payload)
+    r = as_admin.put('/groups/' + data.group + '/tags/' + tag, data=payload)
     assert r.ok
 
-    r = api_as_admin.get('/groups/' + data.group)
+    r = as_admin.get('/groups/' + data.group)
     assert r.ok and tag_renamed in json.loads(r.content)['tags']
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     assert r.ok and tag_renamed in json.loads(r.content)['tags']
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     assert r.ok and tag_renamed in json.loads(r.content)['tags']
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok and tag_renamed in json.loads(r.content)['tags']
 
     # Delete tag
-    r = api_as_admin.delete('/groups/' + data.group + '/tags/' + tag_renamed)
+    r = as_admin.delete('/groups/' + data.group + '/tags/' + tag_renamed)
     assert r.ok
 
-    r = api_as_admin.get('/groups/' + data.group)
+    r = as_admin.get('/groups/' + data.group)
     assert r.ok and tag_renamed not in json.loads(r.content)['tags']
-    r = api_as_admin.get('/projects/' + data.project)
+    r = as_admin.get('/projects/' + data.project)
     assert r.ok and tag_renamed not in json.loads(r.content)['tags']
-    r = api_as_admin.get('/sessions/' + data.session)
+    r = as_admin.get('/sessions/' + data.session)
     assert r.ok and tag_renamed not in json.loads(r.content)['tags']
-    r = api_as_admin.get('/acquisitions/' + data.acquisition)
+    r = as_admin.get('/acquisitions/' + data.acquisition)
     assert r.ok and tag_renamed not in json.loads(r.content)['tags']

--- a/test/integration_tests/python/test_roles.py
+++ b/test/integration_tests/python/test_roles.py
@@ -6,22 +6,21 @@ import pytest
 
 
 @pytest.fixture()
-def with_a_group_and_a_user(data_builder, api_as_admin, request, bunch):
+def with_a_group_and_a_user(data_builder, as_admin, request, bunch):
     user_id = 'other@user.com'
     group_id = 'test_group_' + str(int(time.time() * 1000))
     data_builder.create_group(group_id)
 
-    payload = json.dumps({
+    r = as_admin.post('/users', json={
         '_id': user_id,
         'firstname': 'Other',
         'lastname': 'User',
     })
-    r = api_as_admin.post('/users', data=payload)
     assert r.ok
 
     def teardown_db():
         data_builder.delete_group(group_id)
-        api_as_admin.delete('/users/' + user_id)
+        as_admin.delete('/users/' + user_id)
 
     request.addfinalizer(teardown_db)
 
@@ -39,66 +38,68 @@ def create_role_payload(user, site, access):
     })
 
 
-def test_roles(api_as_admin, with_a_group_and_a_user, api_accessor, db):
+def test_roles(as_admin, with_a_group_and_a_user, as_public, db):
     data = with_a_group_and_a_user
-    user_api_key = "4hOn5aBx/nUiI0blDbTUPpKQsEbEn74rH9z5KctlXw6GrMKdicPGXKQg"
-    api_key_doc = {
-        "key":user_api_key,
-        "created":datetime.datetime.utcnow()
-    }
+
+    api_key = '4hOn5aBx/nUiI0blDbTUPpKQsEbEn74rH9z5KctlXw6GrMKdicPGXKQg'
     update_result = db.users.update_one(
-        {"_id":data.user_id},
-        {"$set":{"api_key":api_key_doc}}
-        )
+        {'_id': data.user_id},
+        {'$set': {'api_key': {
+            'key': api_key,
+            'created': datetime.datetime.utcnow()
+        }}}
+    )
     assert update_result.modified_count == 1
-    api_as_other_user = api_accessor(user_api_key)
+
+    as_other_user = as_public
+    as_other_user.headers.update({'Authorization': 'scitran-user ' + api_key})
 
     roles_path = '/groups/' + data.group_id + '/roles'
     local_user_roles_path = roles_path + '/local/' + data.user_id
     admin_user_roles_path = roles_path + '/local/' + 'admin@user.com'
 
     # Cannot retrieve roles that don't exist
-    r = api_as_admin.get(local_user_roles_path)
+    r = as_admin.get(local_user_roles_path)
     assert r.status_code == 404
 
     # Create role for user
     payload = create_role_payload(data.user_id, 'local', 'rw')
-    r = api_as_admin.post(roles_path, data=payload)
+    r = as_admin.post(roles_path, data=payload)
     assert r.ok
 
     # Verify new user role
-    r = api_as_admin.get(local_user_roles_path)
+    r = as_admin.get(local_user_roles_path)
     assert r.ok
     content = json.loads(r.content)
     assert content['access'] == 'rw'
     assert content['_id'] == data.user_id
 
     # 'rw' users cannot access other user roles
-    r = api_as_other_user.get(admin_user_roles_path)
+    r = as_other_user.get(admin_user_roles_path)
     assert r.status_code == 403
 
     # Upgrade user to admin
     payload = json.dumps({'access': 'admin'})
-    r = api_as_admin.put(local_user_roles_path, data=payload)
+    r = as_admin.put(local_user_roles_path, data=payload)
     assert r.ok
 
     # User should now be able to access other roles
-    r = api_as_other_user.get(admin_user_roles_path)
+    r = as_other_user.get(admin_user_roles_path)
     assert r.ok
 
     # Change user back to 'rw' access
     payload = json.dumps({'access': 'rw'})
-    r = api_as_admin.put(local_user_roles_path, data=payload)
+    r = as_admin.put(local_user_roles_path, data=payload)
     assert r.ok
 
     # User is now forbidden again
-    r = api_as_other_user.get(admin_user_roles_path)
+    r = as_other_user.get(admin_user_roles_path)
     assert r.status_code == 403
 
     # Delete role
-    r = api_as_admin.delete(local_user_roles_path)
+    r = as_admin.delete(local_user_roles_path)
     assert r.ok
 
     # Verify delete
-    r = api_as_admin.get(local_user_roles_path)
+    r = as_admin.get(local_user_roles_path)
     assert r.status_code == 404

--- a/test/integration_tests/python/test_tags.py
+++ b/test/integration_tests/python/test_tags.py
@@ -6,7 +6,7 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 
 
-def test_tags(with_a_group_and_a_project, api_as_admin):
+def test_tags(with_a_group_and_a_project, as_admin):
     data = with_a_group_and_a_project
     tag = 'test_tag'
     new_tag = 'new_test_tag'
@@ -21,63 +21,63 @@ def test_tags(with_a_group_and_a_project, api_as_admin):
     short_tag_path = tags_path + '/' + short_tag
 
     # Add tag and verify
-    r = api_as_admin.get(tag_path)
+    r = as_admin.get(tag_path)
     assert r.status_code == 404
     payload = json.dumps({'value': tag})
-    r = api_as_admin.post(tags_path, data=payload)
+    r = as_admin.post(tags_path, data=payload)
     assert r.ok
-    r = api_as_admin.get(tag_path)
+    r = as_admin.get(tag_path)
     assert r.ok
     assert json.loads(r.content) == tag
 
     # Add new tag and verify
     payload = json.dumps({'value': new_tag})
-    r = api_as_admin.post(tags_path, data=payload)
+    r = as_admin.post(tags_path, data=payload)
     assert r.ok
     # Add a duplicate tag, returns 404
     payload = json.dumps({'value': new_tag})
-    r = api_as_admin.post(tags_path, data=payload)
+    r = as_admin.post(tags_path, data=payload)
     assert r.status_code == 409
-    r = api_as_admin.get(new_tag_path)
+    r = as_admin.get(new_tag_path)
     assert r.ok
     assert json.loads(r.content) == new_tag
 
     # Add short tag and verify
     payload = json.dumps({'value': short_tag})
-    r = api_as_admin.post(tags_path, data=payload)
+    r = as_admin.post(tags_path, data=payload)
     assert r.ok
     # Add too long tag and verify
     payload = json.dumps({'value': too_long_tag})
-    r = api_as_admin.post(tags_path, data=payload)
+    r = as_admin.post(tags_path, data=payload)
     assert r.status_code == 400
 
     # Attempt to update tag, returns 404
     payload = json.dumps({'value': new_tag})
-    r = api_as_admin.put(tag_path, data=payload)
+    r = as_admin.put(tag_path, data=payload)
     assert r.status_code == 404
 
     # Update existing tag to other_tag
-    r = api_as_admin.get(other_tag_path)
+    r = as_admin.get(other_tag_path)
     assert r.status_code == 404
     payload = json.dumps({'value': other_tag})
-    r = api_as_admin.put(tag_path, data=payload)
+    r = as_admin.put(tag_path, data=payload)
     assert r.ok
-    r = api_as_admin.get(other_tag_path)
+    r = as_admin.get(other_tag_path)
     assert r.ok
     assert json.loads(r.content) == other_tag
-    r = api_as_admin.get(tag_path)
+    r = as_admin.get(tag_path)
     assert r.status_code == 404
 
     # Cleanup
-    r = api_as_admin.delete(other_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
+    r = as_admin.delete(other_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = api_as_admin.get(other_tag_path)
+    r = as_admin.get(other_tag_path)
     assert r.status_code == 404
-    r = api_as_admin.delete(new_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
+    r = as_admin.delete(new_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = api_as_admin.get(new_tag_path)
+    r = as_admin.get(new_tag_path)
     assert r.status_code == 404
-    r = api_as_admin.delete(short_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
+    r = as_admin.delete(short_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = api_as_admin.get(short_tag_path)
+    r = as_admin.get(short_tag_path)
     assert r.status_code == 404

--- a/test/integration_tests/python/test_users.py
+++ b/test/integration_tests/python/test_users.py
@@ -6,15 +6,15 @@ sh = logging.StreamHandler()
 log.addHandler(sh)
 
 
-def test_users(api_as_admin):
+def test_users(as_admin):
     new_user_id = 'new@user.com'
 
     # List users
-    r = api_as_admin.get('/users')
+    r = as_admin.get('/users')
     assert r.ok
 
     # Get self
-    r = api_as_admin.get('/users/self')
+    r = as_admin.get('/users/self')
     assert r.ok
 
     # Try adding new user missing required attr
@@ -23,30 +23,30 @@ def test_users(api_as_admin):
         'lastname': 'Doe',
         'email': 'jane.doe@gmail.com',
     })
-    r = api_as_admin.post('/users', data=payload)
+    r = as_admin.post('/users', data=payload)
     assert r.status_code == 400
     assert "'firstname' is a required property" in r.text
 
     # Add new user
-    r = api_as_admin.get('/users/' + new_user_id)
+    r = as_admin.get('/users/' + new_user_id)
     assert r.status_code == 404
     payload = json.dumps({
         '_id': new_user_id,
         'firstname': 'New',
         'lastname': 'User',
     })
-    r = api_as_admin.post('/users', data=payload)
+    r = as_admin.post('/users', data=payload)
     assert r.ok
-    r = api_as_admin.get('/users/' + new_user_id)
+    r = as_admin.get('/users/' + new_user_id)
     assert r.ok
 
     # Modify existing user
     payload = json.dumps({
         'firstname': 'Realname'
     })
-    r = api_as_admin.put('/users/' + new_user_id, data=payload)
+    r = as_admin.put('/users/' + new_user_id, data=payload)
     assert r.ok
 
     # Cleanup
-    r = api_as_admin.delete('/users/' + new_user_id)
+    r = as_admin.delete('/users/' + new_user_id)
     assert r.ok


### PR DESCRIPTION
Context: [comments](https://github.com/scitran/core/compare/port-tests-from-fixture-api_as_admin-to-as_admin?expand=1#diff-7efe753e7372f603a4a51a7844e67980L3) [in](https://github.com/scitran/core/compare/port-tests-from-fixture-api_as_admin-to-as_admin?expand=1#diff-7efe753e7372f603a4a51a7844e67980L24) `tests/integration_tests/python/basics.py` indicated that [RequestsAccessor](https://github.com/scitran/core/compare/port-tests-from-fixture-api_as_admin-to-as_admin?expand=1#diff-4cfc2d319d5834744d4ada14c9d00b20L44) is obsolete. I was adding new tests with the preferred new fixtures from `basics.py` that are not relying on RequestsAccessor.

The fixture schism started getting messy and hindering test cov progress. Ported all old api_as_* fixture usages.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
