### PR TITLE
Reduce docker hub build trigger obfuscation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ script:
 
 after_success:
   - coveralls
-  # docker/build-trigger.sh contains the rules for when to, and not to trigger
-  - if [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
-      ./docker/build-trigger.sh Tag "${TRAVIS_TAG}" "${BUILD_TRIGGER_URL}" ;
-      ./docker/build-trigger.sh Branch "${TRAVIS_BRANCH}" "${BUILD_TRIGGER_URL}" ;
+  - if [ "$TRAVIS_TAG" ]; then
+        ./docker/build-trigger.sh Tag "$TRAVIS_TAG" "$BUILD_TRIGGER_URL";
+    fi
+  - if [ "$TRAVIS_EVENT_TYPE" == "push" -a "$TRAVIS_BRANCH" == "master" ]; then
+        ./docker/build-trigger.sh Branch "$TRAVIS_BRANCH" "$BUILD_TRIGGER_URL";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - mongodb
 env:
   global:
-    secure: HELJx6WPr+W2S0FV47KkRdlS9NCqlMcdRMK8xWgRqqrEPv24KEvNnHxCy0tRbzITqadYtyvI1MtqtmpG04uty8Gpkc7w6L6LMJ/OuLG0gVX7AnaUovYTlY04m1/L9oyzOrTDXk5J/BKbcyiz7uJtkTc/A8MMZAFfZh7hmhLID78=
+    secure: HELJx6WPr+W2S0FV47KkRdlS9NCqlMcdRMK8xWgRqqrEPv24KEvNnHxCy0tRbzITqadYtyvI1MtqtmpG04uty8Gpkc7w6L6LMJ/OuLG0gVX7AnaUovYTlY04m1/L9oyzOrTDXk5J/BKbcyiz7uJtkTc/A8MMZAFfZh7hmhLID78= # BUILD_TRIGGER_URL
 
 install:
   - bin/install-ubuntu.sh

--- a/docker/build-trigger.sh
+++ b/docker/build-trigger.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Triggers an auto-build on dockerhub for the given source control reference.
+# Triggers an auto-build on Docker Hub for the given source control reference.
 #
 # Example usage: ./build-trigger Tag 1.0.0 https://registry.hub.docker.com/u/scitran/reaper/trigger/11111111-2222-3333-4444-abcdefabcdef/
 
@@ -15,36 +15,17 @@ SOURCE_CONTROL_REF_TYPE="${1}"
 SOURCE_CONTROL_REF_NAME="${2}"
 TRIGGER_URL="${3}"
 
-
 if [ -z "${SOURCE_CONTROL_REF_TYPE}" ] ; then
-  >&2 echo "INFO: Source control reference type not provided, skipping build trigger."
-  exit 0
+  >&2 echo "Source control reference type not provided. Skipping build trigger."
+  exit 1
 fi
 
 if [ -z "${SOURCE_CONTROL_REF_NAME}" ] ; then
-  >&2 echo "INFO: Source control tag name not provided, skipping build trigger."
-  exit 0
+  >&2 echo "Source control tag name not provided. Skipping build trigger."
+  exit 1
 fi
 
-
-# Skip trigger unless branch is master, or for any tag.
-EXEC_BUILD_TRIGGER=false
-
-if [ "${SOURCE_CONTROL_REF_TYPE}" == "Branch" ] && [ "${SOURCE_CONTROL_REF_NAME}" == "master" ] ; then
-  EXEC_BUILD_TRIGGER=true
-fi
-
-if [ "${SOURCE_CONTROL_REF_TYPE}" == "Tag" ] ; then
-  EXEC_BUILD_TRIGGER=true
-fi
-
-if ! $EXEC_BUILD_TRIGGER ; then
-  >&2 echo "INFO: Source control ${SOURCE_CONTROL_REF_TYPE}: '${SOURCE_CONTROL_REF_NAME}' is not enabled for the build trigger."
-  exit 0
-fi
-
-# Trigger the dockerhub build
 TRIGGER_PAYLOAD="{\"source_type\": \"${SOURCE_CONTROL_REF_TYPE}\", \"source_name\": \"${SOURCE_CONTROL_REF_NAME}\"}"
 curl -H "Content-Type: application/json" --data "${TRIGGER_PAYLOAD}" -X POST "${TRIGGER_URL}"
 >&2 echo
->&2 echo "INFO: A dockerhub build for ${SOURCE_CONTROL_REF_TYPE}: '${SOURCE_CONTROL_REF_NAME}' has been triggered."
+>&2 echo "Docker Hub build for ${SOURCE_CONTROL_REF_TYPE} '${SOURCE_CONTROL_REF_NAME}' triggered."


### PR DESCRIPTION
This is an attempt to de-obfuscate our Docker Hub build trigger logic. No functional change. Tested successfully in reaper repo.

Ideally, we'd manage shared code, such as `build-trigger.sh` or the calling logic in `.travis.yml` in a centralized fashion, rather than separately maintaining copies in each repo. Food for thought.