### PR TITLE
On label uploads, if project label is blank, add to "Unknown" project

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -246,7 +246,7 @@ def initialize_db():
     create_or_recreate_ttl_index('downloads', 'timestamp', 60)
 
     now = datetime.datetime.utcnow()
-    db.groups.update_one({'_id': 'unknown'}, {'$setOnInsert': { 'created': now, 'modified': now, 'name': 'Unknown', 'permissions': []}}, upsert=True)
+    db.groups.update_one({'_id': 'unknown'}, {'$setOnInsert': { 'created': now, 'modified': now, 'label': 'Unknown', 'permissions': []}}, upsert=True)
 
 def get_config():
     global __last_update, __config, __config_persisted #pylint: disable=global-statement

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -320,9 +320,7 @@ def _group_id_fuzzy_match(group_id, project_label):
     if len(group_id_matches) == 1:
         group_id = group_id_matches[0]
     else:
-        if project_label == '':
-            project_label = 'Unknown'
-        else:
+        if group_id != '' or project_label != '':
             project_label = group_id + '_' + project_label
         group_id = 'unknown'
     return group_id, project_label
@@ -330,6 +328,9 @@ def _group_id_fuzzy_match(group_id, project_label):
 def _find_or_create_destination_project(group_id, project_label, timestamp, user):
     group_id, project_label = _group_id_fuzzy_match(group_id, project_label)
     group = config.db.groups.find_one({'_id': group_id})
+
+    if project_label == '':
+        project_label = 'Unknown'
 
     project = config.db.projects.find_one({'group': group['_id'], 'label': {'$regex': re.escape(project_label), '$options': 'i'}})
 

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -320,7 +320,10 @@ def _group_id_fuzzy_match(group_id, project_label):
     if len(group_id_matches) == 1:
         group_id = group_id_matches[0]
     else:
-        project_label = group_id + '_' + project_label
+        if project_label == '':
+            project_label = 'Unknown'
+        else:
+            project_label = group_id + '_' + project_label
         group_id = 'unknown'
     return group_id, project_label
 

--- a/test/integration_tests/python/test_uploads.py
+++ b/test/integration_tests/python/test_uploads.py
@@ -90,7 +90,7 @@ def test_reaper_upload(data_builder, randstr, upload_file_form, as_admin):
     data_builder.delete_group(group_1, recursive=True)
     data_builder.delete_group(group_2, recursive=True)
 
