### PR TITLE
Optionally join in gear name on job docs in containerhandler

### DIFF
--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -117,7 +117,11 @@ class ContainerHandler(base.RequestHandler):
         """
 
         # If `join=origin` passed as a request param, join out that key
-        join_origin = 'origin' in self.request.params.getall('join')
+        join_origin    = 'origin' in self.request.params.getall('join')
+
+        # Now that gears are identified by ID rather than name, the origin.job.gear_id is not enough.
+        # Joining the whole gear doc in feels like overkill; for now let's just add gear names to jobs
+        join_gear_name = 'origin_job_gear_name' in self.request.params.getall('join')
 
         # If it was requested, create a map of each type of origin to hold the join
         if join_origin:
@@ -148,7 +152,17 @@ class ContainerHandler(base.RequestHandler):
 
                 # Join from database if we haven't for this origin before
                 if j_type != 'unknown' and result['join-origin'][j_type].get(j_id, None) is None:
-                    result['join-origin'][j_type][j_id] = config.db[j_type + 's'].find_one({'_id': j_id_b})
+                    # Initial join
+                    join_doc = config.db[j_type + 's'].find_one({'_id': j_id_b})
+
+                    # Join in gear name on the job doc if requested
+                    if join_gear_name and j_type == 'job':
+                        gear_id_bson = bson.ObjectId(join_doc['gear_id'])
+                        gear = config.db.gears.find_one({'_id': gear_id_bson})
+                        join_doc['gear_name'] = gear['gear']['name']
+
+                    # Save to join table
+                    result['join-origin'][j_type][j_id] = join_doc
 
         return result
 


### PR DESCRIPTION
This addition is useful for knowing the name of the gear when asking for container origin joins.
Does not join the whole gear doc in, though that could happen if desired.

Following the same pattern as before, just add `join=origin_job_gear_name` to your request.

Before:
```
$ 'api/sessions/<id>/acquisitions?join=origin' \
  | jq -r '.[]."join-origin".job | .[] | .gear_id + " " + .gear_name'

58d542de31b1540016f9aefe 
58d542de31b1540016f9aefe 
58d542de31b1540019f9aeff 
58d542de31b1540016f9aefe
```

After:
```
$ 'api/sessions/<id>/acquisitions?join=origin&join=origin_job_gear_name' \
  | jq -r '.[]."join-origin".job | .[] | .gear_id + " " + .gear_name'

58d542de31b1540016f9aefe dcm2niix
58d542de31b1540016f9aefe dcm2niix
58d542de31b1540019f9aeff qa-report-fmri
58d542de31b1540016f9aefe dcm2niix
```

Tagging in @ryansanford for any performance concerns.
One additional DB call per job involving the container.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
