### PR TITLE
Fix error handling during base class init

### DIFF
--- a/api/util.py
+++ b/api/util.py
@@ -183,16 +183,19 @@ def format_hash(hash_alg, hash_):
     return '-'.join(('v0', hash_alg, hash_))
 
 
-def send_json_http_exception(response, message, code, custom=None):
-    response.set_status(code)
+def create_json_http_exception_response(message, code, custom=None):
     content = {
         'message': message,
         'status_code': code
     }
     if custom:
         content.update(custom)
+    return content
 
-    json_content = json.dumps(content)
+
+def send_json_http_exception(response, message, code, custom=None):
+    response.set_status(code)
+    json_content = json.dumps(create_json_http_exception_response(message, code, custom))
     response.headers['Content-Type'] = 'application/json; charset=utf-8'
     response.write(json_content)
 

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -312,7 +312,7 @@ class RequestHandler(webapp2.RequestHandler):
     def get_param(self, param, default=None):
         return self.request.GET.get(param, default)
 
-    def handle_exception(self, exception, debug, return_json=False):
+    def handle_exception(self, exception, debug, return_json=False): # pylint: disable=arguments-differ
         """
         Send JSON response for exception
 

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -50,7 +50,8 @@ class RequestHandler(webapp2.RequestHandler):
             self.initialization_auth(site_id)
 
         except Exception as e: # pylint: disable=broad-except
-            self.handle_exception(e, self.app.debug)
+            error = self.handle_exception(e, self.app.debug, return_json=True)
+            self.abort(error['status_code'], error['message'])
 
 
     def initialize(self, request, response):
@@ -311,7 +312,7 @@ class RequestHandler(webapp2.RequestHandler):
     def get_param(self, param, default=None):
         return self.request.GET.get(param, default)
 
-    def handle_exception(self, exception, debug):
+    def handle_exception(self, exception, debug, return_json=False):
         """
         Send JSON response for exception
 
@@ -351,6 +352,9 @@ class RequestHandler(webapp2.RequestHandler):
         if code == 500:
             tb = traceback.format_exc()
             self.request.logger.error(tb)
+
+        if return_json:
+            return util.create_json_http_exception_response(str(exception), code, custom=custom_errors)
 
         util.send_json_http_exception(self.response, str(exception), code, custom=custom_errors)
 


### PR DESCRIPTION
Although calling `handle_exception` from the init class writes to the response object correctly, the handler method is still called*. I rerouted a few things in order to call self.abort(), but this is only a temporary solution until our error handling layer gets reworked. 

*and fails when `self.user_is_admin` is not available because the init 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
