### PR TITLE
Filter aggregation based on permissions

### DIFF
--- a/api/search/__init__.py
+++ b/api/search/__init__.py
@@ -35,11 +35,24 @@ def es_query(input_query, doc_type, min_score=0.5, additional_filter=None, sourc
 
     return query
 
-def es_aggs(doc_type, field_name):
+def es_aggs(doc_type, field_name, additional_filter=None):
     query = {
       "size": 0,
       "aggs": {}
     }
+    if additional_filter:
+        query['query'] = {
+          "filtered": {
+            "query": {
+              "match_all": {}
+            },
+            "filter": {
+              "term": {
+                additional_filter[0] : additional_filter[1]
+              }
+            }
+          }
+        }
 
     query['aggs'][field_name] = {
         "terms": {


### PR DESCRIPTION
When `all_data` is `false` or absent, filter aggregation results for the user's permissions.

```
POST /api/search/field?all_data=false HTTP/1.1
Host: docker.local.flywheel.io:8443
Content-Type: application/json
{
    "doc_type": "files",
    "field": "type"
}
```
Should only return types for files user has access to.
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
