### PR TITLE
Adapt to new reaper options (--secret, --key)

### DIFF
--- a/bin/install-dev-osx.sh
+++ b/bin/install-dev-osx.sh
@@ -86,5 +86,5 @@ fi
 
 # Install testing dependencies
 echo "Installing testing dependencies"
-pip install -r "test/integration_tests/requirements-integration-test.txt"
+pip install --no-cache-dir -r "test/integration_tests/requirements-integration-test.txt"
 npm install test/integration_tests

--- a/bin/install-dev-osx.sh
+++ b/bin/install-dev-osx.sh
@@ -74,17 +74,3 @@ else
     MONGODB_VERSION=$($SCITRAN_RUNTIME_PATH/bin/mongod --version | grep "db version" | cut -d "v" -f 3)
     echo "MongoDB version $MONGODB_VERSION installed"
 fi
-
-
-# Install Node.js
-if [ ! -f "$SCITRAN_RUNTIME_PATH/bin/node" ]; then
-    echo "Installing Node.js"
-    NODE_URL="https://nodejs.org/dist/v6.4.0/node-v6.4.0-darwin-x64.tar.gz"
-    curl $NODE_URL | tar xz -C $VIRTUAL_ENV --strip-components 1
-fi
-
-
-# Install testing dependencies
-echo "Installing testing dependencies"
-pip install --no-cache-dir -r "test/integration_tests/requirements-integration-test.txt"
-npm install test/integration_tests

--- a/bin/run-dev-osx.sh
+++ b/bin/run-dev-osx.sh
@@ -181,7 +181,7 @@ if [ $BOOTSTRAP_TESTDATA -eq 1 ]; then
             git -C $SCITRAN_PERSISTENT_PATH/testdata pull
         fi
         echo "Ensuring reaper is up to date with master branch"
-        pip install git+https://github.com/scitran/reaper.git@options
+        pip install --upgrade --upgrade-strategy only-if-needed git+https://github.com/scitran/reaper.git@options
         echo "Bootstrapping testdata"
         folder_sniper --yes --insecure --secret "$SCITRAN_CORE_DRONE_SECRET" "$SCITRAN_PERSISTENT_PATH/testdata" $SCITRAN_SITE_API_URL
         echo "Bootstrapped testdata"

--- a/bin/run-dev-osx.sh
+++ b/bin/run-dev-osx.sh
@@ -181,7 +181,7 @@ if [ $BOOTSTRAP_TESTDATA -eq 1 ]; then
             git -C $SCITRAN_PERSISTENT_PATH/testdata pull
         fi
         echo "Ensuring reaper is up to date with master branch"
-        pip install --upgrade --upgrade-strategy only-if-needed git+https://github.com/scitran/reaper.git@options
+        pip install --upgrade --upgrade-strategy only-if-needed git+https://github.com/scitran/reaper.git
         echo "Bootstrapping testdata"
         folder_sniper --yes --insecure --secret "$SCITRAN_CORE_DRONE_SECRET" "$SCITRAN_PERSISTENT_PATH/testdata" $SCITRAN_SITE_API_URL
         echo "Bootstrapped testdata"

--- a/bin/run-dev-osx.sh
+++ b/bin/run-dev-osx.sh
@@ -181,10 +181,9 @@ if [ $BOOTSTRAP_TESTDATA -eq 1 ]; then
             git -C $SCITRAN_PERSISTENT_PATH/testdata pull
         fi
         echo "Ensuring reaper is up to date with master branch"
-        pip install -U git+https://github.com/scitran/reaper.git
+        pip install git+https://github.com/scitran/reaper.git@options
         echo "Bootstrapping testdata"
-        UPLOAD_URI="$SCITRAN_SITE_API_URL?secret=$SCITRAN_CORE_DRONE_SECRET"
-        folder_sniper --yes --insecure "$SCITRAN_PERSISTENT_PATH/testdata" $UPLOAD_URI
+        folder_sniper --yes --insecure --secret "$SCITRAN_CORE_DRONE_SECRET" "$SCITRAN_PERSISTENT_PATH/testdata" $SCITRAN_SITE_API_URL
         echo "Bootstrapped testdata"
         touch "$SCITRAN_PERSISTENT_DATA_PATH/.bootstrapped"
     fi

--- a/docker/bootstrap-data.sh
+++ b/docker/bootstrap-data.sh
@@ -25,7 +25,7 @@ bootstrap_data_label=7d5c3608ff360d6ae28aab0ef262e6781c4ae8d6
 
 
 # Same as bootstrap_data_label above, except for scitran/reaper.