-def test_reaper_upload_unknown_group_project(data_builder, file_form, as_admin):
+def test_reaper_upload_unknown_group_project(data_builder, file_form, as_root, as_admin):
     """
     If the label endpoint receives an upload with a blank group and project, set to
     group: unknown and create or find "Unknown" project
@@ -98,7 +98,7 @@ def test_reaper_upload_unknown_group_project(data_builder, file_form, as_admin):
 
 
     # Upload without group id or project label
-    r = as_admin.post('/upload/label', files=file_form(
+    r = as_root.post('/upload/label', files=file_form(
         'acquisition.csv',
         meta={
             'group': {'_id': ''},
@@ -118,20 +118,20 @@ def test_reaper_upload_unknown_group_project(data_builder, file_form, as_admin):
 
 
     # get session created by the upload
-    r = as_admin.get('/groups/unknown/projects')
+    r = as_root.get('/groups/unknown/projects')
     assert r.ok
     project_list = r.json()
-    assert len(project_list) == 0
+    assert len(project_list) == 1
     project = project_list[0]
     assert 'Unknown' == project_list[0]['label']
     unknown_project = project['_id']
 
-    assert len(as_admin.get('/projects/' + unknown_project + '/sessions').json()) == 1
-    session = as_admin.get('/projects/' + unknown_project + '/sessions').json()[0]['_id']
-    assert len(as_admin.get('/sessions/' + session + '/acquisitions').json()) == 1
+    assert len(as_root.get('/projects/' + unknown_project + '/sessions').json()) == 1
+    session = as_root.get('/projects/' + unknown_project + '/sessions').json()[0]['_id']
+    assert len(as_root.get('/sessions/' + session + '/acquisitions').json()) == 1
 
     # do another upload without group id or project label
-    r = as_admin.post('/upload/label', files=file_form(
+    r = as_root.post('/upload/label', files=file_form(
         'acquisition.csv',
         meta={
             'group': {'_id': ''},
@@ -150,9 +150,9 @@ def test_reaper_upload_unknown_group_project(data_builder, file_form, as_admin):
     assert r.ok
 
     # Test that another session was added to Unkonwn project
-    assert len(as_admin.get('/projects/' + unknown_project + '/sessions').json()) == 2
-    session2 = as_admin.get('/projects/' + unknown_project + '/sessions').json()[1]['_id']
-    assert len(as_admin.get('/sessions/' + session2 + '/acquisitions').json()) == 1
+    assert len(as_root.get('/projects/' + unknown_project + '/sessions').json()) == 2
+    session2 = as_root.get('/projects/' + unknown_project + '/sessions').json()[1]['_id']
+    assert len(as_root.get('/sessions/' + session2 + '/acquisitions').json()) == 1
 
     # clean up
     data_builder.delete_project(unknown_project, recursive=True)

--- a/test/integration_tests/python/test_uploads.py
+++ b/test/integration_tests/python/test_uploads.py
@@ -154,8 +154,78 @@ def test_reaper_upload_unknown_group_project(data_builder, file_form, as_root, a
     session2 = as_root.get('/projects/' + unknown_project + '/sessions').json()[1]['_id']
     assert len(as_root.get('/sessions/' + session2 + '/acquisitions').json()) == 1
 
+    # Upload with a nonexistent group id and a project label
+    r = as_root.post('/upload/label', files=file_form(
+        'acquisition.csv',
+        meta={
+            'group': {'_id': 'not_a_real_group'},
+            'project': {
+                'label': 'new_project',
+            },
+            'session': {
+                'label': 'test_session_label',
+            },
+            'acquisition': {
+                'label': 'test_acquisition_label',
+                'files': [{'name': 'acquisition.csv'}]
+            }
+        })
+    )
+    assert r.ok
+
+
+    # get session created by the upload
+    r = as_root.get('/groups/unknown/projects')
+    assert r.ok
+    project_list = r.json()
+    assert len(project_list) == 2
+    project = project_list[1]
+    assert 'not_a_real_group_new_project' == project['label']
+    named_unknown_project = project['_id']
+
+    assert len(as_root.get('/projects/' + named_unknown_project + '/sessions').json()) == 1
+    session = as_root.get('/projects/' + named_unknown_project + '/sessions').json()[0]['_id']
+    assert len(as_root.get('/sessions/' + session + '/acquisitions').json()) == 1
+
+    group1 = data_builder.create_group()
+
+    # Upload with an existing group id and no project label
+    r = as_root.post('/upload/label', files=file_form(
+        'acquisition.csv',
+        meta={
+            'group': {'_id': group1},
+            'project': {
+                'label': '',
+            },
+            'session': {
+                'label': 'test_session_label',
+            },
+            'acquisition': {
+                'label': 'test_acquisition_label',
+                'files': [{'name': 'acquisition.csv'}]
+            }
+        })
+    )
+    assert r.ok
+
+
+    # get session created by the upload
+    r = as_root.get('/groups/' + group1 + '/projects')
+    assert r.ok
+    project_list = r.json()
+    assert len(project_list) == 1
+    project = project_list[0]
+    assert 'Unknown' == project['label']
+    project1 = project['_id']
+
+    assert len(as_root.get('/projects/' + project1 + '/sessions').json()) == 1
+    session = as_root.get('/projects/' + project1 + '/sessions').json()[0]['_id']
+    assert len(as_root.get('/sessions/' + session + '/acquisitions').json()) == 1
+
     # clean up
+    data_builder.delete_group(group1, recursive=True)
     data_builder.delete_project(unknown_project, recursive=True)
+    data_builder.delete_project(named_unknown_project, recursive=True)
 
 
 def test_uid_upload(data_builder, file_form, as_admin, as_user, as_public):


### PR DESCRIPTION
The group id and project label are required for label uploads, but if they were a blank string, a project would get created with the label "_" in the group "unknown". Any subsequent calls with a blank string for project label would match the first project in the "unknown" group. 

Now, if the project label is `''`, a project is found or created in the group "unknown" with the label "Unknown". Tests were added for this feature. 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
