### PR TITLE
Null search filter

### DIFF
--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -305,7 +305,34 @@ class DataExplorerHandler(base.RequestHandler):
         for f in filters:
             if f.get('terms'):
                 for k,v in f['terms'].iteritems():
-                    modified_filters.append({'terms': {k+'.raw': v}})
+                    if "null" in v:
+                        v.remove("null")
+                        null_filter = {
+                            'bool': {
+                                'should': [
+                                    {
+                                        'bool': {
+                                            'must': [
+                                                {
+                                                    'bool': {
+                                                        'must_not': {
+                                                            'exists': {'field': k}
+                                                        }
+                                                    }
+                                                },
+                                                {"exists":{"field":k.split('.')[0]}}
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                        if v:
+                            null_filter['bool']['should'].append({'terms': {k+'.raw': v}})
+                        modified_filters.append(null_filter)
+
+                    else:
+                        modified_filters.append({'terms': {k+'.raw': v}})
             else:
                 modified_filters.append(f)
 

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -320,9 +320,15 @@ class DataExplorerHandler(base.RequestHandler):
                                 'should': [
                                     {
                                         'bool': {
-                                            'must_not': [
+                                            'must': [
                                                 {
-                                                    'exists': {'field': k}
+                                                    'bool':{
+                                                        'must_not': [
+                                                            {
+                                                                'exists': {'field': k}
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -330,6 +336,8 @@ class DataExplorerHandler(base.RequestHandler):
                                 ]
                             }
                         }
+                        if len(k.split('.')) > 1:
+                            null_filter['bool']['should'][0]['bool']['must'].append({'exists': {'field': k.split('.')[0]}})
                         if v:
                             null_filter['bool']['should'].append({'terms': {k+'.raw': v}})
                         modified_filters.append(null_filter)

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -306,7 +306,10 @@ class DataExplorerHandler(base.RequestHandler):
             if f.get('terms'):
                 for k,v in f['terms'].iteritems():
                     if "null" in v:
-                        v.remove("null")
+                        try:
+                            v.remove("null")
+                        except AttributeError:
+                            v = None
                         null_filter = {
                             'bool': {
                                 'should': [
@@ -315,9 +318,11 @@ class DataExplorerHandler(base.RequestHandler):
                                             'must': [
                                                 {
                                                     'bool': {
-                                                        'must_not': {
-                                                            'exists': {'field': k}
-                                                        }
+                                                        'must_not': [
+                                                            {
+                                                                'exists': {'field': k}
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {"exists":{"field":k.split('.')[0]}}

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -156,19 +156,22 @@ FACET_QUERY = {
                 "subject.sex" : {
                     "terms" : {
                         "field" : "subject.sex.raw",
-                        "size" : 15
+                        "size" : 15,
+                        "missing": "null"
                     }
                 },
                 "session.tags" : {
                     "terms" : {
                         "field" : "subject.tags.raw",
-                        "size" : 15
+                        "size" : 15,
+                        "missing": "null"
                     }
                 },
                 "subject.code" : {
                     "terms" : {
                         "field" : "subject.code.raw",
-                        "size" : 15
+                        "size" : 15,
+                        "missing": "null"
                     }
                 },
                 "session.timestamp" : {
@@ -213,13 +216,15 @@ FACET_QUERY = {
                 "file.measurements" : {
                     "terms" : {
                         "field" : "file.measurements.raw",
-                        "size" : 15
+                        "size" : 15,
+                        "missing": "null"
                     }
                 },
                 "file.type" : {
                     "terms" : {
                         "field" : "file.type.raw",
-                        "size" : 15
+                        "size" : 15,
+                        "missing": "null"
                     }
                 }
             }
@@ -306,26 +311,19 @@ class DataExplorerHandler(base.RequestHandler):
             if f.get('terms'):
                 for k,v in f['terms'].iteritems():
                     if "null" in v:
-                        try:
+                        if isinstance(v, list):
                             v.remove("null")
-                        except AttributeError:
+                        elif isinstance(v, str):
                             v = None
                         null_filter = {
                             'bool': {
                                 'should': [
                                     {
                                         'bool': {
-                                            'must': [
+                                            'must_not': [
                                                 {
-                                                    'bool': {
-                                                        'must_not': [
-                                                            {
-                                                                'exists': {'field': k}
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {"exists":{"field":k.split('.')[0]}}
+                                                    'exists': {'field': k}
+                                                }
                                             ]
                                         }
                                     }
@@ -396,7 +394,8 @@ class DataExplorerHandler(base.RequestHandler):
                 "results" : {
                     "terms" : {
                         "field" : field_name + ".raw",
-                        "size" : 15
+                        "size" : 15,
+                        "missing": "null"
                     }
                 }
             }

--- a/test/unit_tests/python/test_dataexplorer.py
+++ b/test/unit_tests/python/test_dataexplorer.py
@@ -154,16 +154,9 @@ def test_search(as_public, as_drone, es):
                         {'should':
                             [
                                 {'bool':
-                                    {'must':
+                                    {'must_not':
                                         [
-                                            {'bool':
-                                                {'must_not':
-                                                    [
-                                                        {"exists": {"field":filter_key}}
-                                                    ]
-                                                }
-                                            },
-                                            {'exists': {'field': filter_key.split('.')[0]}}
+                                            {"exists": {"field":filter_key}}
                                         ]
                                     }
                                 },
@@ -342,7 +335,7 @@ def test_aggregate_field_values(as_public, as_drone, es):
     es.search.return_value = {'aggregations': {'results': result}}
     r = as_drone.post('/dataexplorer/search/fields/aggregate', json={'field_name': field_name})
     es.search.assert_called_with(
-        body={'aggs': {'results': {'terms': {'field': field_name + '.raw', 'size': 15}}},
+        body={'aggs': {'results': {'terms': {'field': field_name + '.raw', 'size': 15, 'missing': 'null'}}},
               'query': {'bool': {'filter': [{'term': {'permissions._id': None}}], 'must': {'match_all': {}}}},
               'size': 0},
         doc_type='flywheel',
@@ -353,7 +346,7 @@ def test_aggregate_field_values(as_public, as_drone, es):
     # get typeahead w/ search string for string|boolean field type
     r = as_drone.post('/dataexplorer/search/fields/aggregate', json={'field_name': field_name, 'search_string': search_str})
     es.search.assert_called_with(
-        body={'aggs': {'results': {'terms': {'field': field_name + '.raw', 'size': 15}}},
+        body={'aggs': {'results': {'terms': {'field': field_name + '.raw', 'size': 15, 'missing': 'null'}}},
               'query': {'bool': {'filter': [{'term': {'permissions._id': None}}], 'must': {'match': {'field': search_str}}}},
               'size': 0},
         doc_type='flywheel',

--- a/test/unit_tests/python/test_dataexplorer.py
+++ b/test/unit_tests/python/test_dataexplorer.py
@@ -154,9 +154,15 @@ def test_search(as_public, as_drone, es):
                         {'should':
                             [
                                 {'bool':
-                                    {'must_not':
-                                        [
-                                            {"exists": {"field":filter_key}}
+                                    {
+                                        'must': [
+                                            {
+                                                'bool': {
+                                                    'must_not': [
+                                                        {"exists": {"field":filter_key}}
+                                                    ]
+                                                }
+                                            }
                                         ]
                                     }
                                 },


### PR DESCRIPTION
When search is given a list of values for a field in filters, if "null" is included, it will return all containers with those values and those for which the field does not have a value.
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
