### PR TITLE
Coverage low hanging - final

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -74,7 +74,7 @@ class GearHandler(base.RequestHandler):
         return suggest_container(gear, cont_name+'s', cid)
 
     # Temporary Function
-    def upload(self):
+    def upload(self): # pragma: no cover
         """Upload new gear tarball file"""
         if not self.user_is_admin:
             self.abort(403, 'Request requires admin')
@@ -88,7 +88,7 @@ class GearHandler(base.RequestHandler):
         return {'_id': str(gear_id)}
 
     # Temporary Function
-    def download(self, **kwargs):
+    def download(self, **kwargs): # pragma: no cover
         """Download gear tarball file"""
         dl_id = kwargs.pop('cid')
         gear = get_gear(dl_id)
@@ -224,7 +224,7 @@ class RuleHandler(base.RequestHandler):
 
 class JobsHandler(base.RequestHandler):
     """Provide /jobs API routes."""
-    def get(self):
+    def get(self): # pragma: no cover (no route)
         """List all jobs."""
         if not self.superuser_request and not self.user_is_admin:
             self.abort(403, 'Request requires admin')

--- a/api/placer.py
+++ b/api/placer.py
@@ -250,8 +250,8 @@ class EnginePlacer(Placer):
 
             ###
             # Remove when switch to dmv2 is complete across all gears
-            c_metadata = self.metadata.get(self.container_type, {})
-            if self.context.get('job_id') and c_metadata and not c_metadata.get('files', []):
+            c_metadata = self.metadata.get(self.container_type, {}) # pragma: no cover
+            if self.context.get('job_id') and c_metadata and not c_metadata.get('files', []): # pragma: no cover
                 job = Job.get(self.context.get('job_id'))
                 input_names = [{'name': v.name} for v in job.inputs.itervalues()]
 

--- a/api/resolver.py
+++ b/api/resolver.py
@@ -26,11 +26,11 @@ class Node(object):
 
     @staticmethod
     def get_children(parent):
-        raise NotImplementedError()
+        raise NotImplementedError() # pragma: no cover
 
     @staticmethod
     def filter(children, criterion):
