### PR TITLE
PHI permission Enhancements

### DIFF
--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -4,7 +4,7 @@ from ..types import Origin
 PERMISSIONS = [
     {
         'rid': 'no-phi-ro',
-        'name': 'PHI-Read-Only',
+        'name': 'Read-Only (No PHI)',
     },
     {
         'rid': 'ro',

--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -7,6 +7,10 @@ PERMISSIONS = [
         'name': 'Read-Only',
     },
     {
+        'rid': 'phi-ro',
+        'name': 'PHI-Read-Only',
+    },
+    {
         'rid': 'rw',
         'name': 'Read-Write',
     },
@@ -17,6 +21,11 @@ PERMISSIONS = [
 ]
 
 INTEGER_PERMISSIONS = {r['rid']: i for i, r in enumerate(PERMISSIONS)}
+
+PHI_FIELDS = {'info': 0, 'analyses': 0, 'subject.firstname': 0,
+              'subject.lastname': 0, 'subject.sex': 0, 'subject.age': 0,
+              'subject.race': 0, 'subject.ethnicity': 0, 'subject.info': 0,
+              'files.info': 0, 'tags': 0}
 
 def _get_access(uid, container):
     permissions_list = container.get('permissions', [])

--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -3,12 +3,12 @@ from ..types import Origin
 
 PERMISSIONS = [
     {
-        'rid': 'ro',
-        'name': 'Read-Only',
+        'rid': 'no-phi-ro',
+        'name': 'PHI-Read-Only',
     },
     {
-        'rid': 'phi-ro',
-        'name': 'PHI-Read-Only',
+        'rid': 'ro',
+        'name': 'Read-Only',
     },
     {
         'rid': 'rw',

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -90,8 +90,8 @@ def collection_permissions(handler, container=None, _=None):
 
             if has_access:
                 result = exec_op(method, _id=_id, payload=payload)
-                if handler.is_true('phi'):
-                    if _get_access(handler.uid, parent_container) <= INTEGER_PERMISSIONS['no-phi-ro']:
+                if not handler.is_true('phi'):
+                    if _get_access(handler.uid, container) <= INTEGER_PERMISSIONS['no-phi-ro']:
                         handler.abort(403, "User not authorized to view PHI fields.")
                     result = file_info_scrub(result)
                 return result
@@ -116,7 +116,7 @@ def default_referer(handler, parent_container=None):
 
             if has_access:
                 result = exec_op(method, _id=_id, payload=payload)
-                if handler.is_true('phi'):
+                if not handler.is_true('phi'):
                     if _get_access(handler.uid, parent_container) <= INTEGER_PERMISSIONS['no-phi-ro']:
                         handler.abort(403, "User not authorized to view PHI fields.")
                     result = file_info_scrub(result)
@@ -167,7 +167,7 @@ def phi_scrub(result):
                 if result.get(field):
                     result[field][deeper_field] = SCRUB
         elif result.get(field):
-            result[field] = scrub
+            result[field] = SCRUB
     result = file_info_scrub(result)
     return result
 

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -22,7 +22,7 @@ def default_container(handler, container=None, target_parent_container=None):
             if method == 'GET' and container.get('public', False):
                 has_access = True
             elif method == 'GET':
-                has_access = _get_access(handler.uid, container) >= INTEGER_PERMISSIONS['ro']
+                has_access = _get_access(handler.uid, container) >= INTEGER_PERMISSIONS['no-phi-ro']
             elif method == 'POST':
                 required_perm = 'rw'
                 if target_parent_container.get('cont_name') == 'group':
@@ -50,7 +50,7 @@ def default_container(handler, container=None, target_parent_container=None):
             else:
                 has_access = False
 
-            if _get_access(handler.uid, container) < INTEGER_PERMISSIONS['phi-ro']:
+            if method == 'GET' and _get_access(handler.uid, container) < INTEGER_PERMISSIONS['ro']:
                 if not projection:
                     projection = PHI_FIELDS
                 else:
@@ -77,7 +77,7 @@ def collection_permissions(handler, container=None, _=None):
             if method == 'GET' and container.get('public', False):
                 has_access = True
             elif method == 'GET':
-                has_access = _get_access(handler.uid, container) >= INTEGER_PERMISSIONS['ro']
+                has_access = _get_access(handler.uid, container) >= INTEGER_PERMISSIONS['no-phi-ro']
             elif method == 'DELETE':
                 has_access = _get_access(handler.uid, container) >= INTEGER_PERMISSIONS['admin']
             elif method == 'POST':
@@ -102,7 +102,7 @@ def default_referer(handler, parent_container=None):
             if method == 'GET' and parent_container.get('public', False):
                 has_access = True
             elif method == 'GET':
-                has_access = access >= INTEGER_PERMISSIONS['ro']
+                has_access = access >= INTEGER_PERMISSIONS['no-phi-ro']
             elif method in ['POST', 'PUT', 'DELETE']:
                 has_access = access >= INTEGER_PERMISSIONS['rw']
             else:

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -92,9 +92,9 @@ def collection_permissions(handler, container=None, _=None):
             if has_access:
                 result = exec_op(method, _id=_id, payload=payload)
                 if method == 'GET' and not handler.is_true('phi'):
-                    if _get_access(handler.uid, container) <= INTEGER_PERMISSIONS['no-phi-ro']:
-                        handler.abort(403, "User not authorized to view PHI fields.")
                     result = file_info_scrub(result)
+                elif _get_access(handler.uid, container) <= INTEGER_PERMISSIONS['no-phi-ro']:
+                    handler.abort(403, "User not authorized to view PHI fields.")
                 return result
             else:
                 handler.abort(403, 'user not authorized to perform a {} operation on the container'.format(method))
@@ -118,9 +118,9 @@ def default_referer(handler, parent_container=None):
             if has_access:
                 result = exec_op(method, _id=_id, payload=payload)
                 if method == 'GET' and not handler.is_true('phi') and exec_op is not noop:
-                    if _get_access(handler.uid, parent_container) <= INTEGER_PERMISSIONS['no-phi-ro']:
-                        handler.abort(403, "User not authorized to view PHI fields.")
                     result = file_info_scrub(result)
+                elif _get_access(handler.uid, parent_container) <= INTEGER_PERMISSIONS['no-phi-ro']:
+                    handler.abort(403, "User not authorized to view PHI fields.")
                 return result
             else:
                 handler.abort(403, 'user not authorized to perform a {} operation on parent container'.format(method))

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -4,6 +4,10 @@ Purpose of this module is to define all the permissions checker decorators for t
 
 from . import _get_access, INTEGER_PERMISSIONS
 
+PHI_FIELDS = {'info': 0, 'analyses': 0, 'subject.firstname': 0,
+              'subject.lastname': 0, 'subject.sex': 0, 'subject.age': 0,
+              'subject.race': 0, 'subject.ethnicity': 0, 'subject.info': 0,
+              'files.info': 0, 'tags': 0}
 
 def default_container(handler, container=None, target_parent_container=None):
     """
@@ -45,6 +49,12 @@ def default_container(handler, container=None, target_parent_container=None):
                 has_access = _get_access(handler.uid, container) >= INTEGER_PERMISSIONS[required_perm]
             else:
                 has_access = False
+
+            if _get_access(handler.uid, container) < INTEGER_PERMISSIONS['phi-ro']:
+                if not projection:
+                    projection = PHI_FIELDS
+                else:
+                    projection.update(PHI_FIELDS)
 
             if has_access:
                 return exec_op(method, _id=_id, payload=payload, unset_payload=unset_payload, recursive=recursive, r_payload=r_payload, replace_metadata=replace_metadata, projection=projection)

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -3,6 +3,7 @@ Purpose of this module is to define all the permissions checker decorators for t
 """
 
 from . import _get_access, INTEGER_PERMISSIONS
+from ..dao import noop
 
 PHI_FIELDS = {'info': '***', 'analyses': "***", 'subject': {'firstname': "***", 'lastname': "***", 'sex': "***",
                     'age': "***", 'race': "***", 'ethnicity': "***", 'info': "***"}, 'tags': "***"}
@@ -56,7 +57,7 @@ def default_container(handler, container=None, target_parent_container=None):
                     if handler.is_true('phi'):
                         handler.abort(403, "User not authorized to view PHI fields.")
                     result = phi_scrub(result)
-                elif not handler.is_true('phi'):
+                elif method == 'GET' and not handler.is_true('phi') and exec_op is not noop:
                     result = file_info_scrub(result)
                 return result
             else:
@@ -90,7 +91,7 @@ def collection_permissions(handler, container=None, _=None):
 
             if has_access:
                 result = exec_op(method, _id=_id, payload=payload)
-                if not handler.is_true('phi'):
+                if method == 'GET' and not handler.is_true('phi'):
                     if _get_access(handler.uid, container) <= INTEGER_PERMISSIONS['no-phi-ro']:
                         handler.abort(403, "User not authorized to view PHI fields.")
                     result = file_info_scrub(result)
@@ -116,7 +117,7 @@ def default_referer(handler, parent_container=None):
 
             if has_access:
                 result = exec_op(method, _id=_id, payload=payload)
-                if not handler.is_true('phi'):
+                if method == 'GET' and not handler.is_true('phi') and exec_op is not noop:
                     if _get_access(handler.uid, parent_container) <= INTEGER_PERMISSIONS['no-phi-ro']:
                         handler.abort(403, "User not authorized to view PHI fields.")
                     result = file_info_scrub(result)

--- a/api/auth/groupauth.py
+++ b/api/auth/groupauth.py
@@ -17,7 +17,7 @@ def default(handler, group=None):
                 handler.abort(403, 'not allowed to perform operation')
             elif _get_access(handler.uid, group) >= INTEGER_PERMISSIONS['admin']:
                 pass
-            elif method == 'GET' and _get_access(handler.uid, group) >= INTEGER_PERMISSIONS['ro']:
+            elif method == 'GET' and _get_access(handler.uid, group) >= INTEGER_PERMISSIONS['no-phi-ro']:
                 pass
             else:
                 handler.abort(403, 'not allowed to perform operation')

--- a/api/auth/listauth.py
+++ b/api/auth/listauth.py
@@ -23,7 +23,7 @@ def default_sublist(handler, container):
             if method == 'GET' and container.get('public', False):
                 min_access = -1
             elif method == 'GET':
-                min_access = INTEGER_PERMISSIONS['ro']
+                min_access = INTEGER_PERMISSIONS['no-phi-ro']
             elif method in ['POST', 'PUT', 'DELETE']:
                 min_access = INTEGER_PERMISSIONS['rw']
             else:
@@ -59,7 +59,7 @@ def group_tags_sublist(handler, container):
     access = _get_access(handler.uid, container)
     def g(exec_op):
         def f(method, _id, query_params = None, payload = None, exclude_params=None):
-            if method == 'GET'  and access >= INTEGER_PERMISSIONS['ro']:
+            if method == 'GET'  and access >= INTEGER_PERMISSIONS['no-phi-ro']:
                 return exec_op(method, _id, query_params, payload, exclude_params)
             elif access >= INTEGER_PERMISSIONS['rw']:
                 return exec_op(method, _id, query_params, payload, exclude_params)
@@ -96,7 +96,7 @@ def notes_sublist(handler, container):
                 pass
             elif method == 'POST' and access >= INTEGER_PERMISSIONS['rw'] and payload['user'] == handler.uid:
                 pass
-            elif method == 'GET' and (access >= INTEGER_PERMISSIONS['ro'] or container.get('public')):
+            elif method == 'GET' and (access >= INTEGER_PERMISSIONS['no-phi-ro'] or container.get('public')):
                 pass
             elif method in ['GET', 'DELETE', 'PUT'] and container['notes'][0]['user'] == handler.uid:
                 pass

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -5,6 +5,7 @@ from .. import config
 from ..auth import containerauth, always_ok
 from ..dao import containerstorage, containerutil
 from ..dao import APIStorageException
+from ..web.request import AccessType
 from .containerhandler import ContainerHandler
 
 log = config.log

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -402,6 +402,7 @@ class ContainerHandler(base.RequestHandler):
         # Load the parent container in which the new container will be created
         # to check permissions.
         parent_container, parent_id_property = self._get_parent_container(payload)
+        
         # Always add the id of the parent to the container
         payload[parent_id_property] = parent_container['_id']
         # If the new container is a session add the group of the parent project in the payload

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -115,6 +115,8 @@ class ContainerHandler(base.RequestHandler):
 
         inflate_job_info = cont_name == 'sessions'
         result['analyses'] = AnalysisStorage().get_analyses(cont_name, _id, inflate_job_info)
+
+
         return self.handle_origin(result)
 
     def handle_origin(self, result):
@@ -299,6 +301,8 @@ class ContainerHandler(base.RequestHandler):
         if self.is_true('permissions'):
             if not projection:
                 projection = None
+        if self.is_true('phi'):
+            projection = None
 
         # select which permission filter will be applied to the list of results.
         if self.superuser_request:
@@ -321,6 +325,7 @@ class ContainerHandler(base.RequestHandler):
             query = {}
         if not self.is_true('archived'):
             query['archived'] = {'$ne': True}
+
         # this request executes the actual reqeust filtering containers based on the user permissions
         results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection)
         if results is None:
@@ -342,6 +347,8 @@ class ContainerHandler(base.RequestHandler):
                 result = containerutil.get_stats(result, cont_name)
             result = self.handle_origin(result)
             modified_results.append(result)
+            if self.is_true('phi'):
+                self.log_user_access(AccessType.view_container, cont_name=cont_name, cont_id=result.get('_id'))
 
         if self.is_true('join_avatars'):
             modified_results = self.join_user_info(modified_results)

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -349,6 +349,7 @@ class ContainerHandler(base.RequestHandler):
             modified_results.append(result)
             if self.is_true('phi'):
                 self.log_user_access(AccessType.view_container, cont_name=cont_name, cont_id=result.get('_id'))
+                self.log_user_access(AccessType.view_file, cont_name=cont_name, cont_id=result.get('_id'))
 
         if self.is_true('join_avatars'):
             modified_results = self.join_user_info(modified_results)

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -492,6 +492,7 @@ class ContainerHandler(base.RequestHandler):
             # and checking permissions using respectively the two decorators, mongo_validator and permchecker
             result = mongo_validator(permchecker(self.storage.exec_op))('PUT',
                         _id=_id, payload=payload, recursive=rec, r_payload=r_payload, replace_metadata=replace_metadata)
+
         except APIStorageException as e:
             self.abort(400, e.message)
 

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -92,8 +92,7 @@ class AnalysesHandler(RefererHandler):
     def get(self, cont_name, cid, _id):
         parent = self.storage.get_parent(cont_name, cid)
         permchecker = self.get_permchecker(parent)
-        permchecker(noop)('GET')
-        return self.storage.get_container(_id)
+        return permchecker(self.storage.exec_op)('GET', _id=_id)
 
 
     @log_access(AccessType.delete_analysis)

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -88,7 +88,7 @@ class AnalysesHandler(RefererHandler):
         else:
             self.abort(500, 'Analysis not added for container {} {}'.format(cont_name, cid))
 
-
+    @log_access(AccessType.view_analysis)
     def get(self, cont_name, cid, _id):
         parent = self.storage.get_parent(cont_name, cid)
         permchecker = self.get_permchecker(parent)

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -362,7 +362,7 @@ class RequestHandler(webapp2.RequestHandler):
         if access_type not in [AccessType.user_login, AccessType.user_logout]:
 
             if cont_name is None or cont_id is None:
-                raise Exception('Container information not available.')
+                raise Exception('Container information, {}, {}, not available.'.format(cont_name, cont_id))
 
             # Create a context tree for the container
             context = {}

--- a/api/web/request.py
+++ b/api/web/request.py
@@ -7,6 +7,7 @@ from .. import config
 from .. import util
 
 AccessType = util.Enum('AccessType', {
+    'view_analysis':    'view_analysis',
     'view_container':   'view_container',
     'view_subject':     'view_subject',
     'view_file':        'view_file',
@@ -59,12 +60,18 @@ def log_access(access_type, cont_kwarg='cont_name', cont_id_kwarg='cid'):
                 cont_name = kwargs.get(cont_kwarg)
                 cont_id = kwargs.get(cont_id_kwarg)
 
+                if self.is_true('phi'):
+                    if access_type is AccessType.view_container:
+                        self.log_user_access(AccessType.view_file, cont_name, cont_id)
+                    elif access_type is AccessType.view_analysis:
+                        self.log_user_access(AccessType.view_file, "analyses", kwargs.get('_id'))
+                        return result
+
+
                 # Only log view_container events when the container is a session
                 if access_type is AccessType.view_container and cont_name not in ['sessions', 'session']:
                     return result
 
-            if self.is_true('phi') and access_type is AccessType.view_container:
-                self.log_user_access(AccessType.view_file, cont_name, cont_id)
             self.log_user_access(access_type, cont_name, cont_id)
 
             return result

--- a/api/web/request.py
+++ b/api/web/request.py
@@ -63,6 +63,8 @@ def log_access(access_type, cont_kwarg='cont_name', cont_id_kwarg='cid'):
                 if access_type is AccessType.view_container and cont_name not in ['sessions', 'session']:
                     return result
 
+            if self.is_true('phi') and access_type is AccessType.view_container:
+                self.log_user_access(AccessType.view_file, cont_name, cont_id)
             self.log_user_access(access_type, cont_name, cont_id)
 
             return result

--- a/raml/schemas/definitions/permission.json
+++ b/raml/schemas/definitions/permission.json
@@ -3,7 +3,7 @@
   "type": "object",
   "definitions": {
     "_id":            { "type": "string" },
-    "access":         { "enum": ["ro", "rw", "admin"] },
+    "access":         { "enum": ["ro", "phi-ro", "rw", "admin"] },
     "permission":{
       "type":"object",
       "properties":{

--- a/raml/schemas/definitions/permission.json
+++ b/raml/schemas/definitions/permission.json
@@ -3,7 +3,7 @@
   "type": "object",
   "definitions": {
     "_id":            { "type": "string" },
-    "access":         { "enum": ["ro", "phi-ro", "rw", "admin"] },
+    "access":         { "enum": ["no-phi-ro", "ro", "rw", "admin"] },
     "permission":{
       "type":"object",
       "properties":{

--- a/test/integration_tests/python/test_containers.py
+++ b/test/integration_tests/python/test_containers.py
@@ -299,14 +299,6 @@ def test_get_container(data_builder, file_form, as_drone, as_admin, as_public, a
     assert r.ok
     assert r.json()['analyses'][1]['job']['id'] != analysis_job
 
-    r = as_admin.put('/sessions/' + session, json={"subject":{"firstname":"FirstName"}}, params={'replace_metadata':True})
-    assert r.ok
-    r = as_admin.put('/projects/' + project + '/permissions/admin@user.com', json={'access': 'no-phi-ro'})
-    assert r.ok
-    r = as_admin.get('/sessions/' + session)
-    assert r.ok
-    assert r.json().get('subject').get('firstname') == '***'
-
 
 def test_get_session_jobs(data_builder, as_admin):
     gear = data_builder.create_gear()
@@ -379,6 +371,46 @@ def test_post_container(data_builder, as_admin, as_user):
     assert r.ok
 
     data_builder.delete_group(group, recursive=True)
+
+def test_phi_access(data_builder, as_admin, file_form, log_db):
+    project = data_builder.create_project()
+    session = data_builder.create_session()
+    as_admin.post('/projects/' + project + '/files', files=file_form(
+        'user.csv', meta={'name': 'user.csv', 'info': {'PHI': 'VERY PHI'}}))
+    r = as_admin.put('/sessions/' + session, json={"subject":{"firstname":"FirstName"}}, params={'replace_metadata':True})
+    assert r.ok
+
+
+    # Test PHI access and logging of containers with and without phi flag
+    pre_log = log_db.access_log.count({})
+    r = as_admin.get('/sessions/' + session)
+    assert r.ok
+    assert r.json().get('subject').get('firstname') == 'FirstName'
+    post_log = log_db.access_log.count({})
+    assert pre_log == post_log - 1
+
+    r = as_admin.get('/projects/' + project)
+    assert r.ok
+    assert r.json().get('files')[0].get('info') == '***'
+    r = as_admin.get('/projects/' + project, params={'phi':True})
+    assert r.ok
+    assert r.json().get('files')[0].get('info').get('PHI') == 'VERY PHI'
+    post_log = log_db.access_log.count({})
+    assert pre_log == post_log - 2
+
+    # Test no PHI access of containers with and without phi flag
+    r = as_admin.put('/projects/' + project + '/permissions/admin@user.com', json={'access': 'no-phi-ro'})
+    assert r.ok
+    r = as_admin.get('/sessions/' + session)
+    assert r.ok
+    assert r.json().get('subject').get('firstname') == '***'
+
+    r = as_admin.get('/sessions/' + session, params={'phi':True})
+    assert r.status_code == 403
+
+    
+
+
 
 
 def test_put_container(data_builder, as_admin):

--- a/test/integration_tests/python/test_containers.py
+++ b/test/integration_tests/python/test_containers.py
@@ -299,6 +299,14 @@ def test_get_container(data_builder, file_form, as_drone, as_admin, as_public, a
     assert r.ok
     assert r.json()['analyses'][1]['job']['id'] != analysis_job
 
+    r = as_admin.put('/sessions/' + session, json={"subject":{"firstname":"FirstName"}}, params={'replace_metadata':True})
+    assert r.ok
+    r = as_admin.put('/projects/' + project + '/permissions/admin@user.com', json={'access': 'no-phi-ro'})
+    assert r.ok
+    r = as_admin.get('/sessions/' + session)
+    assert r.ok
+    assert r.json().get('subject').get('firstname') == '***'
+
 
 def test_get_session_jobs(data_builder, as_admin):
     gear = data_builder.create_gear()


### PR DESCRIPTION
Fixes #869 
### To Do
- [ ] Tests
- [ ] Collections
### Changes Made
- New access level `no-phi-ro`, allows users to to read only with out any PHI fields
- New flag `phi` that can only be used by users with access level > `no-phi-ro` that returns all PHI fields for get and get_all
- Log file views when file info is accessed through use of the `phi` flag for containers, analyses, and collections
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
