### PR TITLE
Up result size for api/search/fields

### DIFF
--- a/api/search/__init__.py
+++ b/api/search/__init__.py
@@ -56,7 +56,8 @@ def es_aggs(doc_type, field_name, additional_filter=None):
 
     query['aggs'][field_name] = {
         "terms": {
-            "field": '.'.join((doc_type, field_name, 'exact_'+field_name))
+            "field": '.'.join((doc_type, field_name, 'exact_'+field_name)),
+            'size': 1000
         }
     }
 


### PR DESCRIPTION
Return a max of 1000 buckets for fields aggregation instead of Elastic's default of 10.

In the future we could make this an option for clients via a query string. 
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