-        raise NotImplementedError()
+        raise NotImplementedError() # pragma: no cover
 
 def _get_files(table, match):
     """

--- a/api/resolver.py
+++ b/api/resolver.py
@@ -81,7 +81,7 @@ class AcquisitionNode(Node):
         for x in children:
             if x['node_type'] == "file" and x.get('name') == criterion:
                 return x, FileNode
-        raise Exception('No ' + criterion + ' acquisition or file found.')
+        raise Exception('No ' + criterion + ' file found.')
 
 class SessionNode(Node):
 

--- a/api/web/start.py
+++ b/api/web/start.py
@@ -8,7 +8,7 @@ import webapp2
 # Enable code coverage for testing when API is started
 # Start coverage before local module loading so their def and imports are counted
 #   http://coverage.readthedocs.io/en/coverage-4.2/faq.html
-if os.environ.get("SCITRAN_RUNTIME_COVERAGE") == "true":
+if os.environ.get("SCITRAN_RUNTIME_COVERAGE") == "true": # pragma: no cover - oh, the irony
     def save_coverage(cov):
         print("Saving coverage")
         cov.stop()

--- a/test/integration_tests/python/test_handlers.py
+++ b/test/integration_tests/python/test_handlers.py
@@ -78,3 +78,10 @@ def test_devicehandler(as_user, as_root, as_drone, api_db):
 
     # clean up
     api_db.devices.remove({'_id': 'test_drone'})
+
+
+def test_config_version(as_user):
+    # get database schema version
+    r = as_user.get('/version')
+    assert r.ok
+    assert r.text == '' # not set yet

--- a/test/integration_tests/python/test_jobs.py
+++ b/test/integration_tests/python/test_jobs.py
@@ -1,5 +1,7 @@
 import copy
 
+import bson
+
 
 def test_jobs_access(as_user):
     r = as_user.get('/jobs/next')
@@ -18,7 +20,7 @@ def test_jobs_access(as_user):
     assert r.status_code == 403
 
 
-def test_jobs(data_builder, as_user, as_admin, as_root):
+def test_jobs(data_builder, as_user, as_admin, as_root, api_db):
     gear = data_builder.create_gear()
     invalid_gear = data_builder.create_gear(gear={'custom': {'flywheel': {'invalid': True}}})
     acquisition = data_builder.create_acquisition()
@@ -70,6 +72,16 @@ def test_jobs(data_builder, as_user, as_admin, as_root):
     r = as_root.post('/jobs/000000000000000000000000/logs', json=job_logs)
     assert r.status_code == 404
 
+    # get job log as text w/o logs
+    r = as_admin.get('/jobs/' + job1_id + '/logs/text')
+    assert r.ok
+    assert r.text == '<span class="fd--1">No logs were found for this job.</span>'
+
+    # get job log as html w/o logs
+    r = as_admin.get('/jobs/' + job1_id + '/logs/html')
+    assert r.ok
+    assert r.text == '<span class="fd--1">No logs were found for this job.</span>'
+
     # add job log
     r = as_root.post('/jobs/' + job1_id + '/logs', json=job_logs)
     assert r.ok
@@ -83,17 +95,31 @@ def test_jobs(data_builder, as_user, as_admin, as_root):
     assert r.ok
     assert len(r.json()['logs']) == 2
 
+    # add same logs again (for testing text/html logs)
+    r = as_root.post('/jobs/' + job1_id + '/logs', json=job_logs)
+    assert r.ok
+
+    # get job log as text
+    r = as_admin.get('/jobs/' + job1_id + '/logs/text')
+    assert r.ok
+    assert r.text == 2 * ''.join(log['msg'] for log in job_logs)
+
+    # get job log as html
+    r = as_admin.get('/jobs/' + job1_id + '/logs/html')
+    assert r.ok
+    assert r.text == 2 * ''.join('<span class="fd-{fd}">{msg}</span>\n'.format(**log) for log in job_logs)
+
     # get job config
     r = as_root.get('/jobs/' + job1_id + '/config.json')
     assert r.ok
 
-    # try to update job (user may only cancel)
-    # root = true for as_admin, until thats fixed, using user
-    r = as_user.put('/jobs/' + job1_id, json={'test': 'invalid'})
-    assert r.status_code == 403
-
     # try to cancel job w/o permission (different user)
     r = as_user.put('/jobs/' + job1_id, json={'state': 'cancelled'})
+    assert r.status_code == 403
+
+    # try to update job (user may only cancel)
+    api_db.jobs.update_one({'_id': bson.ObjectId(job1_id)}, {'$set': {'origin.id': 'user@user.com'}})
+    r = as_user.put('/jobs/' + job1_id, json={'test': 'invalid'})
     assert r.status_code == 403
 
     # add job with implicit destination

--- a/test/integration_tests/python/test_resolver.py
+++ b/test/integration_tests/python/test_resolver.py
@@ -1,4 +1,13 @@
-def test_resolver(data_builder, as_admin, as_public):
+def path_in_result(path, result):
+    return [node.get('_id', node.get('name')) for node in result['path']] == path
+
+
+def child_in_result(child, result):
+    return sum(all((k in c and c[k]==v) for k,v in child.iteritems()) for c in result['children']) == 1
+
+
+def test_resolver(data_builder, as_admin, as_user, as_public, file_form):
+    # ROOT
     # try accessing resolver w/o logging in
     r = as_public.post('/resolve', json={'path': []})
     assert r.status_code == 403
@@ -7,58 +16,166 @@ def test_resolver(data_builder, as_admin, as_public):
     r = as_admin.post('/resolve', json={'path': 'test'})
     assert r.status_code == 500
 
-    # resolve root
+    # resolve root (empty)
     r = as_admin.post('/resolve', json={'path': []})
+    result = r.json()
     assert r.ok
-    assert r.json()['path'] == []
+    assert result['path'] == []
+    assert result['children'] == []
 
-    # resolve root w/ group
+    # resolve root (1 group)
     group = data_builder.create_group()
     r = as_admin.post('/resolve', json={'path': []})
     result = r.json()
     assert r.ok
     assert result['path'] == []
-    assert sum(child['_id'] == group for child in result['children']) == 1
-    assert all(child['node_type'] == 'group' for child in result['children'])
+    assert child_in_result({'_id': group, 'node_type': 'group'}, result)
 
-    # try to resolve non-existent group id
-    r = as_admin.post('/resolve', json={'path': ['non-existent-group-id']})
+    # try to resolve non-existent root/child
+    r = as_admin.post('/resolve', json={'path': ['child']})
     assert r.status_code == 500
 
-    # resolve group
+
+    # GROUP
+    # try to resolve root/group as different (and non-root) user
+    r = as_user.post('/resolve', json={'path': [group]})
+    assert r.status_code == 403
+
+    # resolve root/group (empty)
     r = as_admin.post('/resolve', json={'path': [group]})
     result = r.json()
     assert r.ok
-    assert [node['_id'] for node in result['path']] == [group]
+    assert path_in_result([group], result)
     assert result['children'] == []
 
-    # resolve group w/ project
+    # resolve root/group (1 project)
     project_label = 'test-resolver-project-label'
     project = data_builder.create_project(label=project_label)
     r = as_admin.post('/resolve', json={'path': [group]})
     result = r.json()
     assert r.ok
-    assert [node['_id'] for node in result['path']] == [group]
-    assert sum(child['_id'] == project for child in result['children']) == 1
-    assert all(child['node_type'] == 'project' for child in result['children'])
+    assert path_in_result([group], result)
+    assert child_in_result({'_id': project, 'node_type': 'project'}, result)
 
-    # try to resolve non-existent project label
-    r = as_admin.post('/resolve', json={'path': [group, 'non-existent-project-label']})
+    # try to resolve non-existent root/group/child
+    r = as_admin.post('/resolve', json={'path': [group, 'child']})
     assert r.status_code == 500
 
-    # resolve project
+
+    # PROJECT
+    # resolve root/group/project (empty)
     r = as_admin.post('/resolve', json={'path': [group, project_label]})
     result = r.json()
     assert r.ok
-    assert [node['_id'] for node in result['path']] == [group, project]
+    assert path_in_result([group, project], result)
     assert result['children'] == []
 
-    # resolve project w/ session
+    # resolve root/group/project (1 file)
+    project_file = 'project_file'
+    r = as_admin.post('/projects/' + project + '/files', files=file_form(project_file))
+    assert r.ok
+    r = as_admin.post('/resolve', json={'path': [group, project_label]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project], result)
+    assert child_in_result({'name': project_file, 'node_type': 'file'}, result)
+    assert len(result['children']) == 1
+
+    # resolve root/group/project (1 file, 1 session)
     session_label = 'test-resolver-session-label'
     session = data_builder.create_session(label=session_label)
     r = as_admin.post('/resolve', json={'path': [group, project_label]})
     result = r.json()
     assert r.ok
-    assert [node['_id'] for node in result['path']] == [group, project]
-    assert sum(child['_id'] == session for child in result['children']) == 1
-    assert all(child['node_type'] == 'session' for child in result['children'])
+    assert path_in_result([group, project], result)
+    assert child_in_result({'_id': session, 'node_type': 'session'}, result)
+    assert len(result['children']) == 2
+
+    # resolve root/group/project/file
+    r = as_admin.post('/resolve', json={'path': [group, project_label, project_file]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, project_file], result)
+    assert result['children'] == []
+
+    # try to resolve non-existent root/group/project/child
+    r = as_admin.post('/resolve', json={'path': [group, project_label, 'child']})
+    assert r.status_code == 500
+
+
+    # SESSION
+    # resolve root/group/project/session (empty)
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, session], result)
+    assert result['children'] == []
+
+    # resolve root/group/project/session (1 file)
+    session_file = 'session_file'
+    r = as_admin.post('/sessions/' + session + '/files', files=file_form(session_file))
+    assert r.ok
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, session], result)
+    assert child_in_result({'name': session_file, 'node_type': 'file'}, result)
+    assert len(result['children']) == 1
+
+    # resolve root/group/project/session (1 file, 1 acquisition)
+    acquisition_label = 'test-resolver-acquisition-label'
+    acquisition = data_builder.create_acquisition(label=acquisition_label)
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, session], result)
+    assert child_in_result({'_id': acquisition, 'node_type': 'acquisition'}, result)
+    assert len(result['children']) == 2
+
+    # resolve root/group/project/session/file
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, session_file]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, session, session_file], result)
+    assert result['children'] == []
+
+    # try to resolve non-existent root/group/project/session/child
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, 'child']})
+    assert r.status_code == 500
+
+
+    # ACQUISITION
+    # resolve root/group/project/session/acquisition (empty)
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, acquisition_label]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, session, acquisition], result)
+    assert result['children'] == []
+
+    # resolve root/group/project/session/acquisition (1 file)
+    acquisition_file = 'acquisition_file'
+    r = as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(acquisition_file))
+    assert r.ok
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, acquisition_label]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, session, acquisition], result)
+    assert child_in_result({'name': acquisition_file, 'node_type': 'file'}, result)
+    assert len(result['children']) == 1
+
+    # resolve root/group/project/session/acquisition/file
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, acquisition_label, acquisition_file]})
+    result = r.json()
+    assert r.ok
+    assert path_in_result([group, project, session, acquisition, acquisition_file], result)
+    assert result['children'] == []
+
+    # try to resolve non-existent root/group/project/session/acquisition/child
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, acquisition_label, 'child']})
+    assert r.status_code == 500
+
+
+    # FILE
+    # try to resolve non-existent (also invalid) root/group/project/session/acquisition/file/child
+    r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, acquisition_label, acquisition_file, 'child']})
+    assert r.status_code == 500

--- a/test/integration_tests/requirements-integration-test.txt
+++ b/test/integration_tests/requirements-integration-test.txt
@@ -6,6 +6,7 @@ mongomock==3.8.0
 pdbpp==0.8.3
 pylint==1.5.3
 pytest-cov==2.2.0
+pytest-mock==1.6.0
 pytest-watch==3.8.0
 pytest==2.8.5
 requests_mock==1.3.0

--- a/test/integration_tests/requirements-integration-test.txt
+++ b/test/integration_tests/requirements-integration-test.txt
@@ -3,6 +3,7 @@ coverage==4.0.3
 coveralls==1.1
 mock==2.0.0
 mongomock==3.8.0
+newrelic==2.60.0.46
 pdbpp==0.8.3
 pylint==1.5.3
 pytest-cov==2.2.0

--- a/test/unit_tests/python/test_config.py
+++ b/test/unit_tests/python/test_config.py
@@ -1,0 +1,51 @@
+import json
+
+import api.config
+
+
+def test_apply_env_variables(mocker, tmpdir):
+    auth_file, auth_content = 'auth_config.json', {'auth': {'test': 'test'}}
+    tmpdir.join(auth_file).write(json.dumps(auth_content))
+    mocker.patch('os.environ', {
+        'SCITRAN_AUTH_CONFIG_FILE': str(tmpdir.join(auth_file)),
+        'SCITRAN_TEST_TRUE': 'true',
+        'SCITRAN_TEST_FALSE': 'false',
+        'SCITRAN_TEST_NONE': 'none'})
+    config = {
+        'auth': {},
+        'test': {'true': '', 'false': '', 'none': ''}}
+    api.config.apply_env_variables(config)
+    assert config == {
+        'auth': {'test': 'test'},
+        'test': {'true': True, 'false': False, 'none': None}}
+
+
+def test_create_or_recreate_ttl_index(mocker):
+    db = mocker.patch('api.config.db')
+    collection, index_id, index_name, ttl = 'collection', 'timestamp_1', 'timestamp', 1
+
+    # create - collection not in collection_names
+    db.collection_names.return_value = []
+    api.config.create_or_recreate_ttl_index(collection, index_name, ttl)
+    db.collection_names.assert_called_with()
+    db[collection].create_index.assert_called_with(index_name, expireAfterSeconds=ttl)
+    db[collection].create_index.reset_mock()
+
+    # create - index doesn't exist
+    db.collection_names.return_value = [collection]
+    db[collection].index_information.return_value = {}
+    api.config.create_or_recreate_ttl_index(collection, index_name, ttl)
+    db[collection].create_index.assert_called_with(index_name, expireAfterSeconds=ttl)
+    db[collection].create_index.reset_mock()
+
+    # skip - index exists and matches
+    db[collection].index_information.return_value = {index_id: {'key': [[index_name]], 'expireAfterSeconds': ttl}}
+    api.config.create_or_recreate_ttl_index(collection, index_name, ttl)
+    assert not db[collection].create_index.called
+
+    # recreate - index exists but doesn't match
+    db[collection].create_index.reset_mock()
+    db[collection].index_information.return_value = {index_id: {'key': [[index_name]], 'expireAfterSeconds': 10}}
+    api.config.create_or_recreate_ttl_index(collection, index_name, ttl)
+    db[collection].drop_index.assert_called_with(index_id)
+    db[collection].create_index.assert_called_with(index_name, expireAfterSeconds=ttl)

--- a/test/unit_tests/python/test_web_start.py
+++ b/test/unit_tests/python/test_web_start.py
@@ -1,0 +1,32 @@
+import sys
+
+import mock
+import newrelic.api.exceptions
+import pytest
+
+import api.web.start
+
+
+def test_newrelic(config, mocker):
+    # set config var to trigger newrelic setup and setup mocks
+    config['core']['newrelic'] = 'test'
+    init = mocker.patch('newrelic.agent.initialize')
+    log = mocker.patch('api.web.start.log')
+
+    # successfully enable monitoring via newrelic
+    api.web.start.app_factory()
+    init.assert_called_with('test')
+    log.info.assert_called_with('New Relic detected and loaded. Monitoring enabled.')
+
+    # newrelic import error => log error and exit
+    init.side_effect = ImportError
+    with pytest.raises(SystemExit):
+        api.web.start.app_factory()
+    log.critical.assert_called_with('New Relic libraries not found.')
+    init.side_effect = None
+
+    # newrelic config error => log error and exit
+    init.side_effect = newrelic.api.exceptions.ConfigurationError
+    with pytest.raises(SystemExit):
+        api.web.start.app_factory()
+    log.critical.assert_called_with('New Relic detected, but configuration invalid.')


### PR DESCRIPTION
Closes #727 - declaring leftover coverage non-low-hanging
Closes #702 - perm handling got largely covered without explicit focus on the separate issue

- Added a small number of safe no-cover pragmas
- Added resolver, config, web.start and job text/html log coverage
- Together w/ dataexplorer-tests (#847) coverage is at 91.26%

### Leftovers
- It's most efficient to target contiguous chunks
- There are no obvious large chunks of missed statements left
- Progress estimate from here on is 0.5% / day (around 30 lines)

### Going forward - enforcement, CI integration
Ryan suggested adding no-cover to missed statements. My only addition is to add an extra tag to enable revisiting these in the future - eg. `#pragma no-cover 100%`
Pros:
- having "100%" allows for very simple coverage enforcement going forward
- works the same way locally and on CI

Con:
- there's a chance that these "hidden" lines will never be revisited again

I've also considered the incremental approach (comparing to previous commit, or to master), but found way more cons:
- harder (slower) to implement correctly
- needs state (at least two runs)
- local testing/CI differences more likely
- doesn't get rid of the 'deleting covered code can decrease overall cov' problem

The current coverage-miss, sorted by missed-lines-per-file (skipping completely covered ones):

Module | statements | missing | excluded | coverage
--- | ---:| ---:| ---:| ---:
`api/dao/hierarchy.py` | 386 | 42 | 14 | 89%
`api/dao/containerstorage.py` | 249 | 28 | 0 | 89%
`api/handlers/listhandler.py` | 311 | 28 | 0 | 91%
`api/handlers/containerhandler.py` | 375 | 23 | 0 | 94%
`api/handlers/reporthandler.py` | 393 | 23 | 0 | 94%
`api/jobs/gears.py` | 95 | 22 | 0 | 77%
`api/auth/listauth.py` | 78 | 21 | 0 | 73%
`api/handlers/collectionshandler.py` | 138 | 20 | 0 | 86%
`api/jobs/queue.py` | 108 | 20 | 0 | 81%
`api/placer.py` | 329 | 20 | 21 | 94%
`api/dao/base.py` | 129 | 19 | 0 | 85%
`api/dao/containerutil.py` | 118 | 19 | 0 | 84%
`api/handlers/userhandler.py` | 141 | 19 | 0 | 87%
`api/web/base.py` | 222 | 19 | 0 | 91%
`api/jobs/rules.py` | 96 | 18 | 0 | 81%
`api/auth/containerauth.py` | 97 | 15 | 0 | 85%
`api/jobs/batch.py` | 124 | 15 | 0 | 88%
`api/handlers/refererhandler.py` | 169 | 14 | 0 | 92%
`api/tempdir.py` | 58 | 14 | 0 | 76%
`api/upload.py` | 118 | 14 | 0 | 88%
`api/handlers/dataexplorerhandler.py` | 196 | 11 | 0 | 94%
`api/auth/groupauth.py` | 43 | 10 | 0 | 77%
`api/config.py` | 142 | 10 | 0 | 93%
`api/handlers/grouphandler.py` | 83 | 10 | 0 | 88%
`api/auth/userauth.py` | 35 | 9 | 0 | 74%
`api/dao/liststorage.py` | 137 | 9 | 0 | 93%
`api/download.py` | 241 | 8 | 0 | 97%
`api/web/start.py` | 52 | 8 | 12 | 85%
`api/jobs/jobs.py` | 154 | 7 | 0 | 95%
`api/validators.py` | 97 | 7 | 0 | 93%
`api/dao/consistencychecker.py` | 35 | 5 | 0 | 86%
`api/auth/authproviders.py` | 162 | 3 | 2 | 98%
`api/dao/dbutil.py` | 15 | 3 | 0 | 80%
`api/jobs/handlers.py` | 313 | 3 | 22 | 99%
`api/util.py` | 117 | 3 | 5 | 97%
`api/auth/__init__.py` | 48 | 2 | 0 | 96%
`api/dao/__init__.py` | 16 | 2 | 0 | 88%
`api/files.py` | 84 | 2 | 0 | 98%
`api/handlers/devicehandler.py` | 49 | 1 | 2 | 98%
`api/web/encoder.py` | 25 | 1 | 0 | 96%
**Total** | 6030 | 527 | 80 | 91%


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
