### PR TITLE
Code is sent with subject and test doesn't filter out acquisition files

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -139,10 +139,12 @@ class Download(base.RequestHandler):
                 subject_prefixes = {}
                 for session in session_dict.itervalues():
                     if session.get('subject'):
-                        code = session['subject'].get('code', 'unknown_subject')
-                        # This is bad and we should try to combine these somehow,
-                        # or at least make sure we get all the files
-                        subject_dict[code] = session['subject']
+                        subject = session.get('subject', {'code': 'unknown_subject'})
+                        code = subject.get('code')
+                        if code is None:
+                            code = 'unknown_subject'
+                            subject['code'] = code
+                        subject_dict[code] = subject
 
                 for code, subject in subject_dict.iteritems():
                     subject_prefix = prefix + '/' + self._path_from_container(subject, used_subpaths, ids_of_paths, code)

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -37,14 +37,10 @@ def test_download(data_builder, file_form, as_admin, api_db):
     r = as_admin.post('/download', json={
         'optional': False,
         'filters': [{'tags': {
-            '-': ['minus'],
-            '+': ['plus']
+            '-': ['minus']
         }}],
         'nodes': [
-            {'level': 'project', '_id': project},
-            {'level': 'session', '_id': session},
-            {'level': 'acquisition', '_id': acquisition},
-            {'level': 'acquisition', '_id':acquisition2},
+            {'level': 'project', '_id': project},        
         ]
     })
     assert r.ok


### PR DESCRIPTION
### Changes
- Subject code is sent with subject to `_path_from_container`
- Download filter was filtering out the acquisition files (expected) so part of the filter was removed
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
