### PR TITLE
Analysis downloaded files separated into input and output folders

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -33,6 +33,12 @@ def _filter_check(property_filter, property_values):
 
 class Download(base.RequestHandler):
 
+    def _input_or_output(self, file_):
+        if file_.get('input'):
+            return 'input'
+        else:
+            return 'output'
+
     def _append_targets(self, targets, cont_name, container, prefix, total_size, total_cnt, optional, data_path, filters):
         for f in container.get('files', []):
             if filters:
@@ -50,7 +56,10 @@ class Download(base.RequestHandler):
             if optional or not f.get('optional', False):
                 filepath = os.path.join(data_path, util.path_from_hash(f['hash']))
                 if os.path.exists(filepath): # silently skip missing files
-                    targets.append((filepath, prefix + '/' + f['name'], cont_name, str(container.get('_id')),f['size']))
+                    if cont_name == 'analyses':
+                        targets.append((filepath, prefix + '/' + self._input_or_output(f) + '/' + f['name'], cont_name, str(container.get('_id')),f['size']))
+                    else:
+                        targets.append((filepath, prefix + '/' + f['name'], cont_name, str(container.get('_id')),f['size']))
                     total_size += f['size']
                     total_cnt += 1
         return total_size, total_cnt

--- a/api/download.py
+++ b/api/download.py
@@ -51,7 +51,7 @@ class Download(base.RequestHandler):
                 filepath = os.path.join(data_path, util.path_from_hash(f['hash']))
                 if os.path.exists(filepath): # silently skip missing files
                     if cont_name == 'analyses':
-                        targets.append((filepath, prefix + '/' + 'input' if f.get('input') else 'output' + '/' + f['name'], cont_name, str(container.get('_id')),f['size']))
+                        targets.append((filepath, prefix + '/' + ('input' if f.get('input') else 'output') + '/' + f['name'], cont_name, str(container.get('_id')),f['size']))
                     else:
                         targets.append((filepath, prefix + '/' + f['name'], cont_name, str(container.get('_id')),f['size']))
                     total_size += f['size']

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -378,7 +378,7 @@ class AnalysesHandler(RefererHandler):
             filepath = os.path.join(data_path, util.path_from_hash(f['hash']))
             if os.path.exists(filepath): # silently skip missing files
                 targets.append((filepath,
-                                util.sanitize_string_to_filename(analysis['label']) + '/' + 'input' if f.get('input') else 'output' + '/'+ f['name'],
+                                util.sanitize_string_to_filename(analysis['label']) + '/' + ('input' if f.get('input') else 'output') + '/'+ f['name'],
                                 'analyses', analysis['_id'], f['size']))
                 total_size += f['size']
                 total_cnt += 1

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -367,11 +367,6 @@ class AnalysesHandler(RefererHandler):
             self.abort(400, 'ticket not for this resource')
         return ticket
 
-    def _input_or_output(self, file_):
-        if file_.get('input'):
-            return 'input'
-        else:
-            return 'output'
 
     def _prepare_batch(self, fileinfo, analysis):
         ## duplicated code from download.py
@@ -383,7 +378,7 @@ class AnalysesHandler(RefererHandler):
             filepath = os.path.join(data_path, util.path_from_hash(f['hash']))
             if os.path.exists(filepath): # silently skip missing files
                 targets.append((filepath,
-                                util.sanitize_string_to_filename(analysis['label']) + '/' + self._input_or_output(f) + '/'+ f['name'],
+                                util.sanitize_string_to_filename(analysis['label']) + '/' + 'input' if f.get('input') else 'output' + '/'+ f['name'],
                                 'analyses', analysis['_id'], f['size']))
                 total_size += f['size']
                 total_cnt += 1

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -367,6 +367,11 @@ class AnalysesHandler(RefererHandler):
             self.abort(400, 'ticket not for this resource')
         return ticket
 
+    def _input_or_output(self, file_):
+        if file_.get('input'):
+            return 'input'
+        else:
+            return 'output'
 
     def _prepare_batch(self, fileinfo, analysis):
         ## duplicated code from download.py
@@ -378,7 +383,7 @@ class AnalysesHandler(RefererHandler):
             filepath = os.path.join(data_path, util.path_from_hash(f['hash']))
             if os.path.exists(filepath): # silently skip missing files
                 targets.append((filepath,
-                                util.sanitize_string_to_filename(analysis['label']) + '/' + f['name'],
+                                util.sanitize_string_to_filename(analysis['label']) + '/' + self._input_or_output(f) + '/'+ f['name'],
                                 'analyses', analysis['_id'], f['size']))
                 total_size += f['size']
                 total_cnt += 1


### PR DESCRIPTION
Fixes #971 

### Breaking Changes
Analysis downloads will have another folder level in the filepath: `input` and `output`.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
