### PR TITLE
Add hdf5 file type

### DIFF
--- a/api/filetypes.json
+++ b/api/filetypes.json
@@ -2,7 +2,7 @@
     "bval":         [ ".bval", ".bvals" ],
     "bvec":         [ ".bvec", ".bvecs" ],
     "dicom":        [ ".dcm", ".dcm.zip", ".dicom.zip" ],
-    "ismrmrd":      [ ".h5" ],
+    "ismrmrd":      [ ".h5", ".hdf5" ],
     "parrec":       [ ".parrec.zip", ".par-rec.zip" ],
     "gephysio":     [ ".gephysio.zip" ],
     "MATLAB data":  [ ".mat" ],


### PR DESCRIPTION
Some files have `.h5`, others `.hdf5`.



### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
