### PR TITLE
Gear logging

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -136,6 +136,8 @@ endpoints = [
             route('/<:[^/]+>',             JobHandler),
             route('/<:[^/]+>/config.json', JobHandler,  h='get_config'),
             route('/<:[^/]+>/retry',       JobHandler,  h='retry',      m=['POST']),
+            route('/<:[^/]+>/logs',        JobHandler,  h='get_logs',   m=['GET']),
+            route('/<:[^/]+>/logs',        JobHandler,  h='add_logs',   m=['POST']),
         ]),
         route('/gears',                                  GearsHandler),
         prefix('/gears', [

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -79,7 +79,6 @@ class Job(object):
                 'id': None
             }
 
-
         self.gear_id            = gear_id
         self.inputs             = inputs
         self.destination        = destination

--- a/test/integration_tests/python/test_jobs.py
+++ b/test/integration_tests/python/test_jobs.py
@@ -59,6 +59,18 @@ def test_jobs(with_hierarchy, with_gear, with_invalid_gear, as_user, as_admin):
     r = as_admin.get('/jobs/' + job1_id)
     assert r.ok
 
+    # add job log
+    r = as_admin.post('/jobs/' + job1_id + '/logs', json=[
+        { 'fd': 1, 'msg': 'Hello' },
+        { 'fd': 2, 'msg': 'World' }
+    ])
+    assert r.ok
+
+    # get job log
+    r = as_admin.get('/jobs/' + job1_id + '/logs')
+    assert r.ok
+    assert len(r.json()['logs']) == 2
+
     # get job config
     r = as_admin.get('/jobs/' + job1_id + '/config.json')
     assert r.ok


### PR DESCRIPTION
Allows gears to send up logs. Any user with read access to the job's input can read; superuser can write.

```go
type JobLogStatement struct {
	// The file descriptor the log line came from.
	// Negative values are external logs from system components;
	// One is standard out;
	// Two is standard err;
	// Other values are invalid.
	FileDescriptor int8 `json:"fd"`

	// The message for this statement. Typically newline-delimited.
	Message string `json:"msg"`
}

type JobLog struct {
	Id   string             `json:"_id,omitempty"`
	Logs []*JobLogStatement `json:"logs,omitempty"`
}
```

Intentionally very basic.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
