### PR TITLE
Allow batch processing of gears with no input (SDK gears)

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -207,15 +207,17 @@ class SessionStorage(ContainerStorage):
         if not include_archived:
             query['archived'] = {'$ne': True}
 
-        if containerutil.singularize(target_type) == 'project':
+        target_type = containerutil.singularize(target_type)
+
+        if target_type == 'project':
             query['project'] = {'$in':target_ids}
 
-        elif containerutil.singularize(target_type) == 'session':
+        elif target_type == 'session':
             query['_id'] = {'$in':target_ids}
 
-        elif containerutil.singularize(target_type) == 'acquisition':
+        elif target_type == 'acquisition':
             a_query = copy.deepcopy(query)
-            a_query['session'] = {'$in':target_ids}
+            a_query['_id'] = {'$in':target_ids}
             session_ids = list(set([a['session'] for a in AcquisitionStorage().get_all_el(a_query, user, {'session':1})]))
             query['_id'] = {'$in':session_ids}
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -585,7 +585,7 @@ class BatchHandler(base.RequestHandler):
             # All containers become matched destinations
 
             results = {
-                'matched': [{'id': x['_id'], 'type': 'session'} for x in containers]
+                'matched': [{'id': str(x['_id']), 'type': 'session'} for x in containers]
             }
 
         else:


### PR DESCRIPTION
Notable differences from regular batch running gears:
  - one job will be created for each session that can be found from targets (there is no matching based on files in sessions)
  - if "targets" are acquisitions or projects, sessions are derived from this target list
  - one analysis is created for each session if the gear is an analysis gear

TODO: create tests for new changes

### Breaking Changes
None


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
