### PR TITLE
re-add roles and tags to group projection

### DIFF
--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -37,7 +37,7 @@ class GroupHandler(base.RequestHandler):
         return result
 
     def get_all(self, uid=None):
-        projection = {'name': 1, 'created': 1, 'modified': 1}
+        projection = {'name': 1, 'created': 1, 'modified': 1, 'roles': 1, 'tags': 1}
         permchecker = groupauth.list_permission_checker(self, uid)
         results = permchecker(self.storage.exec_op)('GET', projection=projection)
         if not self.superuser_request and not self.is_true('join_avatars'):


### PR DESCRIPTION
Closes #803 

### Background:
- the roles and the tags projection used to be set to an empty list []
- while creating the unit test infrastructure I ran into mongomock not handling the projection value []
- assumed the intent was to *not* include roles and tags, and simply removed those
- frontend bug arose because of the now missing roles key (realized pymongo *includes* when proj=[])
- re-added roles and tags to projection, now with value 1

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
