### PR TITLE
Change API key format and allow for colon-separated key preambles

### DIFF
--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -164,7 +164,7 @@ class UserHandler(base.RequestHandler):
     def generate_api_key(self):
         if not self.uid:
             self.abort(400, 'no user is logged in')
-        generated_key = base64.urlsafe_b64encode(os.urandom(42))
+        generated_key = util.create_nonce()
         now = datetime.datetime.utcnow()
         payload = {'api_key': {'key': generated_key, 'created': now, 'last_used': None}}
         result = self.storage.exec_op('PUT', _id=self.uid, payload=payload)

--- a/api/util.py
+++ b/api/util.py
@@ -1,12 +1,14 @@
 import datetime
 import enum as baseEnum
 import errno
+import hashlib
 import json
 import mimetypes
 import os
-import uuid
+import random
 import requests
-import hashlib
+import string
+import uuid
 
 MIMETYPES = [
     ('.bvec', 'text', 'bvec'),
@@ -204,3 +206,15 @@ def mkdir_p(path):
             pass
         else:
             raise
+
+NONCE_CHARS  = string.ascii_letters + string.digits
+NONCE_LENGTH = 18
+
+def create_nonce():
+    x = len(NONCE_CHARS)
+
+    # Class that uses the os.urandom() function for generating random numbers.
+    # https://docs.python.org/2/library/random.html#random.SystemRandom
+    randrange = random.SystemRandom().randrange
+
+    return ''.join([NONCE_CHARS[randrange(x)] for _ in range(NONCE_LENGTH)])

--- a/test/unit_tests/python/test_key.py
+++ b/test/unit_tests/python/test_key.py
@@ -1,0 +1,8 @@
+import pytest
+from api.auth.authproviders import APIKeyAuthProvider
+
+def test_api_key_preprocess():
+    assert APIKeyAuthProvider._preprocess_key("key")             == "key"
+    assert APIKeyAuthProvider._preprocess_key("preamble:key")    == "key"
+    assert APIKeyAuthProvider._preprocess_key("preamble:37:key") == "key"
+    assert APIKeyAuthProvider._preprocess_key("preamble::key")   == "key"


### PR DESCRIPTION
The current API key format takes some entropy and base64 encodes it. This ends up being longer than it needs to be, and has some formatting issues (#668 among other things).

Instead, generate an alphanum string directly, using the same entropy source.
Additionally, allow for arbitrary preambles to be added to a key, separated by `:`.
This can hold, for example, connection information for passing between connected products.

Closes #668.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
