### PR TITLE
Remove gear exit wrapper

### DIFF
--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -228,7 +228,7 @@ class Job(object):
                 }
             ],
             'target': {
-                'command': ['bash', '-c', 'rm -rf output; mkdir -p output; ./run; echo "Exit was $?"'],
+                'command': ['bash', '-c', 'rm -rf output; mkdir -p output; ./run'],
                 'env': {
                     'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
                 },


### PR DESCRIPTION
Jobs will now fail if the gear exits non-zero, as per the spec. Ref scitran/core#364, scitran/apps#19.

This causes some consternation on the example dataset:

```
"cancelled":   0  --> "cancelled":  0 
"complete":  135  --> "complete":  80 
"failed":      0  --> "failed":    55 
"pending":     0  --> "pending":    0
"running":     0  --> "running":    0
````

Can merge whenever ya'll are ready for it :fire: :fire: :fire: 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
