### PR TITLE
Change rule logic to use before/after container changes

### DIFF
--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -117,6 +117,12 @@ class ContainerReference(object):
         self.type = type
         self.id = id
 
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self.__dict__ == other.__dict__
+
     @classmethod
     def from_dictionary(cls, d):
         return cls(
@@ -175,6 +181,12 @@ class FileReference(ContainerReference):
     def __init__(self, type, id, name):
         super(FileReference, self).__init__(type, id)
         self.name = name
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self.__dict__ == other.__dict__
 
     @classmethod
     def from_dictionary(cls, d):

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -272,12 +272,27 @@ def upsert_fileinfo(cont_name, _id, fileinfo):
         '_id': _id,
         'files.name': fileinfo['name'],
     })
+    container, file_before, file_after = None, None, None
 
     if result is None:
+
         fileinfo['created'] = fileinfo['modified']
-        return add_fileinfo(cont_name, _id, fileinfo)
+        container = add_fileinfo(cont_name, _id, fileinfo)
     else:
-        return update_fileinfo(cont_name, _id, fileinfo)
+        # Find existing file in result and set to file_before
+        for f in result['files']:
+            if f['name'] == fileinfo['name']:
+                file_before = f
+                break
+        container = update_fileinfo(cont_name, _id, fileinfo)
+
+    for f in container['files']:
+        # Fine file in result and set to file_after
+        if f['name'] == fileinfo['name']:
+            file_after = f
+            break
+
+    return container, file_before, file_after
 
 def update_fileinfo(cont_name, _id, fileinfo):
     if fileinfo.get('size') is not None:

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -96,6 +96,30 @@ class Job(object):
         self.saved_files        = saved_files
         self.produced_metadata  = produced_metadata
 
+
+    def intention_equals(self, other_job):
+        """
+        Compare this job's intention to other_job.
+        Returns True if other_job's gear_id, inputs and destination match self.
+        Returns False otherwise.
+
+        Useful for comparing auto-triggered jobs for equality.
+        Implicitly uses dict, FileReference and ContainerReference _cmp_ methods.
+        """
+        if (
+            isinstance(other_job, Job) and
+            self.gear_id == other_job.gear_id and
+            self.inputs == other_job.inputs and
+            self.destination == other_job.destination
+        ):
+            config.log.debug('the jobs {} and {} are equal.'.format(self.map, other_job.map))
+            return True
+
+        else:
+            config.log.debug('the jobs {} and {} are NOT equal.'.format(self.map, other_job.map))
+            return False
+
+
     @classmethod
     def load(cls, e):
         # TODO: validate

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -204,22 +204,7 @@ def create_potential_jobs(db, container, container_type, file_):
 
     return potential_jobs
 
-def create_jobs(db, container, container_type, file_):
-    """
-    Given a file and it's container, enqueues all jobs created via rules for that file and its container.
-    Returns the algorithm names that were queued.
-    """
-
-    potential_jobs = create_potential_jobs(db, container, container_type, file_)
-    spawned_jobs = []
-
-    for pj in potential_jobs:
-        pj['job'].insert()
-        spawned_jobs.append(pj['rule']['alg'])
-
-    return spawned_jobs
-
-def create_jobs_from_attributes_change(db, container_before, container_after, container_type):
+def create_jobs(db, container_before, container_after, container_type):
     """
     Given a before and after set of file attributes, enqueue a list of jobs that would only be possible
     after the changes.

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -35,6 +35,10 @@ log = config.log
 #         {
 #             'type': 'container.has-type', # Match the container having any file (including this one) with this type
 #             'value': 'bvec'
+#         },
+#         {
+#             'type': 'container.has-measurement', # Match the container having any file (including this one) with this measurement
+#             'value': 'functional'
 #         }
 #     ]
 # }
@@ -89,6 +93,16 @@ def eval_match(match_type, match_param, file_, container):
         for c_file in container['files']:
             if match_param.lower() == c_file.get('type').lower():
                 return True
+
+        return False
+
+    # Match the container having any file (including this one) with this measurement
+    elif match_type == 'container.has-measurement':
+        for c_file in container['files']:
+            if match_param:
+                return match_param.lower() in map(lower, file_.get('measurements', []))
+            else:
+                continue
 
         return False
 

--- a/api/placer.py
+++ b/api/placer.py
@@ -95,7 +95,7 @@ class Placer(object):
 
             # Queue any jobs as a result of this upload, uploading to a gear will not make jobs though
             if self.container_type != 'gear':
-                rules.create_jobs_from_attributes_change(config.db, container_before, self.container, self.container_type)
+                rules.create_jobs(config.db, container_before, self.container, self.container_type)
 
     def recalc_session_compliance(self):
         if self.container_type in ['session', 'acquisition'] and self.id_:

--- a/raml/schemas/input/rule-add.json
+++ b/raml/schemas/input/rule-add.json
@@ -20,7 +20,8 @@
                             "file.type",
                             "file.name",
                             "file.measurements",
-                            "container.has-type"
+                            "container.has-type",
+                            "container.has-measurement"
                         ]
                     },
                     "value": {
@@ -40,7 +41,8 @@
                             "file.type",
                             "file.name",
                             "file.measurements",
-                            "container.has-type"
+                            "container.has-type",
+                            "container.has-measurement"
                         ]
                     },
                     "value": {

--- a/raml/schemas/input/rule-update.json
+++ b/raml/schemas/input/rule-update.json
@@ -26,7 +26,8 @@
                             "file.type",
                             "file.name",
                             "file.measurements",
-                            "container.has-type"
+                            "container.has-type",
+                            "container.has-measurement"
                         ]
                     },
                     "value": {
@@ -46,7 +47,8 @@
                             "file.type",
                             "file.name",
                             "file.measurements",
-                            "container.has-type"
+                            "container.has-type",
+                            "container.has-measurement"
                         ]
                     },
                     "value": {


### PR DESCRIPTION
Closes #863

Adds a new rule type `container.has-measurement` that, like the existing type `container.has-type`, will "match" when the container has a file (including the one being evaluated) with the given measurement string. Direct match only, wildcards are not currently supported. 

Example of rule using new rule type:
```
{
    "alg": "qa-report-fmri",
    "name": "Run qa-report-fmri on nifti",
    "all": [
        { "type": "file.type", "value": "nifti" }
    ],
    "any": [
        { "type": "container.has-measurement", "value": "functional" },
        { "type": "container.has-measurement", "value": "anatomical" }
    ]
}
``` 

This PR also changes the behavior of rule evaluation after a file is added or modified via one of the placers. 
  - Before, new jobs spawned via rules would only be triggered for a file when it was added. Using that logic, any rule that referenced the container would only be triggered if the container was in the proper state when the file was added. For example, if a nifti is added the dicom must already be classified and have a measurement, or this rule would not trigger. Later, when the dicom's measurement is set, the nifti has already had its one and only rule evaluation during upload so the job would never trigger. 

  - Now, when files are added or edited via one of the placers, the container is evaluated as a whole before and after the change. The list of jobs that would be spawned before and after is compared, and only those in the after set are spawned, which solved the problem noted above. 

### Breaking Changes
New rule type: `container.has-measurement`

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
