### PR TITLE
/users/uid/groups returns permission for User(uid)

### DIFF
--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -48,7 +48,7 @@ class GroupHandler(base.RequestHandler):
         projection = {'label': 1, 'created': 1, 'modified': 1, 'permissions': 1, 'tags': 1}
         permchecker = groupauth.list_permission_checker(self, uid)
         results = permchecker(self.storage.exec_op)('GET', projection=projection)
-        if not self.superuser_request and not self.is_true('join_avatars'):
+        if not self.superuser_request and not self.is_true('join_avatars') and not self.user_is_admin:
             self._filter_permissions(results, self.uid)
         if self.is_true('join_avatars'):
             results = ContainerHandler.join_user_info(results)

--- a/test/integration_tests/python/test_groups.py
+++ b/test/integration_tests/python/test_groups.py
@@ -82,6 +82,11 @@ def test_groups(as_user, as_admin, data_builder):
     r = as_admin.put('/groups/' + group + '/permissions/' + user['_id'], json=user)
     assert r.ok
 
+    # Get all permissions for each group
+    r = as_admin.get('/users/admin@user.com/groups')
+    assert r.ok
+    assert r.json()[0].get("permissions")[0].get("_id") == "admin@user.com"
+
     # Get the group again to compare timestamps for the Edit permission test groups
     r = as_admin.get('/groups/' + group)
     assert r.ok


### PR DESCRIPTION
Fixes #948 
Only returns permission for the user with the id in the url
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
