### PR TITLE
Temporary gear tar file upload and downloads endpoints

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -143,7 +143,7 @@ endpoints = [
         ]),
         route('/gears',                                  GearsHandler),
         route('/gears/temp',                             GearHandler, h='upload', m=['POST']),
-        route('/gears/temp/<cid:{cid}>',                 GearHandler, h='download', m=['GET']),
+        route('/gears/temp/<cid:{cid}>',  GearHandler, h='download', m=['GET']),
         prefix('/gears', [
             route('/<:[^/]+>',                           GearHandler),
             route('/<:[^/]+>/invocation',                GearHandler, h='get_invocation'),

--- a/api/api.py
+++ b/api/api.py
@@ -142,7 +142,8 @@ endpoints = [
             route('/<:[^/]+>/logs',        JobHandler,  h='add_logs',      m=['POST']),
         ]),
         route('/gears',                                  GearsHandler),
-        route('/gears/temp',                                   GearHandler, h='upload', m=['POST']),
+        route('/gears/temp',                             GearHandler, h='upload', m=['POST']),
+        route('/gears/temp/<cid:{cid}>',                 GearHandler, h='download', m=['GET']),
         prefix('/gears', [
             route('/<:[^/]+>',                           GearHandler),
             route('/<:[^/]+>/invocation',                GearHandler, h='get_invocation'),

--- a/api/api.py
+++ b/api/api.py
@@ -142,6 +142,7 @@ endpoints = [
             route('/<:[^/]+>/logs',        JobHandler,  h='add_logs',      m=['POST']),
         ]),
         route('/gears',                                  GearsHandler),
+        route('/gears/temp',                                   GearHandler, h='upload', m=['POST']),
         prefix('/gears', [
             route('/<:[^/]+>',                           GearHandler),
             route('/<:[^/]+>/invocation',                GearHandler, h='get_invocation'),

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -91,7 +91,7 @@ class GearHandler(base.RequestHandler):
 
         dl_id = kwargs.pop('cid')
         gear = get_gear(dl_id)
-        hash_ = gear['hash']
+        hash_ = gear['exchange']['rootfs-hash']
         filepath = os.path.join(config.get_item('persistent', 'data_path'), util.path_from_hash(hash_))
         self.response.app_iter = open(filepath, 'rb')
         self.response.headers['Content-Length'] = str(gear['size']) # must be set after setting app_iter

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -71,19 +71,26 @@ class GearHandler(base.RequestHandler):
         gear = get_gear(_id)
         return suggest_container(gear, cont_name+'s', cid)
 
+    # Temporary Function
     def upload(self):
         """Upload new gear file"""
         if not self.user_is_admin:
             self.abort(403, 'Request requires admin')
 
         r = upload.process_upload(self.request, upload.Strategy.gear, container_type='gear', origin=self.origin, metadata=self.request.headers.get('metadata'))
-        id = upsert_gear(r[1])
-        return {'_id': str(id)}
+        gear_id = upsert_gear(r[1])
+        return {'_id': str(gear_id)}
+
+    # Temporary Function
+    def download(self, **kwargs):
+        dl_id = kwargs.pop('cid')
+        return {'_id':str(dl_id)}
+
 
     def post(self, _id):
         """Upsert an entire gear document."""
 
-        if not self.user_is_admin:
+        if not self.superuser_request:
             self.abort(403, 'Request requires superuser')
 
         doc = self.request.json

--- a/api/placer.py
+++ b/api/placer.py
@@ -685,12 +685,14 @@ class GearPlacer(Placer):
     def process_file_field(self, field, file_attrs):
         if self.metadata:
             file_attrs.update(self.metadata)
-            self.metadata.update({'hash': file_attrs.get('hash')})
+            self.metadata.update({'exchange': {'rootfs-hash': file_attrs.get('hash'),
+                                               'git-commit': 'local',
+                                               'rootfs-url': '/api/gears/temp/'+file_attrs.get('hash')}})
         # self.metadata['hash'] = file_attrs.get('hash')
         self.save_file(field, file_attrs)
         self.saved.append(file_attrs)
         self.saved.append(self.metadata)
-        
+
 
 
     def finalize(self):

--- a/api/placer.py
+++ b/api/placer.py
@@ -128,7 +128,6 @@ class TargetedPlacer(Placer):
         self.recalc_session_compliance()
         return self.saved
 
-
 class UIDPlacer(Placer):
     """
     A placer that can accept multiple files.
@@ -228,7 +227,6 @@ class LabelPlacer(UIDPlacer):
     create_hierarchy = staticmethod(hierarchy.upsert_top_down_hierarchy)
     match_type = 'label'
 
-
 class UIDMatchPlacer(UIDPlacer):
     """
     A placer that uploads to an existing hierarchy it finds based on uid.
@@ -237,7 +235,6 @@ class UIDMatchPlacer(UIDPlacer):
     metadata_schema = 'uidmatchupload.json'
     create_hierarchy = staticmethod(hierarchy.find_existing_hierarchy)
     match_type = 'uid'
-
 
 class EnginePlacer(Placer):
     """
@@ -314,7 +311,6 @@ class EnginePlacer(Placer):
         self.recalc_session_compliance()
         return self.saved
 
-
 class TokenPlacer(Placer):
     """
     A placer that can accept N files and save them to a persistent directory across multiple requests.
@@ -354,7 +350,6 @@ class TokenPlacer(Placer):
             shutil.move(path, dest)
         self.recalc_session_compliance()
         return self.saved
-
 
 class PackfilePlacer(Placer):
     """
@@ -678,22 +673,19 @@ class AnalysisJobPlacer(Placer):
 
 class GearPlacer(Placer):
     def check(self):
-        pass
-        # self.requireTarget()
-        # validators.validate_data(self.metadata, 'file.json', 'input', 'POST', optional=True)
+        self.requireMetadata()
 
     def process_file_field(self, field, file_attrs):
         if self.metadata:
             file_attrs.update(self.metadata)
-            self.metadata.update({'exchange': {'rootfs-hash': file_attrs.get('hash'),
+            proper_hash = file_attrs.get('hash')[3:].replace('-', ':')
+            self.metadata.update({'exchange': {'rootfs-hash': proper_hash,
                                                'git-commit': 'local',
-                                               'rootfs-url': '/api/gears/temp/'+file_attrs.get('hash')}})
+                                               'rootfs-url': 'INVALID'}})
         # self.metadata['hash'] = file_attrs.get('hash')
         self.save_file(field)
         self.saved.append(file_attrs)
         self.saved.append(self.metadata)
-
-
 
     def finalize(self):
         return self.saved

--- a/api/placer.py
+++ b/api/placer.py
@@ -689,7 +689,7 @@ class GearPlacer(Placer):
                                                'git-commit': 'local',
                                                'rootfs-url': '/api/gears/temp/'+file_attrs.get('hash')}})
         # self.metadata['hash'] = file_attrs.get('hash')
-        self.save_file(field, file_attrs)
+        self.save_file(field)
         self.saved.append(file_attrs)
         self.saved.append(self.metadata)
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -91,8 +91,6 @@ def process_upload(request, strategy, container_type=None, id_=None, origin=None
 
     # Non-file form fields may have an empty string as filename, check for 'falsy' values
     file_fields = [x for x in form if form[x].filename]
-    # if file_fields:
-    #     return file_fields
     # TODO: Change schemas to enabled targeted uploads of more than one file.
     # Ref docs from placer.TargetedPlacer for details.
     if strategy == Strategy.targeted and len(file_fields) > 1:

--- a/api/upload.py
+++ b/api/upload.py
@@ -23,7 +23,8 @@ Strategy = util.Enum('Strategy', {
     'uidmatch'    : pl.UIDMatchPlacer,
     'reaper'      : pl.UIDReaperPlacer,
     'analysis'    : pl.AnalysisPlacer,      # Upload N files to an analysis as input and output (no db updates)
-    'analysis_job': pl.AnalysisJobPlacer   # Upload N files to an analysis as output from job results
+    'analysis_job': pl.AnalysisJobPlacer,   # Upload N files to an analysis as output from job results
+    'gear'        : pl.GearPlacer
 })
 
 def process_upload(request, strategy, container_type=None, id_=None, origin=None, context=None, response=None, metadata=None):
@@ -61,7 +62,7 @@ def process_upload(request, strategy, container_type=None, id_=None, origin=None
     if id_ is not None and container_type == None:
         raise Exception('Unspecified container type')
 
-    if container_type is not None and container_type not in ('acquisition', 'session', 'project', 'collection', 'analysis'):
+    if container_type is not None and container_type not in ('acquisition', 'session', 'project', 'collection', 'analysis', 'gear'):
         raise Exception('Unknown container type')
 
     timestamp = datetime.datetime.utcnow()
@@ -90,15 +91,16 @@ def process_upload(request, strategy, container_type=None, id_=None, origin=None
 
     # Non-file form fields may have an empty string as filename, check for 'falsy' values
     file_fields = [x for x in form if form[x].filename]
-
+    # if file_fields:
+    #     return file_fields
     # TODO: Change schemas to enabled targeted uploads of more than one file.
     # Ref docs from placer.TargetedPlacer for details.
     if strategy == Strategy.targeted and len(file_fields) > 1:
         raise Exception("Targeted uploads can only send one file")
 
+
     for field in file_fields:
         field = form[field]
-
         # Augment the cgi.FieldStorage with a variety of custom fields.
         # Not the best practice. Open to improvements.
         # These are presumbed to be required by every function later called with field as a parameter.


### PR DESCRIPTION
Fixes #822
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md

Requirements:
  - [ ] Add GearPlacer class that adds the file in the form to the CAS and returns the metadata (gear manifest) and information about where it stored the file 
  - [ ] Add upload function to `jobs.handlers.GearHandler` that calls GearPlacer class, and then calls `jobs.gears.upsert_gear` with the metadata it gets from GearPlacer.
  - [ ] Add a new key to gear objects in the `gears` collection that stores it's location in the CAS
  - [ ] Add download function to `jobs.handlers.GearHandler` that serves the file from the CAS
  - [ ] Ensure only admin level users can call either of these endpoints