### PR TITLE
increase coverage of api/handlers/containerhandler.py

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -203,9 +203,6 @@ endpoints = [
             route('/<cid:{cid}>/subject',       ContainerHandler, h='get_subject',  m=['GET']),
         ]),
 
-        route('/sessions/<cid:{cid}>/jobs',    ContainerHandler, h='get_jobs', m=['GET']),
-        route('/sessions/<cid:{cid}>/jobs',    ContainerHandler, h='get_jobs', m=['GET']),
-
 
         # Collections
 

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -90,7 +90,7 @@ class ContainerHandler(base.RequestHandler):
         _id = kwargs.get('cid')
         self.config = self.container_handler_configurations[cont_name]
         self.storage = self.config['storage']
-        container= self._get_container(_id)
+        container = self._get_container(_id)
 
         permchecker = self._get_permchecker(container)
         try:
@@ -234,9 +234,9 @@ class ContainerHandler(base.RequestHandler):
         if join_cont:
             # create a map of analyses and acquisitions by _id
             containers = dict((str(c['_id']), c) for c in analyses+acquisitions)
-            for c in containers:
+            for container in containers.itervalues():
                 # No need to return perm arrays
-                c.pop('permissions', None)
+                container.pop('permissions', None)
             response['containers'] = containers
 
         return response
@@ -245,7 +245,7 @@ class ContainerHandler(base.RequestHandler):
         self.config = self.container_handler_configurations[cont_name]
         self.storage = self.config['storage']
 
-        projection = self.config['list_projection']
+        projection = self.config['list_projection'].copy()
         if self.is_true('info'):
             projection.pop('info')
             if not projection:
@@ -307,7 +307,7 @@ class ContainerHandler(base.RequestHandler):
     def _add_results_counts(self, results, cont_name):
         dbc_name = self.config.get('children_cont')
         el_cont_name = cont_name[:-1]
-        dbc = config.db.get(dbc_name)
+        dbc = config.db[dbc_name]
         counts =  dbc.aggregate([
             {'$match': {el_cont_name: {'$in': [res['_id'] for res in results]}}},
             {'$group': {'_id': '$' + el_cont_name, 'count': {"$sum": 1}}}

--- a/test/integration_tests/python/states.py
+++ b/test/integration_tests/python/states.py
@@ -76,7 +76,7 @@ test_gear = {
 
 
 @pytest.fixture(scope='module')
-def with_gear(request, as_admin):
+def with_gear(request, as_admin, db):
     gear_name = 'test-gear'
     gear_data = copy.deepcopy(test_gear)
     gear_data['gear']['name'] = gear_name
@@ -86,6 +86,7 @@ def with_gear(request, as_admin):
     gear_id = r.json()['_id']
 
     def teardown_db():
+        db.jobs.delete_many({'gear_id': gear_id})
         r = as_admin.delete('/gears/' + gear_id)
         assert r.ok
 

--- a/test/integration_tests/python/test_containers.py
+++ b/test/integration_tests/python/test_containers.py
@@ -200,7 +200,7 @@ def test_get_container(with_hierarchy, as_user, as_public):
     assert 'join-origin' in r.json()
 
 
-def test_get_session_jobs(with_hierarchy, with_gear, as_user, db):
+def test_get_session_jobs(with_hierarchy, with_gear, as_user):
     data = with_hierarchy
     gear = with_gear
 
@@ -222,10 +222,6 @@ def test_get_session_jobs(with_hierarchy, with_gear, as_user, db):
 
     r = as_user.get('/sessions/' + data.session + '/jobs', params={'join': 'containers'})
     assert r.ok
-
-    # TODO figure out better/generalized way to handle state cleanup
-    # make sure other tests start clean w/o existing jobs (eg for /jobs/next to work as expected)
-    db.jobs.delete_many({'gear_id': gear})
 
 
 def test_post_container(with_hierarchy, as_user):

--- a/test/integration_tests/python/test_containers.py
+++ b/test/integration_tests/python/test_containers.py
@@ -126,3 +126,140 @@ def test_project_template(with_hierarchy, data_builder, as_user):
     assert r.json()['satisfies_template'] == False
 
     data_builder.delete_acquisition(acquisition_id)
+
+    # delete project template
+    r = as_user.delete('/projects/' + data.project + '/template')
+    assert r.ok
+
+
+def test_get_all_containers(with_hierarchy, as_public):
+    data = with_hierarchy
+
+    # get all projects w/ info=true
+    r = as_public.get('/projects', params={'info': 'true'})
+    assert r.ok
+
+    # get all projects w/ counts=true
+    r = as_public.get('/projects', params={'counts': 'true'})
+    assert r.ok
+    assert all('session_count' in proj for proj in r.json())
+
+    # get all sessions for project w/ measurements=true and stats=true
+    r = as_public.get('/projects/' + data.project + '/sessions', params={
+        'measurements': 'true',
+        'stats': 'true'
+    })
+    assert r.ok
+
+
+def test_get_all_for_user(as_user, as_public):
+    r = as_user.get('/users/self')
+    user_id = r.json()['_id']
+
+    # try to get containers for user w/o logging in
+    r = as_public.get('/users/' + user_id + '/sessions')
+    assert r.status_code == 403
+
+    # get containers for user
+    r = as_user.get('/users/' + user_id + '/sessions')
+    assert r.ok
+
+
+def test_get_container(with_hierarchy, as_user, as_public):
+    data = with_hierarchy
+
+    # NOTE cannot reach APIStorageException - wanted to cover 400 error w/ invalid oid
+    # but then realized that api.py's cid regex makes this an invalid route resulting in 404
+
+    # try to get container w/ invalid object id
+    # r = as_user.get('/projects/test')
+    # assert r.status_code == 400
+
+    # try to get container w/ nonexistent object id
+    r = as_public.get('/projects/000000000000000000000000')
+    assert r.status_code == 404
+
+    # get container
+    r = as_public.get('/projects/' + data.project)
+    assert r.ok
+
+    # get container w/ ?paths=true
+    r = as_user.post('/projects/' + data.project + '/files', files={
+        'file': ('test.csv', 'header\nrow1\n'),
+        'metadata': ('', json.dumps({'name': 'test.csv', 'type': 'csv'}))
+    })
+    assert r.ok
+
+    r = as_public.get('/projects/' + data.project, params={'paths': 'true'})
+    assert r.ok
+    assert all('path' in f for f in r.json()['files'])
+
+    # get container w/ ?join=origin
+    r = as_public.get('/projects/' + data.project, params={'join': 'origin'})
+    assert r.ok
+    assert 'join-origin' in r.json()
+
+
+def test_get_session_jobs(with_hierarchy, with_gear, as_user, db):
+    data = with_hierarchy
+    gear = with_gear
+
+    # get session jobs w/ analysis and job
+    r = as_user.post('/sessions/' + data.session + '/analyses', params={'job': 'true'}, json={
+        'analysis': {'label': 'test analysis'},
+        'job': {
+            'gear_id': gear,
+            'inputs': {
+                'dicom': {
+                    'type': 'acquisition',
+                    'id': data.acquisition,
+                    'name': 'test.dcm'
+                }
+            }
+        }
+    })
+    assert r.ok
+
+    r = as_user.get('/sessions/' + data.session + '/jobs', params={'join': 'containers'})
+    assert r.ok
+
+    # TODO figure out better/generalized way to handle state cleanup
+    # make sure other tests start clean w/o existing jobs (eg for /jobs/next to work as expected)
+    db.jobs.delete_many({'gear_id': gear})
+
+
+def test_post_container(with_hierarchy, as_user):
+    data = with_hierarchy
+
+    # create project w/ param inherit=true
+    r = as_user.post('/projects', params={'inherit': 'true'}, json={
+        'group': data.group,
+        'label': 'test-inheritance-project'
+    })
+    assert r.ok
+    as_user.delete('/projects/' + r.json()['_id'])
+
+    # create session w/ timestamp
+    r = as_user.post('/sessions', json={
+        'project': data.project,
+        'label': 'test-timestamp-session',
+        'timestamp': '1979-01-01T00:00:00+00:00'
+    })
+    assert r.ok
+    as_user.delete('/sessions/' + r.json()['_id'])
+
+
+def test_put_container(with_hierarchy, as_user):
+    data = with_hierarchy
+
+    # update session w/ timestamp
+    r = as_user.put('/sessions/' + data.session, json={
+        'timestamp': '1979-01-01T00:00:00+00:00'
+    })
+    assert r.ok
+
+    # update subject w/ oid
+    r = as_user.put('/sessions/' + data.session, json={
+        'subject': {'_id': '000000000000000000000000'}
+    })
+    assert r.ok

--- a/test/integration_tests/python/test_jobs.py
+++ b/test/integration_tests/python/test_jobs.py
@@ -28,7 +28,7 @@ def test_jobs_access(as_user):
     assert r.status_code == 403
 
 
-def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin):
+def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin, db):
     data = with_hierarchy
     gear = with_gear
     invalid_gear = with_invalid_gear
@@ -94,3 +94,5 @@ def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin):
 
     r = as_user.post('/jobs/' + job1_id + '/retry')
     assert r.ok
