### PR TITLE
Allow workers to gracefully lose the config upsert race

### DIFF
--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -81,7 +81,7 @@ class AuthProvider(object):
             'auth_type': self.auth_type,
             'uid': uid
         }
-        dbutil.fault_tolerant_replace_one('refreshtokens', query, refresh_doc, upsert=True)
+        dbutil.fault_tolerant_replace_one(config.db, 'refreshtokens', query, refresh_doc, upsert=True)
 
 class JWTAuthProvider(AuthProvider):
 

--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -2,30 +2,40 @@ import random
 import time
 
 from pymongo.errors import DuplicateKeyError
-from .. import config
 from . import APIStorageException
 
-
-
-
-def fault_tolerant_replace_one(coll_name, query, update, upsert=False):
+def try_replace_one(db, coll_name, query, update, upsert=False):
     """
     Mongo does not see replace w/ upsert as an atomic action:
     https://jira.mongodb.org/browse/SERVER-14322
 
-    Attempt a retry if first try produces DuplicateKeyError
+    This function will try a replace_one operation, returning the result and if the operation succeeded.
+    """
+
+    try:
+        result = db[coll_name].replace_one(query, update, upsert=upsert)
+    except DuplicateKeyError:
+        return result, False
+    else:
+        return result, True
+
+
+def fault_tolerant_replace_one(db, coll_name, query, update, upsert=False):
+    """
+    Like try_replace_one, but will retry several times, waiting a random short duration each time.
+
+    Raises an APIStorageException if the retry loop gives up.
     """
 
     attempts = 0
     while attempts < 10:
         attempts += 1
-        try:
-            result = config.db[coll_name].replace_one(query, update, upsert=upsert)
-        except DuplicateKeyError:
-            time.sleep(random.uniform(0.01,0.05))
-        else:
+
+        result, success = try_replace_one(db, coll_name, query, update, upsert)
+
+        if success:
             return result
+        else:
+            time.sleep(random.uniform(0.01,0.05))
 
     raise APIStorageException('Unable to replace object.')
-
-


### PR DESCRIPTION
An adaptation of the work @davidfarkas put on the `mongo-filetypes` branch. Closes #844.

