### PR TITLE
switch to literal 1 as 1st day of month (monthrange[0] is 1st weekday #)

### DIFF
--- a/test/integration_tests/python/test_reports.py
+++ b/test/integration_tests/python/test_reports.py
@@ -181,7 +181,7 @@ def test_usage_report(data_builder, file_form, as_user, as_admin):
 
     # get month-aggregated usage report
     monthrange = calendar.monthrange(today.year, today.month)
-    start_ts = ts_format.format(today.replace(day=monthrange[0]))
+    start_ts = ts_format.format(today.replace(day=1))
     end_ts = ts_format.format(today.replace(day=monthrange[1]))
     r = as_admin.get('/report/usage', params={
         'type': 'month', 'start_date': start_ts, 'end_date': end_ts


### PR DESCRIPTION
The dreaded day-of-the-month dependent failing test returned very briefly, and got corrected for good.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
