### PR TITLE
Case-insensitive rules, and gear list filters

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -31,7 +31,13 @@ class GearsHandler(base.RequestHandler):
         if self.public_request:
             self.abort(403, 'Request requires login')
 
-        return get_gears()
+        gears   = get_gears()
+        filters = self.request.GET.getall('filter')
+
+        if 'single_input' in filters:
+            gears = list(filter(lambda x: len(x["gear"]["inputs"].keys()) <= 1, gears))
+
+        return gears
 
 class GearHandler(base.RequestHandler):
     """Provide /gears/x API routes."""

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -57,22 +57,29 @@ def eval_match(match_type, match_param, file_, container):
     Given a match entry, return if the match succeeded.
     """
 
+    def lower(x):
+        return x.lower()
+
+
     # Match the file's type
     if match_type == 'file.type':
         try:
-            return file_['type'] == match_param
+            return file_['type'].lower() == match_param.lower()
         except KeyError:
             _log_file_key_error(file_, container, 'has no type key')
             return False
 
     # Match a shell glob for the file name
     elif match_type == 'file.name':
-        return fnmatch.fnmatch(file_['name'], match_param)
+        return fnmatch.fnmatch(file_['name'].lower(), match_param.lower())
 
     # Match any of the file's measurements
     elif match_type == 'file.measurements':
         try:
-            return match_param in file_['measurements']
+            if match_param:
+                return match_param.lower() in map(lower, file_.get('measurements', []))
+            else:
+                return False
         except KeyError:
             _log_file_key_error(file_, container, 'has no measurements key')
             return False
@@ -80,7 +87,7 @@ def eval_match(match_type, match_param, file_, container):
     # Match the container having any file (including this one) with this type
     elif match_type == 'container.has-type':
         for c_file in container['files']:
-            if match_param == c_file.get('type'):
+            if match_param.lower() == c_file.get('type').lower():
                 return True
 
         return False

--- a/test/unit_tests/python/test_rules.py
+++ b/test/unit_tests/python/test_rules.py
@@ -78,7 +78,7 @@ def test_eval_match_file_measurements():
     assert result == False
 
     # Check match returns false without raising when not given a file.type
-    args = part.gen(file_={'a': 'b'}, container={'a': 'b'})
+    args = part.gen(file_={'a': 'b'}, match_param='', container={'a': 'b'})
     result = rules.eval_match(*args)
     assert result == False
 


### PR DESCRIPTION

1. Gear rules are now case-insensitive. Closes #750
1. The `/gears` endpoint now accepts `filter=single_input` to only return gears that take a single input.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
