### PR TITLE
Add mimetype field to to packfile object 

### DIFF
--- a/api/placer.py
+++ b/api/placer.py
@@ -507,6 +507,7 @@ class PackfilePlacer(Placer):
             'modified': cgi_field.modified,
             'size':	 cgi_field.size,
             'hash':	 cgi_field.hash,
+            'mimetype': cgi_field.mimetype,
 
             'type': self.metadata['packfile']['type'],
 

--- a/bin/database.py
+++ b/bin/database.py
@@ -1208,7 +1208,7 @@ def upgrade_to_36():
     """
     scitran/core issue #931 - mimetype not set on packfile uploads
     """
-    cursor = config.db.acquisitions.find({'files.mimetype': None})
+    cursor = config.db.acquisitions.find({'files': { '$gt': [] }, 'files.mimetype': None})
     process_cursor(cursor, upgrade_to_36_closure)
 
 

--- a/test/integration_tests/python/test_uploads.py
+++ b/test/integration_tests/python/test_uploads.py
@@ -932,6 +932,12 @@ def test_packfile_upload(data_builder, file_form, as_admin, as_root, api_db):
         params={'token': token, 'metadata': metadata_json})
     assert r.ok
 
+    # make sure file was uploaded and mimetype and type are properly set
+    packfile = as_admin.get('/acquisitions').json()[0]['files'][0]
+    assert packfile['mimetype'] == 'application/zip'
+    assert packfile['type'] == 'test'
+
+
     # get another token (start packfile-upload)
     r = as_admin.post('/projects/' + project + '/packfile-start')
     assert r.ok


### PR DESCRIPTION
Fixes #931 

Changes that require mimetype in `jobs/add` unearthed that the mimetype for a packfile upload was never persisted to the db. 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
