### PR TITLE
Add context information to gear input files

### DIFF
--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -239,6 +239,15 @@ class FileReference(ContainerReference):
             name = d['name']
         )
 
+    def get_file(self):
+        container = super(FileReference, self).get()
+
+        for file in container['files']:
+            if file['name'] == self.name:
+                return file
+
+        raise Exception('No such file {} on {} {} in database'.format(self.name, self.type, self.id))
+
 
 def create_filereference_from_dictionary(d):
     return FileReference.from_dictionary(d)

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -14,6 +14,7 @@ from ..dao import APIPermissionException, APINotFoundException
 from ..dao.containerstorage import ProjectStorage, AcquisitionStorage
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference, ContainerReference
 from ..web import base
+from ..web.encoder import pseudo_consistent_json_encode
 from ..validators import InputValidationException
 from .. import config
 from . import batch
@@ -317,7 +318,7 @@ class JobsHandler(base.RequestHandler):
         # B) a user editing the file object
         #
         # You can count on neither occurring before a job starts, because the queue is not globally FIFO.
-        # So option #2 is potentially more convenient, but unintuitive and prone to customer confusion.
+        # So option #2 is potentially more convenient, but unintuitive and prone to user confusion.
 
 
         for x in inputs:
@@ -412,11 +413,11 @@ class JobHandler(base.RequestHandler):
 
         if c.get('config') is not None and c.get('inputs') is not None:
             # New behavior
-            encoded = json.dumps(c, sort_keys=True, indent=4, separators=(',', ': ')) + '\n'
+            encoded = pseudo_consistent_json_encode(c)
             self.response.app_iter = StringIO.StringIO(encoded)
         else:
             # Legacy behavior
-            encoded = json.dumps({"config": c}, sort_keys=True, indent=4, separators=(',', ': ')) + '\n'
+            encoded = pseudo_consistent_json_encode({"config": c})
             self.response.app_iter = StringIO.StringIO(encoded)
 
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -2,7 +2,6 @@
 API request handlers for the jobs module
 """
 import bson
-import json
 import os
 import StringIO
 from jsonschema import ValidationError

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -119,7 +119,6 @@ def eval_rule(rule, file_, container):
     for match in rule.get('any', []):
         if eval_match(match['type'], match['value'], file_, container):
             has_match = True
-            config.log.debug('we found one here')
             break
 
     # If there were matches in the 'any' array and none of them succeeded
@@ -129,7 +128,6 @@ def eval_rule(rule, file_, container):
     # Are there matches in the 'all' set?
     for match in rule.get('all', []):
         if not eval_match(match['type'], match['value'], file_, container):
-            config.log.debug('we didnt fine one here')
             return False
 
     return True
@@ -261,10 +259,8 @@ def get_rules_for_container(db, container):
         result = list(db.project_rules.find({'project_id': str(container['_id'])}))
 
         if not result:
-            log.debug('Container ' + str(container['_id']) + ' found NO rules')
             return []
         else:
-            log.debug('Container ' + str(container['_id']) + ' found ' + str(len(result)) + ' rules')
             return result
 
 def copy_site_rules_for_project(project_id):

--- a/api/web/encoder.py
+++ b/api/web/encoder.py
@@ -43,3 +43,11 @@ def json_sse_pack(d):
     d['data'] = json.dumps(d['data'], default=custom_json_serializer)
 
     return sse_pack(d)
+
+def pseudo_consistent_json_encode(d):
+    """
+    Some parts of our system rely upon consistently-produced JSON encoding.
+    This implementation is not guaranteed to be consistent, but it's good enough for now.
+    """
+
+    return json.dumps(d, sort_keys=True, indent=4, separators=(',', ': ')) + '\n'

--- a/bin/database.py
+++ b/bin/database.py
@@ -1188,6 +1188,32 @@ def upgrade_to_35():
     cursor = config.db.batch.find({})
     process_cursor(cursor, upgrade_to_35_closure)
 
+
+
+
+###
+### BEGIN RESERVED UPGRADE SECTION
+###
+
+# Due to performance concerns with database upgrades, some upgrade implementations might be postposed.
+# The team contract is that if you write an upgrade touch one of the tables mentioned below, you MUST also implement any reserved upgrades.
+# This way, we can bundle changes together that need large cursor iterations and save multi-hour upgrade times.
+
+
+## Jobs table
+
+# The old job.config format was a set of keys, which was manually placed on a "config": key when fetched.
+# Now, it's a { "config": , "inputs": } map, with the old values being placed under the "config": key when stored.
+# Move the keys accordingly so that legacy logic can be removed.
+#
+# Ref: JobHandler.get_config, Job.generate_request
+
+
+###
+### END RESERVED UPGRADE SECTION
+###
+
+
 def upgrade_schema(force_from = None):
     """
     Upgrades db to the current schema version

--- a/bin/install-ubuntu.sh
+++ b/bin/install-ubuntu.sh
@@ -19,6 +19,6 @@ sudo apt-get install -y \
     libpcre3-dev \
     git
 
-pip install -U pip
+sudo pip install -U pip
 
-pip install -r requirements.txt
+sudo pip install -r requirements.txt

