### PR TITLE
Fix UID upload to new project with same UID bug 

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -370,6 +370,7 @@ def _create_query(cont, cont_type, parent_type, parent_id, upload_type):
         return q
     elif upload_type == 'uid':
         return {
+            parent_type : bson.ObjectId(parent_id),
             'uid': cont['uid']
         }
     else:

--- a/api/placer.py
+++ b/api/placer.py
@@ -131,7 +131,7 @@ class TargetedPlacer(Placer):
 class UIDPlacer(Placer):
     """
     A placer that can accept multiple files.
-    It uses the method upsert_bottom_up_hierarchy to create its project/session/acquisition hierarchy
+    It uses the method upsert_top_down_hierarchy to create its project/session/acquisition hierarchy
     Sessions and acquisitions are identified by UID.
     """
     metadata_schema = 'uidupload.json'


### PR DESCRIPTION
`/upload/uid` respects the project label when uploading and so will not upload to other projects
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
