### PR TITLE
Access log query project filter added

### DIFF
--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -505,7 +505,7 @@ class AccessLogReport(Report):
         uid = params.get('user')
         limit= params.get('limit', 100)
         subject = params.get('subject', None)
-        project = parmas.get('project', None)
+        project = params.get('project', None)
         access_types = params.getall('access_type')
 
         if start_date:

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -505,6 +505,7 @@ class AccessLogReport(Report):
         uid = params.get('user')
         limit= params.get('limit', 100)
         subject = params.get('subject', None)
+        project = parmas.get('project', None)
         access_types = params.getall('access_type')
 
         if start_date:
@@ -532,6 +533,7 @@ class AccessLogReport(Report):
         self.uid            = uid
         self.limit          = limit
         self.subject        = subject
+        self.project        = project
         self.access_types   = access_types
 
     def user_can_generate(self, uid):
@@ -555,6 +557,8 @@ class AccessLogReport(Report):
             query['timestamp']['$lte'] = self.end_date
         if self.subject:
             query['context.subject.label'] = self.subject
+        if self.project:
+            query['context.project.id'] = self.project
         if self.access_types:
             query['access_type'] = {'$in': self.access_types}
 

--- a/bin/log_csv.py
+++ b/bin/log_csv.py
@@ -22,6 +22,7 @@ ARG_TO_PARAMS= {
     'e': 'end_date',
     'u': 'uid',
     'j': 'subject',
+    'p': 'project',
     't': 'access_types'
 }
 
@@ -71,6 +72,7 @@ if __name__ == '__main__':
         parser.add_argument("-u", help="User id",               type=str)
         parser.add_argument("-l", help="Limit",                 type=str)
         parser.add_argument("-j", help="subJect",               type=str)
+        parser.add_argument("-p", help="project",               type=str)
         parser.add_argument("-t", help="list of access Types",  type=str, nargs='+')
 
         args = vars(parser.parse_args())


### PR DESCRIPTION
Fixes #924 
### Notes
Another param, similar in function to the subject filter. Uses the project id over label, although if it is going to implemented as a text box instead of drop down, label is probably a better choice.
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
