### PR TITLE
Use central job enqueue logic for jobs spawned by rules

### DIFF
--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -129,9 +129,14 @@ def fill_gear_default_values(gear, config_):
     Given a gear and a config map, fill any missing keys using defaults from the gear's config
     """
 
-    for k,v in gear['gear'].get('config', {}).itervalues:
+    if config_ is None:
+        config_ = {}
+
+    for k,v in gear['gear'].get('config', {}).iteritems():
         if 'default' in v:
             config_.setdefault(k, v['default'])
+
+    return config_
 
 
 def insert_gear(doc):

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -124,6 +124,16 @@ def validate_gear_config(gear, config_):
             })
     return True
 
+def fill_gear_default_values(gear, config_):
+    """
+    Given a gear and a config map, fill any missing keys using defaults from the gear's config
+    """
+
+    for k,v in gear['gear'].get('config', {}).itervalues:
+        if 'default' in v:
+            config_.setdefault(k, v['default'])
+
+
 def insert_gear(doc):
     gear_tools.validate_manifest(doc['gear'])
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -335,7 +335,7 @@ class JobHandler(base.RequestHandler):
         # Detect if config is old- or new-style.
         # TODO: remove this logic with a DB upgrade, ref database.py's reserved upgrade section.
 
-        if c.get('config') is not None and c.get('inputs') is not None:
+        if 'config' in c and c.get('inputs') is not None:
             # New behavior
 
             # API keys are only returned in-flight, when the job is running, and not persisted to the job object.

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -156,8 +156,7 @@ class Queue(object):
         if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             raise InputValidationException('Gear marked as invalid, will not run!')
 
-        config_ = job_map.get('config', {})
-        fill_gear_default_values(gear, config_)
+        config_ = fill_gear_default_values(gear, job_map.get('config', {}))
         validate_gear_config(gear, config_)
 
         # Translate maps to FileReferences

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -9,7 +9,7 @@ import datetime
 
 from .. import config
 from .jobs import Job
-from .gears import get_gear, validate_gear_config
+from .gears import get_gear, validate_gear_config, fill_gear_default_values
 from ..validators import InputValidationException
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
 
@@ -157,6 +157,7 @@ class Queue(object):
             raise InputValidationException('Gear marked as invalid, will not run!')
 
         config_ = job_map.get('config', {})
+        fill_gear_default_values(gear, config_)
         validate_gear_config(gear, config_)
 
         # Translate maps to FileReferences

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -1,6 +1,7 @@
 import fnmatch
 
 from .. import config
+from ..types import Origin
 from ..dao.containerutil import FileReference
 
 from . import gears
@@ -236,10 +237,14 @@ def create_jobs(db, container_before, container_after, container_type):
 
 
     spawned_jobs = []
+    origin ={
+        'type': str(Origin.system),
+        'id': None
+    }
 
     for pj in potential_jobs:
         job_map = pj['job'].map()
-        Queue.enqueue_job(job_map, None) # passing no origin results in system origin
+        Queue.enqueue_job(job_map, origin) # passing no origin results in system origin
 
         spawned_jobs.append(pj['rule']['alg'])
 

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -239,10 +239,8 @@ def create_jobs(db, container_before, container_after, container_type):
 
     for pj in potential_jobs:
         job_map = pj['job'].map()
-        try:
-            Queue.enqueue_job(job_map, None) # passing no origin results in system origin
-        except Exception as e: # pylint: disable=broad-except
-            config.log.exception('Unable to enqueue job from rules: {}'.format(e))
+        Queue.enqueue_job(job_map, None) # passing no origin results in system origin
+
         spawned_jobs.append(pj['rule']['alg'])
 
     return spawned_jobs

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -5,6 +5,7 @@ from ..dao.containerutil import FileReference
 
 from . import gears
 from .jobs import Job
+from .queue import Queue
 
 log = config.log
 
@@ -237,9 +238,12 @@ def create_jobs(db, container_before, container_after, container_type):
     spawned_jobs = []
 
     for pj in potential_jobs:
-        pj['job'].insert()
+        job_map = pj['job'].map()
+        try:
+            Queue.enqueue_job(job_map, None) # passing no origin results in system origin
+        except Exception as e: # pylint: disable=broad-except
+            config.log.exception('Unable to enqueue job from rules: {}'.format(e))
         spawned_jobs.append(pj['rule']['alg'])
-
 
     return spawned_jobs
 

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -244,7 +244,7 @@ def create_jobs(db, container_before, container_after, container_type):
 
     for pj in potential_jobs:
         job_map = pj['job'].map()
-        Queue.enqueue_job(job_map, origin) # passing no origin results in system origin
+        Queue.enqueue_job(job_map, origin)
 
         spawned_jobs.append(pj['rule']['alg'])
 

--- a/test/unit_tests/python/test_gear_util.py
+++ b/test/unit_tests/python/test_gear_util.py
@@ -1,0 +1,56 @@
+
+import copy
+from api.jobs import gears
+
+# DISCUSS: this basically asserts that the log helper doesn't throw, which is of non-zero but questionable value.
+# Could instead be marked for pytest et. al to ignore coverage? Desirability? Compatibility?
+def test_fill_defaults():
+
+    gear_config = {
+        'key_one':      {'default': 1},
+        'key_two':      {'default': 2},
+        'key_three':    {'default': 3},
+        'key_no_de':    {}
+    }
+
+    gear = {
+        'gear': {
+            'config': gear_config
+        }
+    }
+
+    # test sending in complete config does not change
+    config = {
+        'key_one': 4,
+        'key_two': 5,
+        'key_three': 6
+    }
+
+    result = gears.fill_gear_default_values(gear, config)
+    assert result['key_one'] == 4
+    assert result['key_two'] == 5
+    assert result['key_three'] == 6
+
+    # test sending in empty config
+    result = gears.fill_gear_default_values(gear, {})
+    assert result['key_one'] == 1
+    assert result['key_two'] == 2
+    assert result['key_three'] == 3
+
+    # test sending in None config
+    result = gears.fill_gear_default_values(gear, None)
+    assert result['key_one'] == 1
+    assert result['key_two'] == 2
+    assert result['key_three'] == 3
+
+    # test sending in semi-complete config
+    config = {
+        'key_one': None,
+        'key_two': []
+        #'key_three': 6 # missing
+    }
+
+    result = gears.fill_gear_default_values(gear, config)
+    assert result['key_one'] == None
+    assert result['key_two'] == []
+    assert result['key_three'] == 3


### PR DESCRIPTION
Resolves #923 

Changes in this PR
- Jobs launched by rules will get input file context and meta
- Jobs launched by rules will get the defaults of all configs from the gear manifest