### PR TITLE
use handle_exception in base.RequestHandler.__init__

### DIFF
--- a/api/web/base.py
+++ b/api/web/base.py
@@ -49,13 +49,8 @@ class RequestHandler(webapp2.RequestHandler):
 
             self.initialization_auth(site_id)
 
-        except webapp2.HTTPException:
-            raise
-        except Exception: # pylint: disable=broad-except
-            tb = traceback.format_exc()
-            self.request.logger.error(tb)
-            self.abort(500, 'Unexpected error.')
-
+        except Exception as e: # pylint: disable=broad-except
+            self.handle_exception(e, self.app.debug)
 
 
     def initialize(self, request, response):


### PR DESCRIPTION
Closes #739 
Removed 500: Unexpected error.
`self.handle_exception()` was the simplest solution indeed, thanks for the tip @nagem.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
