### PR TITLE
Gear name on job tabs and database upgrade speed improvements

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -96,7 +96,6 @@ class GearHandler(base.RequestHandler):
 
         return remove_gear(_id)
 
-
 class RulesHandler(base.RequestHandler):
 
     def get(self, cid):
@@ -129,7 +128,6 @@ class RulesHandler(base.RequestHandler):
                 self.abort(403, 'Adding rules to a project can only be done by a project admin.')
 
         self.abort(404, 'Project not found')
-
 
 class RuleHandler(base.RequestHandler):
 
@@ -191,7 +189,6 @@ class RuleHandler(base.RequestHandler):
 
         self.abort(404, 'Project not found')
 
-
 class JobsHandler(base.RequestHandler):
     """Provide /jobs API routes."""
     def get(self):
@@ -214,7 +211,7 @@ class JobsHandler(base.RequestHandler):
             inputs[x] = create_filereference_from_dictionary(input_map)
 
         # Add job tags, config, attempt number, and/or previous job ID, if present
-        tags            = submit.get('tags', None)
+        tags            = submit.get('tags', [])
         config_         = submit.get('config', {})
         attempt_n       = submit.get('attempt_n', 1)
         previous_job_id = submit.get('previous_job_id', None)
@@ -244,6 +241,11 @@ class JobsHandler(base.RequestHandler):
         if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             self.abort(400, 'Gear marked as invalid, will not run!')
         validate_gear_config(gear, config_)
+
+        gear_name = gear['gear']['name']
+
+        if gear_name not in tags:
+            tags.append(gear_name)
 
         job = Job(gear_id, inputs, destination=destination, tags=tags, config_=config_, now=now_flag, attempt=attempt_n, previous_job_id=previous_job_id, origin=self.origin)
         result = job.insert()

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -188,7 +188,6 @@ class Job(object):
     def insert(self):
         """
         Warning: this will not stop you from inserting a job for a gear that has gear.custom.flywheel.invald set to true.
-
         """
 
         if self.id_ is not None:

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -129,7 +129,7 @@ def queue_job_legacy(algorithm_id, input_):
         input_name: input_
     }
 
-    job = Job(str(gear['_id']), inputs)
+    job = Job(str(gear['_id']), inputs, tags=['auto', algorithm_id])
     return job.insert()
 
 def find_type_in_container(container, type_):
@@ -172,7 +172,7 @@ def create_jobs(db, container, container_type, file_):
                     inputs[input_name] = FileReference(type=container_type, id=str(container['_id']), name=match['name'])
 
                 gear = gears.get_gear_by_name(alg_name)
-                job = Job(str(gear['_id']), inputs)
+                job = Job(str(gear['_id']), inputs, tags=['auto', alg_name])
                 job.insert()
 
             job_list.append(alg_name)

--- a/bin/database.py
+++ b/bin/database.py
@@ -2,10 +2,12 @@
 
 import bson
 import copy
-import dateutil.parser
 import datetime
+import dateutil.parser
 import json
 import logging
+import multiprocessing
+import os
 import re
 import sys
 import time
@@ -16,7 +18,7 @@ from api.jobs.jobs import Job
 from api.jobs import gears
 from api.types import Origin
 
-CURRENT_DATABASE_VERSION = 25 # An int that is bumped when a new schema change is made
+CURRENT_DATABASE_VERSION = 26 # An int that is bumped when a new schema change is made
 
 def get_db_version():
 
@@ -875,6 +877,85 @@ def upgrade_to_25():
 
     config.db.authtokens.update_many({'refresh_token': {'$exists': True}}, {'$unset': {'refresh_token': ''}})
 
+
+def getMonotonicTime():
+    # http://stackoverflow.com/a/7424304
+    return os.times()[4]
+
+def process_cursor(cursor, closure):
+    begin = getMonotonicTime()
+
+    cores = multiprocessing.cpu_count()
+    pool = multiprocessing.Pool(cores)
+    logging.info('Iterating over cursor with ' + str(cores) + ' workers')
+
+    # Launch all work, iterating over the cursor
+    # Note that this creates an array of n multiprocessing.pool.AsyncResults, where N is table size.
+    # Memory usage concern in the future? Doesn't seem to be an issue with ~120K records.
+    # Could be upgraded later with some yield trickery.
+    results = [pool.apply_async(closure, (document,)) for document in cursor]
+
+    # Read the results back, presumably in order!
+    for res in results:
+        result = res.get()
+        if result != True:
+            logging.info('Upgrade failed: ' + str(result))
+
+    logging.info('Waiting for workers to complete')
+    pool.close()
+    pool.join()
+
+    end = getMonotonicTime()
+    elapsed = end - begin
+    logging.info('Parallel cursor iteration took ' + ('%.3f' % elapsed))
+
+def upgrade(job):
+
+    # Semi-worst-case: single uncacheable lookup per migrated job
+    gear = config.db.gears.find_one({'_id': bson.ObjectId(job['gear_id'])})
+    gear_name = gear['gear']['name']
+
+    # Update doc
+    result = config.db.jobs.update_one({'_id': job['_id']}, {'$push': {'tags': 'parallel-approach'}})
+    if result.modified_count == 1:
+        return True
+    else:
+        return 'Parallel failed: update doc ' + str(job['_id']) + ' resulted modified ' + str(result.modified_count)
+
+def upgrade_to_26():
+    """
+    scitran/core #734
+
+    Add job tags back to the job document, and use a faster cursor-walking update method
+    """
+
+    logging.info('Upgrade v26, removing tags')
+    config.db.jobs.update_many({}, {"$pull": {"tags": "normal-approach"}})
+    config.db.jobs.update_many({}, {"$pull": {"tags": "parallel-approach"}})
+    logging.info('Upgrade v26, removed')
+
+    # Normal approach
+    begin = getMonotonicTime()
+
+    cursor = config.db.jobs.find({})
+    for job in cursor:
+        # Semi-worst-case: single uncacheable lookup per migrated job
+        gear = config.db.gears.find_one({'_id': bson.ObjectId(job['gear_id'])})
+        gear_name = gear['gear']['name']
+
+        # Update doc
+        result = config.db.jobs.update_one({'_id': job['_id']}, {'$push': {'tags': 'normal-approach'}})
+        if result.modified_count != 1:
+            logging.info('Parallel failed: update doc ' + str(job['_id']) + ' resulted modified ' + str(result.modified_count))
+
+    end = getMonotonicTime()
+    elapsed = end - begin
+    logging.info('Upgrade v26, normal approach took ' + ('%.3f' % elapsed))
+
+
+    # Parallel approach
+    cursor = config.db.jobs.find({})
+    process_cursor(cursor, upgrade)
 
 
 def upgrade_schema():


### PR DESCRIPTION
This patch has two components:

1) New jobs will now have the gear name added as a tag on the job

~2) A synthetic upgrade to test speed improvements~

3) An upgrade to add the gear name to all existing job tags.

~Once the upgrade is confirmed faster (via @ryansanford), and general approach approved (via @nagem), then the upgrade will be swapped out for a real one.~

The new upgrade strategy is a slap-happy approach to the worst upgrade times we see right now, where a table cursor is iterated over and the individual upgrade order does not matter.

In this case we can just throw multiprocessing at the problem.
Time is measured in seconds for this benchmark.

With ~ 13,000 documents:

```
Serial   5.110
Parallel 1.520
```

With ~ 126,932 documents:

```
Serial   47.740
Parallel 13.940
```

The pool is currently set to num-v-cpu-cores, for no discernible reason. It could be made tunable if desired.
Closes #734.