### PR TITLE
Pin to latest pyOpenSSL package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ enum==0.4.6
 jsonschema==2.6.0
 Markdown==2.6.5
 pymongo==3.2
-pyOpenSSL==0.15.1
+pyOpenSSL==17.1.0
 python-dateutil==2.4.2
 pytz==2015.7
 requests==2.9.1


### PR DESCRIPTION
In recent builds, an older version of pyOpenSSL was causing issues:
https://travis-ci.org/scitran/core/builds/254507311
```
Running pylint ...
Traceback (most recent call last):
  File "/opt/python/2.7.13/lib/python2.7/site-packages/_pytest/config.py", line 319, in _importconftest
    mod = conftestpath.pyimport()
  File "/opt/python/2.7.13/lib/python2.7/site-packages/py/_path/local.py", line 662, in pyimport
    __import__(modname)
  File "/home/travis/build/scitran/core/test/unit_tests/python/conftest.py", line 10, in <module>
    import api.config
  File "/home/travis/build/scitran/core/api/config.py", line 8, in <module>
    import elasticsearch
  File "/opt/python/2.7.13/lib/python2.7/site-packages/elasticsearch/__init__.py", line 17, in <module>
    from .client import Elasticsearch
  File "/opt/python/2.7.13/lib/python2.7/site-packages/elasticsearch/client/__init__.py", line 4, in <module>
    from ..transport import Transport
  File "/opt/python/2.7.13/lib/python2.7/site-packages/elasticsearch/transport.py", line 4, in <module>
    from .connection import Urllib3HttpConnection
  File "/opt/python/2.7.13/lib/python2.7/site-packages/elasticsearch/connection/__init__.py", line 2, in <module>
    from .http_requests import RequestsHttpConnection
  File "/opt/python/2.7.13/lib/python2.7/site-packages/elasticsearch/connection/http_requests.py", line 4, in <module>
    import requests
  File "/opt/python/2.7.13/lib/python2.7/site-packages/requests/__init__.py", line 84, in <module>
    from urllib3.contrib import pyopenssl
  File "/opt/python/2.7.13/lib/python2.7/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/opt/python/2.7.13/lib/python2.7/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import rand, crypto, SSL
  File "/opt/python/2.7.13/lib/python2.7/site-packages/OpenSSL/SSL.py", line 118, in <module>
    SSL_ST_INIT = _lib.SSL_ST_INIT
AttributeError: 'module' object has no attribute 'SSL_ST_INIT'
ERROR: could not load /home/travis/build/scitran/core/test/unit_tests/python/conftest.py
```

Upgrading to latest fixed the issue. @ryansanford any concerns I should have about moving so far forward with this dependency in your opinion? 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