+
+    db.jobs.delete_many({'gear_id': gear})

--- a/test/integration_tests/python/test_jobs.py
+++ b/test/integration_tests/python/test_jobs.py
@@ -28,7 +28,7 @@ def test_jobs_access(as_user):
     assert r.status_code == 403
 
 
-def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin, db):
+def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin):
     data = with_hierarchy
     gear = with_gear
     invalid_gear = with_invalid_gear
@@ -94,5 +94,3 @@ def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin, d
 
     r = as_user.post('/jobs/' + job1_id + '/retry')
     assert r.ok
-
-    db.jobs.delete_many({'gear_id': gear})


### PR DESCRIPTION
Closes #722 

```
Name                            Stmts   Miss  Cover   Missing
------------------------------------------------------------------
api/handlers/containerhandler.py  346     22    94%   99-100, 102, 135, 147, 204, 265, 268, 278, 337-338, 340, 382, 435-436, 441, 459-460, 465, 540, 549, 553
```

Found+fixed 3 minor bugs:
- GET /session/{sessionId}/jobs?join=containers - pop permissions from dict instead of _id
- GET /{containerName}?info=true - pop info from projection.copy() (otherwise server state and subsequent GETs change!)
- GET /{containerName}?count=true - DataBase has no get method

Missing coverage:
- 99-100: I _think_ it's unreachable due to api.py routes. TBD! More like this below.
- 102: Couldn't reach, need more info.
- 135,147: Effort. Also need info on how one can have missing/different origin via the api.
- 204: Effort - would be nice to have the updated data_builder.
- 265,268: Possibly unreachable due to api routes?
- 278: Effort - data_builder
- 337,338: Possibly unreachable due to api routes?
- 340: Effort - data_builder
- 382: Couldn't figure out how to, need help.
- 435,436: Possibly unreachable due to api routes?
- 465,540: Couldn't figure out how to, need help.
- 549: Possibly unreachable due to api routes?
- 553: Couldn't figure out how to, need help.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
