### PR TITLE
Search followup

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -103,7 +103,7 @@ endpoints = [
         route('/dataexplorer/search',                   DataExplorerHandler,   h='search',                 m=['POST']),
         route('/dataexplorer/facets',                   DataExplorerHandler,   h='get_facets',             m=['POST']),
         route('/dataexplorer/search/fields',            DataExplorerHandler,   h='search_fields',          m=['POST']),
-        route('/dataexplorer/search/fields/aggregate',  DataExplorerHandler,   h='custom_field_values',    m=['POST']),
+        route('/dataexplorer/search/fields/aggregate',  DataExplorerHandler,   h='aggregate_field_values', m=['POST']),
         route('/dataexplorer/index/fields',             DataExplorerHandler,   h='index_field_names',      m=['POST']),
 
         # Users

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -347,7 +347,7 @@ class DataExplorerHandler(base.RequestHandler):
             source.extend(["acquisition._id", "acquisition.label", "acquisition.created", "acquisition.timestamp", "acquisition.archived"])
 
         if return_type == 'analysis':
-            source.extend(["analysis._id", "analysis.label", "analysis.created"])
+            source.extend(["analysis._id", "analysis.label", "analysis.created", "analysis.parent", "analysis.user"])
 
         query = {
             "size": 0,

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -11,7 +11,7 @@ ANALYSIS = {
     "analyzer": {
         "my_analyzer": {
             "tokenizer": "my_tokenizer",
-            "filters": ["lowercase"]
+            "filter": ["lowercase"]
         }
     },
     "tokenizer": {
@@ -38,10 +38,11 @@ DYNAMIC_TEMPLATES = [
                 'type': 'text',
                 'analyzer': 'my_analyzer',
                 'search_analyzer': 'standard',
+                'index': True,
                 "fields": {
                     "raw": {
                         "type": "keyword",
-                        "index": "not_analyzed",
+                        "index": True,
                         "ignore_above": 256
                     }
                 }


### PR DESCRIPTION
## Major Changes:

  - Added `/api/dataexplorer/search/fields/aggregate`, an endpoint that will give varying aggregation results when supplied with a field name. Usage examples below.
  - Fixed field name type ahead completion to properly handle capitalization
  - Added additional input validation and error handling when ES is not available
  - Added boolean key to `data_explorer_fields` called `facet`. When `true`, 85% of values for given field fall within 15 or less values. Can be used by client to make decisions around showing a typeahead input or a list of facet checkboxes.

## Breaking Changes:
None

## Aggregate Endpoint Examples:

### Basic Request format:
```
{
	"search_string": "<user input>",  #OPTIONAL, user input for typeahead responses
	"field_name": "<field.name>" # REQUIRED, name of field
}
```
---------------------

### Example Request:
If the user selects a field of `type`:`string` with `facet`:`false`, it is expected the client will provide an input for the user to start typing. Values from that input will be sent as `search_string`.
```
{
	"search_string": "foo",
	"field_name": "session.label"
}
```

### Example Response:
```
{
  "buckets": [
    {
      "key": "foo",
      "doc_count": 6
    }
  ],
  "sum_other_doc_count": 0,
  "doc_count_error_upper_bound": 0
}
```
---------------------

### Example Request:
To display a starting dropdown without user input, do not send the key `search_string`. 
```
{
	"field_name": "session.label"
}
```

### Example Response:
```
{
  "buckets": [
    {
      "key": "kid_1",
      "doc_count": 34
    },
    {
      "key": "patient_343",
      "doc_count": 26
    },
    {
      "key": "control_2",
      "doc_count": 22
    },
    {
      "key": "MOM_25",
      "doc_count": 17
    },
    {
      "key": "kit_2",
      "doc_count": 13
    },
    {
      "key": "patient_1",
      "doc_count": 13
    },
    {
      "key": "patient_2",
      "doc_count": 13
    },
    {
      "key": "17_dAD",
      "doc_count": 12
    },
    {
      "key": "control_1",
      "doc_count": 11
    },
    {
      "key": "bar",
      "doc_count": 9
    },
    {
      "key": "baz",
      "doc_count": 9
    },
    {
      "key": "foo",
      "doc_count": 6
    }
  ],
  "sum_other_doc_count": 0,
  "doc_count_error_upper_bound": 0
}
```
---------------------

### Example Request
If the user selects a field of `type`:`string` with `facet`:`true`, it is expected the client will provide a list of facet options to the user. If `sum_other_doc_count` > 0, it is suggested the client provide a text input in addition to the facets, using typeahead as above. 
```
{
	"field_name": "project.label"
}
```

### Example Response:
```
{
  "buckets": [
    {
      "key": "Neuroscience",
      "doc_count": 86
    },
    {
      "key": "Psychology",
      "doc_count": 77
    },
    {
      "key": "Testdata",
      "doc_count": 25
    }
  ],
  "sum_other_doc_count": 0,
  "doc_count_error_upper_bound": 0
}
```
---------------------

### Example Request:
If the field type is `integer`, `float`, or `date`, the client can provide a range input, using the aggregation to receive min and max values for starting points. 
```
{
	"field_name": "file.info.MagneticFieldStrength"
}
```

### Example Response:
```
{
  "count": 36,
  "max": 3,
  "sum": 108,
  "avg": 3,
  "min": 3
}
```
---------------------

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
