### PR TITLE
Access log query enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bootstrap.json
 coverage.xml
 /htmlcov
 node_modules/
+/bin/accesslog.csv

--- a/api/api.py
+++ b/api/api.py
@@ -97,6 +97,7 @@ endpoints = [
         route('/resolve',                                       ResolveHandler, h='resolve',  m=['POST']),
         route('/schemas/<schema:{schema}>',                     SchemaHandler,                m=['GET']),
         route('/report/<report_type:site|project|accesslog|usage>',   ReportHandler,                m=['GET']),
+        route('/report/accesslog/types',                        ReportHandler,  h='get_types',  m=['GET']),
 
 
         # Search

--- a/api/config.py
+++ b/api/config.py
@@ -240,6 +240,7 @@ def initialize_db():
 
     if __config['core']['access_log_enabled']:
         log_db.access_log.create_index('context.ticket_id')
+        log_db.access_log.create_index([('timestamp', pymongo.DESCENDING)])
 
     create_or_recreate_ttl_index('authtokens', 'timestamp', 2592000)
     create_or_recreate_ttl_index('uploads', 'timestamp', 60)

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -1,5 +1,5 @@
 import copy
-import csv
+import unicodecsv as csv
 import datetime
 import os
 

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -16,24 +16,24 @@ from ..web import base
 EIGHTEEN_YEARS_IN_SEC = 18 * 365.25 * 24 * 60 * 60
 BYTES_IN_MEGABYTE = float(1<<20)
 ACCESS_LOG_FIELDS = [
-    "context.session.label",
-    "context.project.id",
-    "context.subject.label",
-    "context.ticket_id",
+    "_id",
+    "access_type",
     "context.acquisition.id",
     "context.acquisition.label",
-    "timestamp",
-    "access_type",
     "context.group.id",
-    "request_method",
-    "context.subject.id",
-    "request_path",
     "context.group.label",
+    "context.project.id",
     "context.project.label",
-    "origin.id",
-    "_id",
     "context.session.id",
-    "origin.type"
+    "context.session.label",
+    "context.subject.id",
+    "context.subject.label",
+    "context.ticket_id",
+    "origin.id",
+    "origin.type",
+    "request_method",
+    "request_path",
+    "timestamp"
 ]
 
 class APIReportException(Exception):
@@ -71,6 +71,7 @@ class ReportHandler(base.RequestHandler):
                 for doc in report.build():
                     writer.writerow(doc)
 
+                # Need to close and reopen file to flush buffer into file
                 csv_file.close()
                 self.response.app_iter = open(os.path.join(tempdir.name, 'acceslog.csv'), 'r')
                 self.response.headers['Content-Type'] = 'text/csv'
@@ -504,7 +505,7 @@ class AccessLogReport(Report):
         if limit < 1:
             raise APIReportParamsException('Limit must be an integer greater than 0.')
         for access_type in access_types:
-            if access_type not in ['user_login', 'view_container']:
+            if access_type not in ['user_login', 'view_container', 'download_file']:
                 raise APIReportParamsException('Not a valid access type')
 
         self.start_date     = start_date

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -522,6 +522,8 @@ class AccessLogReport(Report):
             raise APIReportParamsException('Limit must be an integer greater than 0.')
         if limit < 1:
             raise APIReportParamsException('Limit must be an integer greater than 0.')
+        elif limit > 10000:
+            raise APIReportParamsException('Limit exceeds 10,000 entries, please contact admin to run script.')
         for access_type in access_types:
             if access_type not in AccessTypeList:
                 raise APIReportParamsException('Not a valid access type')

--- a/api/web/request.py
+++ b/api/web/request.py
@@ -16,6 +16,7 @@ AccessType = util.Enum('AccessType', {
     'user_login':       'user_login',
     'user_logout':      'user_logout'
 })
+AccessTypeList = [type_name for type_name, member in AccessType.__members__.items()]
 
 
 class SciTranRequest(Request):

--- a/bin/log_csv.py
+++ b/bin/log_csv.py
@@ -1,0 +1,77 @@
+# This implementation as of July 19 2017 has these resource utilizations of the mongodb container:
+#   - 2 million entries: 1.50 Gb
+#   - 3 million entries: 2.05 Gb
+# The entire docker application was given 6 Gb to use, when given the default 2 Gb,
+# the process would frequently crash before 1 million entries were downloaded.
+
+import argparse
+import csv
+import pymongo
+import tarfile
+import sys
+import logging
+import datetime
+
+from api.web.request import AccessTypeList
+from api import config
+from api.handlers.reporthandler import AccessLogReport, ACCESS_LOG_FIELDS
+
+ARG_TO_PARAMS= {
+    'l': 'limit',
+    's': 'start_date',
+    'e': 'end_date',
+    'u': 'uid',
+    'j': 'subject',
+    't': 'access_types'
+}
+
+def download_large_csv(params):
+    """
+    Script to download large csv files to avoid uwsgi worker running out of memory.
+    """
+    lim = int(params['limit'])
+    params['csv'] = "true"
+    params['bin'] = "true"
+    params['limit'] = "100000"
+
+    csv_file = open('accesslog.csv', 'w+')
+    writer = csv.DictWriter(csv_file, ACCESS_LOG_FIELDS)
+    writer.writeheader()
+
+    while lim > 0:
+        print lim
+        params['limit'] = str(min(lim, 100000))
+        report = AccessLogReport(params)
+        retort = report.build()
+        start_date = str(retort[-1]['timestamp'])
+        for doc in retort:
+            lim = lim - 1
+            try:
+                writer.writerow(doc)
+            except UnicodeEncodeError as e:
+                continue
+        csv_file.flush()
+        params['start_date'] = start_date
+
+            
+
+    csv_file.close()
+
+def format_arg(args):
+    return {ARG_TO_PARAMS[arg]: args[arg] for arg in args if args[arg] != None}
+
+if __name__ == '__main__':
+    try:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-s", help="Start date",            type=str)
+        parser.add_argument("-e", help="End date",              type=str)
+        parser.add_argument("-u", help="User id",               type=str)
+        parser.add_argument("-l", help="Limit",                 type=str)
+        parser.add_argument("-j", help="subJect",               type=str)
+        parser.add_argument("-t", help="list of access Types",  type=str, nargs='+')
+
+        args = vars(parser.parse_args())
+        download_large_csv(format_arg(args))
+    except Exception as e:
+        logging.exception('Unexpected error in log_csv.py')
+        sys.exit(1)

--- a/bin/log_csv.py
+++ b/bin/log_csv.py
@@ -5,7 +5,7 @@
 # the process would frequently crash before 1 million entries were downloaded.
 
 import argparse
-import csv
+import unicodecsv as csv
 import pymongo
 import tarfile
 import sys
@@ -46,19 +46,11 @@ def download_large_csv(params):
         end_date = str(rep[-1]['timestamp'])
         for doc in rep[:-1]:
             entries = entries - 1
-            try:
-                writer.writerow(doc)
-            except UnicodeEncodeError as e:
-                unicode_err_count += 1
-                continue
+            writer.writerow(doc)
 
         if len(rep) == 1:
             entries = 0
-            try:
-                writer.writerow(rep[0])
-            except UnicodeEncodeError as e:
-                unicode_err_count += 1
-                continue
+            writer.writerow(rep[0])
         if len(rep) < int(params['limit']) - 1:
             entries = 0
         csv_file.flush()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ uwsgi==2.0.13.1
 webapp2==2.5.2
 WebOb==1.5.1
 git+https://github.com/flywheel-io/gears.git@v0.1.1#egg=gears
+unicodecsv==0.9.0

--- a/test/integration_tests/python/test_reports.py
+++ b/test/integration_tests/python/test_reports.py
@@ -116,6 +116,12 @@ def test_access_log_report(data_builder, with_user, as_user, as_admin):
     r = as_admin.get('/report/accesslog', params={'limit': 0})
     assert r.status_code == 400
 
+    # try to get report w/ limit == 1000 and limit > 1000
+    r = as_admin.get('/report/accesslog', params={'limit': 10000})
+    assert r.ok
+    r = as_admin.get('/report/accesslog', params={'limit': 10001})
+    assert r.status_code == 400
+
     # get access log report for user
     r = as_admin.get('/report/accesslog', params={
         'start_date': yesterday_ts, 'end_date': tomorrow_ts, 'user': with_user.user

--- a/test/integration_tests/python/test_reports.py
+++ b/test/integration_tests/python/test_reports.py
@@ -1,6 +1,7 @@
 import calendar
 import copy
 import datetime
+from api.web.request import AccessTypeList
 
 # create timestamps for report filtering
 today = datetime.datetime.today()
@@ -144,6 +145,8 @@ def test_access_log_report(data_builder, with_user, as_user, as_admin):
     })
     assert r.ok
     session = r.json()['_id']
+
+    # In order to have two logs of this subject (POST does not create a log)
     r = as_admin.get('/sessions/' + session)
     assert r.ok
     session = r.json()['_id']
@@ -176,7 +179,12 @@ def test_access_log_report(data_builder, with_user, as_user, as_admin):
     r = as_admin.get('/report/accesslog', params={'csv': 'true'})
     assert r.ok
 
-    r.content[0][:3] == '_id' 
+    r.content[0][:3] == '_id'
+
+    # get the access types
+    r = as_admin.get('/report/accesslog/types')
+    assert r.ok
+    assert r.json() == AccessTypeList
 
 
 def test_usage_report(data_builder, file_form, as_user, as_admin):


### PR DESCRIPTION
Fixes #811 
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.mdRequirements:

Requirements:
  - [x] Add ability to specify singular `subject` query param that only returns records where `context.subject.label` matches that input
  - [x] Add ability to specify multiple `access_type` query params that only return records where `access_type` matches one of those inputs
  - [x] Add `csv` query param that, when `True`, returns a csv file of all matching records flattened into rows
  - [x] Write integration tests to thoroughly test the new functionality
  - [x] Create new endpoint (`/api/report/accesslog/types` ?) that returns the available access types for frontend use. 