### PR TITLE
Move uid upload logic to 'reaper' class, modify existing uid logic to always follow group/project

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -84,10 +84,10 @@ endpoints = [
 
         # General-purpose upload & download
 
-        route('/download',                              Download, h='download',              m=['GET', 'POST']),
-        route('/upload/<strategy:label|uid|uid-match>', Upload,   h='upload',                m=['POST']),
-        route('/clean-packfiles',                       Upload,   h='clean_packfile_tokens', m=['POST']),
-        route('/engine',                                Upload,   h='engine',                m=['POST']),
+        route('/download',                                      Download, h='download',              m=['GET', 'POST']),
+        route('/upload/<strategy:label|uid|uid-match|reaper>',  Upload,   h='upload',                m=['POST']),
+        route('/clean-packfiles',                               Upload,   h='clean_packfile_tokens', m=['POST']),
+        route('/engine',                                        Upload,   h='engine',                m=['POST']),
 
 
         # Top-level endpoints

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -418,7 +418,7 @@ def _get_targets(project_obj, session, acquisition, type_, timestamp):
     return target_containers
 
 
-def find_existing_hierarchy(metadata, user=None, site=None):
+def find_existing_hierarchy(metadata, type_='uid', user=None, site=None):
     #pylint: disable=unused-argument
     project = metadata.get('project', {})
     session = metadata.get('session', {})
@@ -447,7 +447,7 @@ def find_existing_hierarchy(metadata, user=None, site=None):
     now = datetime.datetime.utcnow()
     project_files = dict_fileinfos(project.pop('files', []))
     project_obj = config.db.projects.find_one({'_id': session_obj['project']}, projection=PROJECTION_FIELDS + ['name'])
-    target_containers = _get_targets(project_obj, session, acquisition, 'uid', now)
+    target_containers = _get_targets(project_obj, session, acquisition, type_, now)
     target_containers.append(
         (TargetContainer(project_obj, 'project'), project_files)
     )
@@ -455,7 +455,6 @@ def find_existing_hierarchy(metadata, user=None, site=None):
 
 
 def upsert_bottom_up_hierarchy(metadata, type_='uid', user=None, site=None):
-    # pylint: disable=unused-argument
     group = metadata.get('group', {})
     project = metadata.get('project', {})
     session = metadata.get('session', {})
@@ -480,13 +479,13 @@ def upsert_bottom_up_hierarchy(metadata, type_='uid', user=None, site=None):
         now = datetime.datetime.utcnow()
         project_files = dict_fileinfos(project.pop('files', []))
         project_obj = config.db.projects.find_one({'_id': session_obj['project']}, projection=PROJECTION_FIELDS + ['name'])
-        target_containers = _get_targets(project_obj, session, acquisition, 'uid', now)
+        target_containers = _get_targets(project_obj, session, acquisition, type_, now)
         target_containers.append(
             (TargetContainer(project_obj, 'project'), project_files)
         )
         return target_containers
     else:
-        return upsert_top_down_hierarchy(metadata, 'uid', user=user, site=site)
+        return upsert_top_down_hierarchy(metadata, type_=type_, user=user, site=site)
 
 
 def upsert_top_down_hierarchy(metadata, type_='label', user=None, site=None):

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -455,6 +455,7 @@ def find_existing_hierarchy(metadata, user=None, site=None):
 
 
 def upsert_bottom_up_hierarchy(metadata, type_='uid', user=None, site=None):
+    # pylint: disable=unused-argument
     group = metadata.get('group', {})
     project = metadata.get('project', {})
     session = metadata.get('session', {})

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -454,7 +454,7 @@ def find_existing_hierarchy(metadata, user=None, site=None):
     return target_containers
 
 
-def upsert_bottom_up_hierarchy(metadata, user=None, site=None):
+def upsert_bottom_up_hierarchy(metadata, type_='uid', user=None, site=None):
     group = metadata.get('group', {})
     project = metadata.get('project', {})
     session = metadata.get('session', {})

--- a/api/placer.py
+++ b/api/placer.py
@@ -152,7 +152,7 @@ class UIDPlacer(Placer):
         metadata_validator(self.metadata, 'POST')
 
         # If not a superuser request, pass uid of user making the upload request
-        targets = self.create_hierarchy(self.metadata, self.match_type, user=self.context.get('uid'), site=self.context.get('site'))
+        targets = self.create_hierarchy(self.metadata, type_=self.match_type, user=self.context.get('uid'), site=self.context.get('site'))
 
         self.metadata_for_file = {}
 

--- a/api/placer.py
+++ b/api/placer.py
@@ -211,7 +211,7 @@ class UIDReaperPlacer(UIDPlacer):
     created in referenced project/group.
     """
 
-    metadata_schema = 'uidmatchupload.json'
+    metadata_schema = 'uidupload.json'
     create_hierarchy = staticmethod(hierarchy.upsert_bottom_up_hierarchy)
     match_type = 'uid'
 

--- a/api/placer.py
+++ b/api/placer.py
@@ -152,7 +152,7 @@ class UIDPlacer(Placer):
         metadata_validator(self.metadata, 'POST')
 
         # If not a superuser request, pass uid of user making the upload request
-        targets = self.create_hierarchy(self.metadata, type_=self.match_type, user=self.context.get('uid'), site=self.context.get('site'))
+        targets = self.create_hierarchy(self.metadata, self.match_type, user=self.context.get('uid'), site=self.context.get('site'))
 
         self.metadata_for_file = {}
 
@@ -202,7 +202,7 @@ class UIDPlacer(Placer):
             self.recalc_session_compliance()
         return self.saved
 
-class ReaperUIDPlacer(UIDPlacer):
+class UIDReaperPlacer(UIDPlacer):
     """
     A placer that creates or matches based on UID.
 
@@ -212,7 +212,7 @@ class ReaperUIDPlacer(UIDPlacer):
     """
 
     metadata_schema = 'uidmatchupload.json'
-    create_hierarchy = staticmethod(hierarchy.hierarchy.upsert_bottom_up_hierarchy)
+    create_hierarchy = staticmethod(hierarchy.upsert_bottom_up_hierarchy)
     match_type = 'uid'
 
 class LabelPlacer(UIDPlacer):

--- a/api/upload.py
+++ b/api/upload.py
@@ -21,6 +21,7 @@ Strategy = util.Enum('Strategy', {
     'labelupload' : pl.LabelPlacer,
     'uidupload'   : pl.UIDPlacer,
     'uidmatch'    : pl.UIDMatchPlacer,
+    'reaper'      : pl.UIDReaperPlacer,
     'analysis'    : pl.AnalysisPlacer,      # Upload N files to an analysis as input and output (no db updates)
     'analysis_job': pl.AnalysisJobPlacer   # Upload N files to an analysis as output from job results
 })
@@ -165,6 +166,8 @@ class Upload(base.RequestHandler):
             strategy = Strategy.uidupload
         elif strategy == 'uid-match':
             strategy = Strategy.uidmatch
+        elif strategy == 'reaper':
+            strategy = Strategy.reaper
         else:
             self.abort(500, 'stragegy {} not implemented'.format(strategy))
         return process_upload(self.request, strategy, origin=self.origin, context=context)

--- a/test/integration_tests/python/conftest.py
+++ b/test/integration_tests/python/conftest.py
@@ -175,6 +175,20 @@ def file_form():
     return file_form
 
 
+@pytest.fixture(scope='session')
+def merge_dict():
+
+    def merge_dict(a, b):
+        """Merge two dicts into the first recursively"""
+        for key, value in b.iteritems():
+            if key in a and isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge_dict(a[key], b[key])
+            else:
+                a[key] = b[key]
+
+    return merge_dict
+
+
 @pytest.fixture(scope='module')
 def log(request):
     """Return logger for the test module for easy logging from tests"""
@@ -218,7 +232,7 @@ class DataBuilder(object):
 
         # merge any kwargs on top of the default payload
         payload = copy.deepcopy(_default_payload[resource])
-        merge_dict(payload, kwargs)
+        _merge_dict(payload, kwargs)
 
         # add missing required unique fields using randstr
         # such fields are: [user._id, group._id, gear.gear.name]
@@ -306,12 +320,4 @@ class DataBuilder(object):
 # as "private singletons" in the module. This seemed the least confusing.
 _default_payload = default_payload()
 _api_db = api_db()
-
-
-def merge_dict(a, b):
-    """Merge two dicts into the first recursively"""
-    for key, value in b.iteritems():
-        if key in a and isinstance(a[key], dict) and isinstance(b[key], dict):
-            merge_dict(a[key], b[key])
-        else:
-            a[key] = b[key]
+_merge_dict = merge_dict()


### PR DESCRIPTION
The old `UID` placer logic would ignore the project/group information in the metadata if it found the session via `UID` in a separate project to support moving sessions during data acquisition. That logic has been moved to a new endpoint at `api/upload/reaper`. The existing endpoint `api/upload/uid` has been changed to always follow what the metadata specifies for project/group.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
