### PR TITLE
Add config option to disable proper SSL connection verification to the JWT Auth service

### DIFF
--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -70,7 +70,7 @@ class JWTAuthProvider(AuthProvider):
         }
 
     def validate_user(self, token):
-        r = requests.post(self.config['verify_endpoint'], data={'token': token})
+        r = requests.post(self.config['verify_endpoint'], data={'token': token}, verify=self.config.get('check_ssl', True))
         if not r.ok:
             raise APIAuthProviderException('User token not valid')
         uid = json.loads(r.content).get('mail')


### PR DESCRIPTION
WARNING: Should only be used for testing environments. 