### PR TITLE
New flag to propagate group perm changes

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -142,7 +142,8 @@ def propagate_changes(cont_name, _id, query, update, oper=None):
     # Apply change to projects
     if cont_name == 'groups' and oper:
         if oper == 'POST':
-            config.db.projects.update_many({'group': _id}, {'$addToSet': {'permissions': update}})
+            config.db.projects.update_many({'group': _id, 'permissions._id' : update['_id']}, {'$set': {'permissions.$.access': update['access']}})
+            config.db.projects.update_many({'group': _id, 'permissions._id' : {'$ne': update['_id']}}, {'$addToSet': {'permissions': update}})
         elif oper == 'PUT':
             config.db.projects.update_many({'group': _id, 'permissions._id' : update['_id']}, {'$set': {'permissions.$.access': update['access']}})
         elif oper == 'DELETE':

--- a/test/integration_tests/python/test_propagation.py
+++ b/test/integration_tests/python/test_propagation.py
@@ -209,7 +209,7 @@ def test_add_and_remove_user_group_permission(data_builder, as_admin):
 
     # Add user to group permissions
     payload = {'_id': user_id, 'access': 'admin'}
-    r = as_admin.post('/groups/' + group + '/permissions', json=payload, params={'propagate': True})
+    r = as_admin.post('/groups/' + group + '/permissions', json=payload, params={'propagate': 'true'})
     assert r.ok
 
     r = as_admin.get('/groups/' + group)
@@ -220,6 +220,7 @@ def test_add_and_remove_user_group_permission(data_builder, as_admin):
     r = as_admin.get('/projects/' + project)
     perms = r.json()['permissions']
     user = get_user_in_perms(perms, user_id)
+    assert r.json()['group'] == group
     assert r.ok and user
 
     r = as_admin.get('/sessions/' + session)
@@ -234,7 +235,7 @@ def test_add_and_remove_user_group_permission(data_builder, as_admin):
 
     # Modify user permissions
     payload = {'access': 'rw', '_id': user_id}
-    r = as_admin.put('/groups/' + group + '/permissions/' + user_id, json=payload, params={'propagate': True})
+    r = as_admin.put('/groups/' + group + '/permissions/' + user_id, json=payload, params={'propagate': 'true'})
     assert r.ok
 
     r = as_admin.get('/groups/' + group)
@@ -258,7 +259,7 @@ def test_add_and_remove_user_group_permission(data_builder, as_admin):
     assert r.ok and user and user['access'] == 'rw'
 
     # Remove user from project permissions
-    r = as_admin.delete('/groups/' + group + '/permissions/' + user_id, json=payload, params={'propagate': True})
+    r = as_admin.delete('/groups/' + group + '/permissions/' + user_id, json=payload, params={'propagate': 'true'})
     assert r.ok
 
     r = as_admin.get('/groups/' + group)

--- a/test/integration_tests/python/test_propagation.py
+++ b/test/integration_tests/python/test_propagation.py
@@ -185,6 +185,101 @@ def test_add_and_remove_user_for_project_permissions(data_builder, as_admin):
     user = get_user_in_perms(perms, user_id)
     assert r.ok and user is None
 
+# Test group permission propagation
+def test_add_and_remove_user_group_permission(data_builder, as_admin):
+    """
+    Tests:
+      - changing permissions at a group level with flag triggers propagation
+      - additive change to list propagates properly
+      - change to list propagates properly
+      - removal from list propagates properly
+    """
+    def get_user_in_perms(perms, uid):
+        for perm in perms:
+            if perm['_id'] == uid:
+                return perm
+        return None
+
+    group = data_builder.create_group()
+    project = data_builder.create_project()
+    session = data_builder.create_session()
+    acquisition = data_builder.create_acquisition()
+
+    user_id = 'propagation@user.com'
+
+    # Add user to group permissions
+    payload = {'_id': user_id, 'access': 'admin'}
+    r = as_admin.post('/groups/' + group + '/permissions', json=payload, params={'propagate': True})
+    assert r.ok
+
+    r = as_admin.get('/groups/' + group)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user
+
+    r = as_admin.get('/projects/' + project)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user
+
+    r = as_admin.get('/sessions/' + session)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user
+
+    r = as_admin.get('/acquisitions/' + acquisition)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user
+
+    # Modify user permissions
+    payload = {'access': 'rw', '_id': user_id}
+    r = as_admin.put('/groups/' + group + '/permissions/' + user_id, json=payload, params={'propagate': True})
+    assert r.ok
+
+    r = as_admin.get('/groups/' + group)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user and user['access'] == 'rw'
+
+    r = as_admin.get('/projects/' + project)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user and user['access'] == 'rw'
+
+    r = as_admin.get('/sessions/' + session)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user and user['access'] == 'rw'
+
+    r = as_admin.get('/acquisitions/' + acquisition)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user and user['access'] == 'rw'
+
+    # Remove user from project permissions
+    r = as_admin.delete('/groups/' + group + '/permissions/' + user_id, json=payload, params={'propagate': True})
+    assert r.ok
+
+    r = as_admin.get('/groups/' + group)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user is None
+
+    r = as_admin.get('/projects/' + project)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user is None
+
+    r = as_admin.get('/sessions/' + session)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user is None
+
+    r = as_admin.get('/acquisitions/' + acquisition)
+    perms = r.json()['permissions']
+    user = get_user_in_perms(perms, user_id)
+    assert r.ok and user is None
 
 # Test tag pool renaming and deletion
 def test_add_rename_remove_group_tag(data_builder, as_admin):


### PR DESCRIPTION
Fixes #601 
### Changes
- ```/groups/{GroupId}/permission?propagate=true``` will now propagate permission changes down hierarchy
- `POST` will add the permission to all of that group's projects that doesn't have that user's permission already, projects that do already have it are updated to the new access
- `PUT` and `DELETE` will update and delete that group's projects that already have the user's permission and won't affect projects without the user's permission.
### Review Checklist
- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
