### PR TITLE
add roles & permissions to session projection to enable has_access

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -433,7 +433,7 @@ def find_existing_hierarchy(metadata, user=None, site=None):
         raise APIStorageException(str(e))
 
     # Confirm session and acquisition exist
-    session_obj = config.db.sessions.find_one({'uid': session_uid}, ['project'])
+    session_obj = config.db.sessions.find_one({'uid': session_uid}, ['project', 'roles', 'permissions'])
 
     if session_obj is None:
         raise APINotFoundException('Session with uid {} does not exist'.format(session_uid))


### PR DESCRIPTION
During testing I found uid-match uploads weren't working due to a minor bug, where has_access always failed because it was called with a session object that was missing the roles/permissions attrs due to a projection.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
