### PR TITLE
New endpoint that returns count, mb size, and nodes for each file type

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -85,6 +85,7 @@ endpoints = [
         # General-purpose upload & download
 
         route('/download',                                      Download, h='download',              m=['GET', 'POST']),
+        route('/download/summary',                              Download, h='summary',               m=['POST']),
         route('/upload/<strategy:label|uid|uid-match|reaper>',  Upload,   h='upload',                m=['POST']),
         route('/clean-packfiles',                               Upload,   h='clean_packfile_tokens', m=['POST']),
         route('/engine',                                        Upload,   h='engine',                m=['POST']),

--- a/api/download.py
+++ b/api/download.py
@@ -20,7 +20,11 @@ BYTES_IN_MEGABYTE = float(1<<20)
 def _filter_check(property_filter, property_values):
     minus = set(property_filter.get('-', []))
     plus = set(property_filter.get('+', []))
-    if not minus.isdisjoint(property_values):
+    if "null" in plus and not property_values:
+        return True
+    if "null" in minus and property_values:
+        return False
+    elif not minus.isdisjoint(property_values):
         return False
     if plus and plus.isdisjoint(property_values):
         return False

--- a/api/download.py
+++ b/api/download.py
@@ -339,7 +339,7 @@ class Download(base.RequestHandler):
 
             # for each type of container below it will have a slightly modified match query
             cont_query = {
-                'projects': {'_id': {'project': req['_id']}},
+                'projects': {'_id': req['_id']},
                 'sessions': {'project': req['_id']},
                 'acquisitions': {'session': {'$in': session_ids}},
                 'analyses': {'parent.id': {'$in': parent_ids}}
@@ -382,8 +382,7 @@ class Download(base.RequestHandler):
             try:
                 result = config.db.command('aggregate', cont_name, pipeline=pipeline)
             except Exception as e: # pylint: disable=broad-except
-                result = e
-                return result
+                return e
 
             if result.get("ok"):
                 for doc in result.get("result"):

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -388,10 +388,23 @@ def test_filters(data_builder, file_form, as_admin):
     assert r.json()['file_cnt'] == 2
 
     # Filter by type
+    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
+        "test", meta={'name': "test", 'tags': ['red', 'blue']}))
     r = as_admin.post('/download', json={
         'optional': False,
         'filters': [
             {'types': {'+':['nifti']}}
+        ],
+        'nodes': [
+            {'level': 'session', '_id': session},
+        ]
+    })
+    assert r.ok
+    assert r.json()['file_cnt'] == 1
+    r = as_admin.post('/download', json={
+        'optional': False,
+        'filters': [
+            {'types': {'+':['null']}}
         ],
         'nodes': [
             {'level': 'session', '_id': session},

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -425,22 +425,22 @@ def test_summary(data_builder, as_admin, file_form):
 
     missing_object_id = '000000000000000000000000'
 
-    r = as_admin.post('/download/summary', json={"level":"projects", "_id":project})
+    r = as_admin.post('/download/summary', json=[{"level":"project", "_id":project}])
     assert r.ok
     assert len(r.json()) == 1
     assert r.json().get("csv", {}).get("count",0) == 4 
 
-    r = as_admin.post('/download/summary', json={"level":"sessions", "_id":session})
+    r = as_admin.post('/download/summary', json=[{"level":"session", "_id":session}])
     assert r.ok
     assert len(r.json()) == 1
     assert r.json().get("csv", {}).get("count",0) == 2 
 
-    r = as_admin.post('/download/summary', json={"level":"acquisitions", "_id":acquisition})
+    r = as_admin.post('/download/summary', json=[{"level":"acquisition", "_id":acquisition},{"level":"acquisition", "_id":acquisition2}])
     assert r.ok
     assert len(r.json()) == 1
-    assert r.json().get("csv", {}).get("count",0) == 1
+    assert r.json().get("csv", {}).get("count",0) == 2
 
-    r = as_admin.post('/download/summary', json={"level":"groups", "_id":missing_object_id})
+    r = as_admin.post('/download/summary', json=[{"level":"group", "_id":missing_object_id}])
     assert r.status_code == 400
 
     r = as_admin.post('/sessions/' + session + '/analyses',  files=file_form(
@@ -448,7 +448,7 @@ def test_summary(data_builder, as_admin, file_form):
     assert r.ok
     analysis = r.json()['_id']
     
-    r = as_admin.post('/download/summary', json={"level":"analyses", "_id":analysis})
+    r = as_admin.post('/download/summary', json=[{"level":"analysis", "_id":analysis}])
     assert r.ok
     assert len(r.json()) == 1
     assert r.json().get("tabular data", {}).get("count",0) == 1

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -442,4 +442,13 @@ def test_summary(data_builder, as_admin, file_form):
 
     r = as_admin.post('/download/summary', json={"level":"groups", "_id":missing_object_id})
     assert r.status_code == 400
+
+    r = as_admin.post('/sessions/' + session + '/analyses',  files=file_form(
+        file_name, meta={'label': 'test', 'inputs':[{'name':file_name}]}))
+    assert r.ok
+    analysis = r.json()['_id']
     
+    r = as_admin.post('/download/summary', json={"level":"analyses", "_id":analysis})
+    assert r.ok
+    assert len(r.json()) == 1
+    assert r.json().get("tabular data", {}).get("count",0) == 1

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -399,3 +399,38 @@ def test_filters(data_builder, file_form, as_admin):
     })
     assert r.ok
     assert r.json()['file_cnt'] == 1
+
+def test_summary(data_builder, as_admin, file_form):
+    project = data_builder.create_project(label='project1')
+    session = data_builder.create_session(label='session1')
+    session2 = data_builder.create_session(label='session1')
+    acquisition = data_builder.create_acquisition(session=session)
+    acquisition2 = data_builder.create_acquisition(session=session2)
+
+    # upload the same file to each container created and use different tags to
+    # facilitate download filter tests:
+    # acquisition: [], session: ['plus'], project: ['plus', 'minus']
+    file_name = 'test.csv'
+    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
+        file_name, meta={'name': file_name, 'type': 'csv'}))
+
+    as_admin.post('/acquisitions/' + acquisition2 + '/files', files=file_form(
+        file_name, meta={'name': file_name, 'type': 'csv'}))
+
+    as_admin.post('/sessions/' + session + '/files', files=file_form(
+        file_name, meta={'name': file_name, 'type': 'csv', 'tags': ['plus']}))
+
+    as_admin.post('/projects/' + project + '/files', files=file_form(
+        file_name, meta={'name': file_name, 'type': 'csv', 'tags': ['plus', 'minus']}))
+
+    missing_object_id = '000000000000000000000000'
+
+    r = as_admin.post('/download/summary', json={"level":"projects", "_id":project})
+    assert r.ok
+    assert len(r.json()) == 1
+    assert r.json().get("csv", {}).get("count",0) == 4 
+
+    r = as_admin.post('/download/summary', json={"level":"sessions", "_id":session})
+    assert r.ok
+    assert len(r.json()) == 1
+    assert r.json().get("csv", {}).get("count",0) == 2 

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -434,3 +434,12 @@ def test_summary(data_builder, as_admin, file_form):
     assert r.ok
     assert len(r.json()) == 1
     assert r.json().get("csv", {}).get("count",0) == 2 
+
+    r = as_admin.post('/download/summary', json={"level":"acquisitions", "_id":acquisition})
+    assert r.ok
+    assert len(r.json()) == 1
+    assert r.json().get("csv", {}).get("count",0) == 1
+
+    r = as_admin.post('/download/summary', json={"level":"groups", "_id":missing_object_id})
+    assert r.status_code == 400
+    


### PR DESCRIPTION
### Notes
- New endpoint `POST /download/summary`
- request body 
```
[{
    "level": {"projects"|"sessions"|"acquisitions"|"analyses"},
     "_id": {ContainerId}
}]
```
- response
```
{
    "dicom": {
        "count" : 1,
        "mb_total": 23124,
        "_id": "dicom"
    }
    .
    .
    .
}
```
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
