### PR TITLE
Move refresh token to user, alert client when invalid

### DIFF
--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -40,7 +40,7 @@ class APIRefreshTokenException(Exception):
     def __init__(self, msg):
 
         super(APIRefreshTokenException, self).__init__(msg)
-        self.errors = {'core_status_code': 'bad_refresh_token'}
+        self.errors = {'core_status_code': 'invalid_refresh_token'}
 
 
 def always_ok(exec_op):

--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -34,6 +34,14 @@ class APIAuthProviderException(Exception):
 class APIUnknownUserException(Exception):
     pass
 
+class APIRefreshTokenException(Exception):
+    # Specifically alert a client when the user's refresh token expires
+    # Requires client to ask for `offline=true` permission to receive a new one
+    def __init__(self, msg):
+
+        super(APIRefreshTokenException, self).__init__(msg)
+        self.errors = {'core_status_code': 'bad_refresh_token'}
+
 
 def always_ok(exec_op):
     """

--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -54,7 +54,7 @@ class AuthProvider(object):
                 # Update the user's gravatar if it has changed.
                 config.db.users.update_one({'_id': uid, 'avatars.gravatar': {'$ne': gravatar}}, {'$set':{'avatars.gravatar': gravatar, 'modified': timestamp}})
 
-    def set_refresh_token(self, uid, refresh_token):
+    def set_refresh_token_if_exists(self, uid, refresh_token):
         if not refresh_token:
             return
 
@@ -113,7 +113,7 @@ class GoogleOAuthProvider(AuthProvider):
         token = response['access_token']
 
         uid = self.validate_user(token)
-        self.set_refresh_token(uid, response.get('refresh_token'))
+        self.set_refresh_token_if_exists(uid, response.get('refresh_token'))
 
         return {
             'access_token': token,
@@ -195,7 +195,7 @@ class WechatOAuthProvider(AuthProvider):
 
         registration_code = kwargs.get('registration_code')
         uid = self.validate_user(openid, registration_code=registration_code)
-        self.set_refresh_token(uid, response.get('refresh_token'))
+        self.set_refresh_token_if_exists(uid, response.get('refresh_token'))
 
         return {
             'access_token': response['access_token'],

--- a/bin/database.py
+++ b/bin/database.py
@@ -16,7 +16,7 @@ from api.jobs.jobs import Job
 from api.jobs import gears
 from api.types import Origin
 
-CURRENT_DATABASE_VERSION = 24 # An int that is bumped when a new schema change is made
+CURRENT_DATABASE_VERSION = 25 # An int that is bumped when a new schema change is made
 
 def get_db_version():
 
@@ -855,6 +855,23 @@ def upgrade_to_24():
     # Remove obsolete singleton
     config.db.singletons.remove({"_id" : "rules"})
     logging.info('Upgrade v23, complete.')
+
+def upgrade_to_25():
+    """
+    scitran/core PR #733
+
+    Migrate refresh token from authtokens to seperate collection
+    """
+
+    auth_tokens = config.db.authtokens.find({'refresh_token': {'$exists': True}})
+
+    for a in auth_tokens:
+        refresh_doc = {
+            'uid': a['uid'],
+            'token': a['refresh_token'],
+            'auth_type': a['auth_type']
+        }
+        config.db.refreshtokens.insert(refresh_doc)
 
 
 

--- a/bin/database.py
+++ b/bin/database.py
@@ -873,6 +873,8 @@ def upgrade_to_25():
         }
         config.db.refreshtokens.insert(refresh_doc)
 
+    config.db.authtokens.update_many({'refresh_token': {'$exists': True}}, {'$unset': {'refresh_token': ''}})
+
 
 
 def upgrade_schema():


### PR DESCRIPTION
Fixes #717 

NOTE: webapp2's built in `handle_exception()` flow does not catch exceptions in the init of the handler with the `handle_exception()` method. Only ever user `self.abort()` in `base.RequestHandler`'s init flow. 

TODO: Move auth logic out of `base.RequestHandler`'s init so more detailed exceptions can be thrown.

Solution to #717, persisting refresh tokens for users:

  - skip init flow when hitting `/api/login`
  - store refresh token on user doc
  - throw specific response (`{'status_code: 401, 'message': 'invalid_refresh_token'}`) to alert client it should request offline access from auth provider to receive a new refresh token 