--- a/test/bin/setup-integration-tests-ubuntu.sh
+++ b/test/bin/setup-integration-tests-ubuntu.sh
@@ -3,7 +3,7 @@ set -e
 unset CDPATH
 cd "$( dirname "${BASH_SOURCE[0]}" )/../.."
 
-pip install -U -r "test/integration_tests/requirements-integration-test.txt"
+sudo pip install -U -r "test/integration_tests/requirements-integration-test.txt"
 
 NODE_URL="https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x64.tar.gz"
 

--- a/test/integration_tests/python/conftest.py
+++ b/test/integration_tests/python/conftest.py
@@ -266,7 +266,15 @@ class DataBuilder(object):
 
         # add missing gear when creating job
         if resource == 'job' and 'gear_id' not in payload:
-            payload['gear_id'] = self.get_or_create('gear')
+
+            # create file inputs for each job input on gear
+            gear_inputs = {}
+            for i in payload.get('inputs', {}).keys():
+                gear_inputs[i] = {'base': 'file'}
+
+            gear_doc = _default_payload['gear']['gear']
+            gear_doc['inputs'] = gear_inputs
+            payload['gear_id'] = self.create('gear', gear=gear_doc)
 
         # put together the create url to post to
         create_url = '/' + resource + 's'

--- a/test/integration_tests/python/test_jobs.py
+++ b/test/integration_tests/python/test_jobs.py
@@ -20,12 +20,19 @@ def test_jobs_access(as_user):
     assert r.status_code == 403
 
 
-def test_jobs(data_builder, as_user, as_admin, as_root, api_db):
-    gear = data_builder.create_gear()
+def test_jobs(data_builder, default_payload, as_user, as_admin, as_root, api_db, file_form):
+    gear_doc = default_payload['gear']['gear']
+    gear_doc['inputs'] = {
+        'dicom': {
+            'base': 'file'
+        }
+    }
+    gear = data_builder.create_gear(gear=gear_doc)
     invalid_gear = data_builder.create_gear(gear={'custom': {'flywheel': {'invalid': True}}})
     project = data_builder.create_project()
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
+    assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.zip')).ok
 
     job_data = {
         'gear_id': gear,

--- a/test/integration_tests/python/test_uploads.py
+++ b/test/integration_tests/python/test_uploads.py
@@ -497,8 +497,11 @@ def test_acquisition_engine_upload(data_builder, file_form, as_root):
     project = data_builder.create_project()
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
+    assert as_root.post('/acquisitions/' + acquisition + '/files', files=file_form('test.txt')).ok
+
+
     job = data_builder.create_job(inputs={
-        'test': {'type': 'acquisition', 'id': acquisition, 'name': 'test'}
+        'test': {'type': 'acquisition', 'id': acquisition, 'name': 'test.txt'}
     })
 
     metadata = {
@@ -569,8 +572,8 @@ def test_acquisition_engine_upload(data_builder, file_form, as_root):
     m_timestamp = dateutil.parser.parse(metadata['acquisition']['timestamp'])
     assert a_timestamp == m_timestamp
 
-    for f in a['files']:
-        mf = find_file_in_array(f['name'], metadata['acquisition']['files'])
+    for mf in metadata['acquisition']['files']:
+        f = find_file_in_array(mf['name'], a['files'])
         assert mf is not None
         assert f['type'] == mf['type']
         assert f['info'] == mf['info']


### PR DESCRIPTION
1. Scalar gear configuration options (so at the moment, all of them) are exposed as environment variables to the gear. For example:

```js
"FW_CONFIG_PHONE" : "555-5555",
"FW_CONFIG_STRING2" : "ggggg",
"FW_CONFIG_BOOLEAN" : "true",
"FW_CONFIG_INTEGER" : "7",
"FW_CONFIG_STRING" : "ger4536y45",
"FW_CONFIG_NUMBER" : "3.5",
"FW_CONFIG_MULTIPLE" : "20",
```

This allows you to do something like `python call.py --number $FW_CONFIG_PHONE` if you're not using a scripting language.

2. The provided contextual `config.json` file will now carry useful information about the files, their location on disk, their location in the hierarchy (if you want to use the API from a gear), and relevant scientific information recorded in the system. For example:

```js
{
    "config" : {
        "multiple" : 20,
        "string" : "ger4536y45",
        "number" : 3.5,
        "phone" : "555-5555",
        "boolean" : true,
        "integer" : 7,
        "string2" : "ggggg"
    },

    "inputs" : {
        "dicom" : {
            "base" : "file",
            "hierarchy" : {
                "type" : "acquisition",
                "id" : "5988d38b3b48ee001bde0853"
            },
            "location" : {
                "path" : "/flywheel/v0/input/dicom/8892_1_1_localizer.dicom_3Plane_Loc_SSFSE_20150215134437_1b.nii.gz",
                "name" : "8892_1_1_localizer.dicom_3Plane_Loc_SSFSE_20150215134437_1b.nii.gz"
            },
            "object" : {
                "info" : {},
                "mimetype" : "application/octet-stream",
                "tags" : [],
                "measurements" : [],
                "type" : "nifti",
                "modality" : null,
                "size" : 2913379
            }
        },
        "file" : {
            // ..
        },
        "text" : {
            // ..
        }
    }
}
```