### PR TITLE
Add `info_exists` boolean to files on container list endpoints

### DIFF
--- a/api/dao/base.py
+++ b/api/dao/base.py
@@ -195,6 +195,8 @@ class ContainerStorage(object):
         results = list(self.dbc.find(query, projection))
         for cont in results:
             cont = self._from_mongo(cont)
+            if fill_defaults:
+                cont =  self._fill_default_values(cont)
             if replace_info_with_bool:
                 for f in cont.get('files', []):
                     f['info_exists'] = bool(f.pop('info', False))

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -80,7 +80,7 @@ class ContainerHandler(base.RequestHandler):
             'parent_storage': containerstorage.SessionStorage(),
             'storage_schema_file': 'acquisition.json',
             'payload_schema_file': 'acquisition.json',
-            'list_projection': {'info': 0, 'collections': 0, 'files.info': 0, 'tag': 0}
+            'list_projection': {'info': 0, 'collections': 0, 'files.info': 0, 'tags': 0}
         }
     }
 

--- a/raml/schemas/definitions/file.json
+++ b/raml/schemas/definitions/file.json
@@ -62,7 +62,8 @@
               "hash":{"$ref":"#/definitions/hash"},
               "created":{"$ref":"../definitions/created-modified.json#/definitions/created"},
               "modified":{"$ref":"../definitions/created-modified.json#/definitions/modified"},
-              "size":{"$ref":"#/definitions/size"}
+              "size":{"$ref":"#/definitions/size"},
+              "info_exists": {"type": "boolean"}
             },
             "additionalProperties": false,
             "required":["modified", "size"]


### PR DESCRIPTION
Allows clients to optionally show "view info" when file has an info field that was withheld (on list endpoints).

### New endpoints
List endpoints will get a new key on files: `info_exists`, a boolean.

Example:
```
GET base_url/api/sessions/<session_id>/acquisitions

[
  {
    "files": [
      {
        "origin": {},
        "info_exists": true,
        "measurements": ["localizer"],
        "name": "149_1_1_localizer.dicom.zip",
        "created": "2017-07-19T17:54:00.355000+00:00",
        "modified": "2017-07-19T17:58:01.127000+00:00",
        "type": "dicom",
        "modality": "MR"
        ...
     
```

### Breaking Changes
None

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