-bootstrap_reaper_label=options
+bootstrap_reaper_label=2.0.0
 
 
 # Move to API folder for relative path assumptions later on

--- a/docker/bootstrap-data.sh
+++ b/docker/bootstrap-data.sh
@@ -25,7 +25,7 @@ bootstrap_data_label=7d5c3608ff360d6ae28aab0ef262e6781c4ae8d6
 
 
 # Same as bootstrap_data_label above, except for scitran/reaper.
-bootstrap_reaper_label=1.0.3
+bootstrap_reaper_label=options
 
 
 # Move to API folder for relative path assumptions later on
@@ -72,6 +72,6 @@ pip install "git+https://github.com/scitran/reaper.git@${bootstrap_reaper_label}
 
 
 ## load the test data in
-folder_sniper --yes --insecure "$TESTDATA_DIR/download" "${SCITRAN_SITE_API_URL}?secret=${SCITRAN_CORE_DRONE_SECRET}"
+folder_sniper --yes --insecure --secret "$SCITRAN_CORE_DRONE_SECRET" "$TESTDATA_DIR/download" $SCITRAN_SITE_API_URL
 
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ strict-rfc3339==0.7
 uwsgi==2.0.13.1
 webapp2==2.5.2
 WebOb==1.5.1
-git+https://github.com/flywheel-io/gears.git@65aae6ae6f8634bf45d744332641b3838fc06668
+git+https://github.com/flywheel-io/gears.git@65aae6ae6f8634bf45d744332641b3838fc06668#egg=gears

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,10 @@ pymongo==3.2
 pyOpenSSL==0.15.1
 python-dateutil==2.4.2
 pytz==2015.7
-requests-toolbelt==0.6.0
 requests==2.9.1
 rfc3987==1.3.4
 strict-rfc3339==0.7
 uwsgi==2.0.13.1
 webapp2==2.5.2
 WebOb==1.5.1
--e git://github.com/flywheel-io/gears.git@65aae6ae6f8634bf45d744332641b3838fc06668#egg=gears
+git+https://github.com/flywheel-io/gears.git@65aae6ae6f8634bf45d744332641b3838fc06668

--- a/test/bin/run-integration-tests.sh
+++ b/test/bin/run-integration-tests.sh
@@ -59,12 +59,13 @@ set +u
 # If no VIRTUAL_ENV, make sure /usr/local/bin is in the path
 if [ -z "$VIRTUAL_ENV" ]; then
     PATH="/usr/local/bin:$PATH"
+    npm install test/integration_tests
+else
+    npm install --global test/integration_tests
 fi
 set -u
 
 PATH="$(npm bin):$PATH"
-
-npm install test/integration_tests
 
 # Allow us to require modules from package.json,
 # since abao_test_hooks.js is not being called from the package directory

--- a/test/bin/run-tests-osx.sh
+++ b/test/bin/run-tests-osx.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -e
 
 unset CDPATH
@@ -24,13 +25,22 @@ clean_up () {
   coverage report -m
   coverage html
 }
-
 trap clean_up EXIT
 
 ./bin/install-dev-osx.sh
 
-# Note this will fail with "unbound variable" errors if "set -u" is enabled
-. "$SCITRAN_RUNTIME_PATH/bin/activate"
+source $SCITRAN_RUNTIME_PATH/bin/activate # will fail with `set -u`
+
+# Install Node.js
+if [ ! -f "$SCITRAN_RUNTIME_PATH/bin/node" ]; then
+    echo "Installing Node.js"
+    NODE_URL="https://nodejs.org/dist/v6.10.2/node-v6.10.2-darwin-x64.tar.gz"
+    curl $NODE_URL | tar xz -C $VIRTUAL_ENV --strip-components 1
+fi
+
+# Install testing dependencies
+echo "Installing testing dependencies"
+pip install --no-cache-dir -r "test/integration_tests/requirements-integration-test.txt"
 
 ./test/bin/lint.sh api
 


### PR DESCRIPTION
This is the start of getting core aligned with the new option parsing capabilities of reaper.
scitran/reaper#54

@ryansanford Please add additional commits here as needed.

**Note that `@options` needs to be removed from `bin/run-dev-osx.sh:184`, and `docker/bootstrap-data.sh:28` needs to be reverted to `1.0.3` or a more recent release.**