### PR TITLE
Groups join=projects Parameter

### DIFF
--- a/api/dao/base.py
+++ b/api/dao/base.py
@@ -80,12 +80,17 @@ class ContainerStorage(object):
             cont[CHILD_MAP[self.cont_name]] = children
         return cont
 
-    def get_children(self, _id, projection=None):
+    def get_children(self, _id, projection=None, uid=None):
         try:
             child_name = CHILD_MAP[self.cont_name]
         except KeyError:
             raise APINotFoundException('Children cannot be listed from the {0} level'.format(self.cont_name))
-        query = {self.cont_name[:-1]: bson.ObjectId(_id)}
+        if self.cont_name == 'groups':
+            query = {self.cont_name[:-1]: _id}
+            if uid:
+                query['permissions'] = {'$elemMatch': {'_id': uid}}
+        else:
+            query = {self.cont_name[:-1]: bson.ObjectId(_id)}
         if not projection:
             projection = {'info': 0, 'files.info': 0, 'subject': 0, 'tags': 0}
         return ContainerStorage.factory(child_name).get_all_el(query, None, projection)

--- a/api/dao/base.py
+++ b/api/dao/base.py
@@ -85,12 +85,13 @@ class ContainerStorage(object):
             child_name = CHILD_MAP[self.cont_name]
         except KeyError:
             raise APINotFoundException('Children cannot be listed from the {0} level'.format(self.cont_name))
-        if self.cont_name == 'groups':
-            query = {self.cont_name[:-1]: _id}
-            if uid:
-                query['permissions'] = {'$elemMatch': {'_id': uid}}
+        if not self.use_object_id:
+            query = {containerutil.singularize(self.cont_name): _id}
         else:
-            query = {self.cont_name[:-1]: bson.ObjectId(_id)}
+            query = {containerutil.singularize(self.cont_name): bson.ObjectId(_id)}
+        
+        if uid:
+            query['permissions'] = {'$elemMatch': {'_id': uid}}
         if not projection:
             projection = {'info': 0, 'files.info': 0, 'subject': 0, 'tags': 0}
         return ContainerStorage.factory(child_name).get_all_el(query, None, projection)

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -40,7 +40,7 @@ class GroupHandler(base.RequestHandler):
         """
         If parameter join=projects, return project id, label, permissions, and description
         """
-        result['projects'] = self.storage.get_children(result.get('_id'), projection={'permissions': 1, 'label': 1, 'description': 1}, uid=self.uid)
+        result['projects'] = self.storage.get_children(result.get('_id'), projection={'permissions': 1, 'label': 1, 'description': 1, 'group': 1}, uid=self.uid)
         self._filter_permissions(result['projects'], self.uid)
         return result
 

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -36,6 +36,14 @@ class GroupHandler(base.RequestHandler):
             self.abort(404, 'Group {} not removed'.format(_id))
         return result
 
+    def handle_projects(self, result):
+        """
+        If parameter join=projects, return project id, label, permissions, and description
+        """
+        result['projects'] = self.storage.get_children(result.get('_id'), projection={'permissions': 1, 'label': 1, 'description': 1}, uid=self.uid)
+        self._filter_permissions(result['projects'], self.uid)
+        return result
+
     def get_all(self, uid=None):
         projection = {'label': 1, 'created': 1, 'modified': 1, 'permissions': 1, 'tags': 1}
         permchecker = groupauth.list_permission_checker(self, uid)
@@ -44,6 +52,9 @@ class GroupHandler(base.RequestHandler):
             self._filter_permissions(results, self.uid)
         if self.is_true('join_avatars'):
             results = ContainerHandler.join_user_info(results)
+        if 'projects' in self.request.params.getall('join'):
+            for result in results:
+                result = self.handle_projects(result)
         return results
 
     @validators.verify_payload_exists

--- a/test/integration_tests/python/test_groups.py
+++ b/test/integration_tests/python/test_groups.py
@@ -118,3 +118,9 @@ def test_groups(as_user, as_admin, data_builder):
     r = as_admin.get('/groups/' + group)
     assert r.ok
     assert r.json()['label'] == group_label
+
+    # Test join=projects
+    project = data_builder.create_project()
+    r = as_admin.get('/groups', params={'join': 'projects'})
+    assert r.ok
+    assert r.json()[1].get('projects')[0].get('_id') == project


### PR DESCRIPTION
Fixes #853 
For `api/groups?join=projects`, each group result is returned with a a list of that group's project that the user has access to, permissions are filtered for the projects as well.
Specifically returned for each project are its
- id
- label
- description
- permissions

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
