### PR TITLE
Fix analysis download 

### DIFF
--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -265,7 +265,7 @@ class AnalysesHandler(RefererHandler):
                 file_cnt = 1
                 ticket = util.download_ticket(self.request.client_addr, 'file', cid, filename, total_size, origin=self.origin)
             else:
-                targets, total_size, file_cnt = self._prepare_batch(fileinfo)
+                targets, total_size, file_cnt = self._prepare_batch(fileinfo, analysis)
                 label = util.sanitize_string_to_filename(self.storage.get_container(_id).get('label', 'No Label'))
                 filename = 'analysis_' + label + '.tar'
                 ticket = util.download_ticket(self.request.client_addr, 'batch', targets, filename, total_size, origin=self.origin)
@@ -357,7 +357,7 @@ class AnalysesHandler(RefererHandler):
         return ticket
 
 
-    def _prepare_batch(self, fileinfo):
+    def _prepare_batch(self, fileinfo, analysis):
         ## duplicated code from download.py
         ## we need a way to avoid this
         targets = []
@@ -366,7 +366,9 @@ class AnalysesHandler(RefererHandler):
         for f in fileinfo:
             filepath = os.path.join(data_path, util.path_from_hash(f['hash']))
             if os.path.exists(filepath): # silently skip missing files
-                targets.append((filepath, 'analyses/' + f['name'], f['size']))
+                targets.append((filepath,
+                                util.sanitize_string_to_filename(analysis['label']) + '/' + f['name'],
+                                'analyses', analysis['_id'], f['size']))
                 total_size += f['size']
                 total_cnt += 1
         return targets, total_size, total_cnt

--- a/test/integration_tests/python/test_download.py
+++ b/test/integration_tests/python/test_download.py
@@ -40,7 +40,7 @@ def test_download(data_builder, file_form, as_admin, api_db):
             '-': ['minus']
         }}],
         'nodes': [
-            {'level': 'project', '_id': project},        
+            {'level': 'project', '_id': project},
         ]
     })
     assert r.ok
@@ -54,7 +54,7 @@ def test_download(data_builder, file_form, as_admin, api_db):
     tar = tarfile.open(mode="r", fileobj=tar_file)
 
     # Verify a single file in tar with correct file name
-    found_second_session = False 
+    found_second_session = False
     for tarinfo in tar:
         assert os.path.basename(tarinfo.name) == file_name
         if 'session1_0' in str(tarinfo.name):
@@ -88,7 +88,7 @@ def test_download(data_builder, file_form, as_admin, api_db):
     tar = tarfile.open(mode="r", fileobj=tar_file)
 
     # Verify a single file in tar with correct file name
-    found_second_session = False 
+    found_second_session = False
     for tarinfo in tar:
         assert os.path.basename(tarinfo.name) == file_name
         if 'session1_0' in str(tarinfo.name):
@@ -250,6 +250,17 @@ def test_analysis_download(data_builder, file_form, as_admin):
     # batch download analysis files w/ ticket
     r = as_admin.get('/download', params={'ticket': ticket})
     assert r.ok
+
+    # Check to make sure files are in tar
+    tar_file = cStringIO.StringIO(r.content)
+    tar = tarfile.open(mode="r", fileobj=tar_file)
+    members = tar.getmembers()
+    assert len(members) == 2
+    for tarinfo in members:
+        assert os.path.basename(tarinfo.name) in ['one.csv', 'two.zip']
+
+    tar.close()
+
 
     # try to get download ticket for non-existent analysis file
     r = as_admin.get(analysis_files + '/non-existent.csv')


### PR DESCRIPTION
The endpoint for a ticketed download at `api/analyses/files` caused issues when it did not provide enough information about the analysis to support access logging. 

A request for the future is that all container file downloads move to using the targeted downloads at `api/download`. The above endpoint should be considered legacy. 


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
