### PR TITLE
Removed a few dozen unhelpful log statements

### DIFF
--- a/api/auth/groupauth.py
+++ b/api/auth/groupauth.py
@@ -43,8 +43,7 @@ def list_permission_checker(handler, uid=None):
                         query['permissions'] = {'$elemMatch': {'_id': handler.uid, 'access': 'admin'}}
                     else:
                         query['permissions._id'] = handler.uid
-            log.debug(query)
-            log.debug(projection)
+
             return exec_op(method, query=query, projection=projection)
         return f
     return g

--- a/api/auth/listauth.py
+++ b/api/auth/listauth.py
@@ -75,7 +75,6 @@ def permissions_sublist(handler, container):
     access = _get_access(handler.uid, container)
     def g(exec_op):
         def f(method, _id, query_params = None, payload = None, exclude_params=None):
-            log.debug(query_params)
             if method in ['GET', 'DELETE']  and query_params.get('_id') == handler.uid:
                 return exec_op(method, _id, query_params, payload, exclude_params)
             elif access >= INTEGER_PERMISSIONS['admin']:

--- a/api/dao/base.py
+++ b/api/dao/base.py
@@ -124,7 +124,6 @@ class ContainerStorage(object):
         raise ValueError('action should be one of GET, POST, PUT, DELETE')
 
     def create_el(self, payload):
-        log.debug(payload)
         payload = self._to_mongo(payload)
         try:
             result = self.dbc.insert_one(payload)
@@ -187,8 +186,6 @@ class ContainerStorage(object):
                 query['$and'] = [{'permissions': {'$elemMatch': user}}, {'permissions': query.pop('permissions')}]
             else:
                 query['permissions'] = {'$elemMatch': user}
-        log.debug(query)
-        log.debug(projection)
 
         # if projection includes files.info, add new key `info_exists`
         if projection and 'files.info' in projection:

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -29,7 +29,6 @@ class GroupStorage(ContainerStorage):
         return cont
 
     def create_el(self, payload):
-        log.debug(payload)
         permissions = payload.pop('permissions')
         return self.dbc.update_one(
             {'_id': payload['_id']},

--- a/api/dao/liststorage.py
+++ b/api/dao/liststorage.py
@@ -233,22 +233,17 @@ class StringListStorage(ListStorage):
         return super(StringListStorage, self).exec_op(action, _id, query_params, payload, exclude_params)
 
     def _create_el(self, _id, payload, exclude_params):
-        log.debug('payload {}'.format(payload))
         query = {'_id': _id, self.list_name: {'$ne': payload}}
         update = {
             '$push': {self.list_name: payload},
             '$set': {'modified': datetime.datetime.utcnow()}
         }
-        log.debug('query {}'.format(query))
-        log.debug('update {}'.format(update))
         result = self.dbc.update_one(query, update)
         if result.matched_count < 1:
             raise APIConflictException('Item already exists in list.')
         return result
 
     def _update_el(self, _id, query_params, payload, exclude_params):
-        log.debug('query_params {}'.format(payload))
-        log.debug('payload {}'.format(query_params))
         query = {
             '_id': _id,
             '$and':[
@@ -260,16 +255,11 @@ class StringListStorage(ListStorage):
             '$set': {self.list_name + '.$': payload,
             'modified': datetime.datetime.utcnow()}
         }
-        log.debug('query {}'.format(query))
-        log.debug('update {}'.format(update))
         return self.dbc.update_one(query, update)
 
     def _get_el(self, _id, query_params):
-        log.debug('query_params {}'.format(query_params))
         query = {'_id': _id, self.list_name: query_params}
         projection = {self.list_name + '.$': 1}
-        log.debug('query {}'.format(query))
-        log.debug('projection {}'.format(projection))
         result = self.dbc.find_one(query, projection)
         if result and result.get(self.list_name):
             return result.get(self.list_name)[0]

--- a/api/download.py
+++ b/api/download.py
@@ -216,7 +216,6 @@ class Download(base.RequestHandler):
                 total_size, file_cnt = self._append_targets(targets, 'analyses', analysis, prefix, total_size, file_cnt, req_spec['optional'], data_path, req_spec.get('filters'))
 
         if len(targets) > 0:
-            log.debug(json.dumps(targets, sort_keys=True, indent=4, separators=(',', ': ')))
             if not filename:
                 filename = arc_prefix + '_' + datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S') + '.tar'
             ticket = util.download_ticket(self.request.client_addr, 'batch', targets, filename, total_size)
@@ -316,8 +315,6 @@ class Download(base.RequestHandler):
                 payload_schema_uri = validators.schema_uri('input', 'download.json')
                 validator = validators.from_schema_path(payload_schema_uri)
                 validator(req_spec, 'POST')
-                log.debug(json.dumps(req_spec, sort_keys=True, indent=4, separators=(',', ': ')))
-
                 return self._preflight_archivestream(req_spec, collection=self.get_param('collection'))
 
     def summary(self):
@@ -335,7 +332,7 @@ class Download(base.RequestHandler):
             level = node['level']
 
             containers = {'projects':0, 'sessions':0, 'acquisitions':0, 'analyses':0}
-            
+
             if level == 'project':
                 # Grab sessions and their ids
                 sessions = config.db.sessions.find({'project': node['_id']}, {'_id': 1})
@@ -374,7 +371,7 @@ class Download(base.RequestHandler):
                 containers['analyses'] = 1
 
             else:
-                self.abort(400, "{} not a recognized level".format(level)) 
+                self.abort(400, "{} not a recognized level".format(level))
 
             containers = [cont for cont in containers if containers[cont] == 1]
 
@@ -386,7 +383,7 @@ class Download(base.RequestHandler):
                 {'$project': {'_id': '$_id', 'type': '$files.type','mbs': {'$divide': ['$files.size', BYTES_IN_MEGABYTE]}}},
                 {'$group': {
                     '_id': '$type',
-                    'count': {'$sum' : 1}, 
+                    'count': {'$sum' : 1},
                     'mb_total': {'$sum':'$mbs'}
                 }}
             ]

--- a/api/download.py
+++ b/api/download.py
@@ -1,5 +1,4 @@
 import bson
-import json
 import pytz
 import os.path
 import tarfile

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -37,7 +37,6 @@ class CollectionsHandler(ContainerHandler):
         mongo_validator, payload_validator = self._get_validators()
 
         payload = self.request.json_body
-        log.debug(payload)
         payload_validator(payload, 'POST')
         payload['permissions'] = [{
             '_id': self.uid,
@@ -92,7 +91,6 @@ class CollectionsHandler(ContainerHandler):
             elif item['level'] == 'acquisition':
                 acq_ids += [item_id]
         operator = '$addToSet' if contents['operation'] == 'add' else '$pull'
-        log.info(' '.join(['collection', _id, operator, str(acq_ids)]))
         if not bson.ObjectId.is_valid(_id):
             self.abort(400, 'not a valid object id')
         config.db.acquisitions.update_many({'_id': {'$in': acq_ids}}, {operator: {'collections': bson.ObjectId(_id)}})
@@ -147,8 +145,6 @@ class CollectionsHandler(ContainerHandler):
         if not self.is_true('archived'):
             query['archived'] = {'$ne': True}
         projection = self.container_handler_configurations['sessions']['list_projection']
-        log.debug(query)
-        log.debug(projection)
         sessions = list(config.db.sessions.find(query, projection))
         self._filter_all_permissions(sessions, self.uid)
         if self.is_true('measurements'):

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -414,7 +414,6 @@ class ContainerHandler(base.RequestHandler):
         mongo_validator, payload_validator = self._get_validators()
 
         payload = self.request.json_body
-        log.debug(payload)
         #validate the input payload
         payload_validator(payload, 'POST')
         # Load the parent container in which the new container will be created

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -531,7 +531,6 @@ class DataExplorerHandler(base.RequestHandler):
 
         nodes = []
         results = helpers.scan(client=config.es, query={'query': query}, scroll='5m', size=1000, index='data_explorer', doc_type='flywheel', _source=[return_type+'._id'])
-        log.debug(results)
         for result in results:
             nodes.append({'level': return_type, '_id': result['_source'][return_type]['_id']})
         return {'nodes':nodes}

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -64,7 +64,6 @@ class UserHandler(base.RequestHandler):
         # Check for authZ before cleaning up user permissions
         permchecker(noop)('DELETE', _id)
         self._cleanup_user_permissions(user.get('_id'))
-        log.debug('2')
         result = self.storage.exec_op('DELETE', _id)
         if result.deleted_count == 1:
             return {'deleted': result.deleted_count}

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -95,7 +95,6 @@ def suggest_for_files(gear, files):
         schemas[x] = Draft4Validator(schema)
 
     suggested_files = {}
-    log.debug(schemas)
     for input_name, schema in schemas.iteritems():
         suggested_files[input_name] = []
         for f in files:

--- a/api/validators.py
+++ b/api/validators.py
@@ -54,7 +54,6 @@ def decorator_from_schema_path(schema_url):
     def g(exec_op):
         def validator(method, **kwargs):
             payload = kwargs['payload']
-            log.debug(payload)
             if method == 'PUT' and schema.get('required'):
                 _schema = copy.copy(schema)
                 _schema.pop('required')
@@ -105,7 +104,6 @@ def key_check(schema_url):
     if schema_url is None:
         return no_op
     schema, _ = _resolve_schema(schema_url)
-    log.debug(schema)
     if schema.get('key_fields') is None:
         return no_op
     def g(exec_op):

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -131,7 +131,6 @@ class RequestHandler(webapp2.RequestHandler):
         cached_token = config.db.authtokens.find_one({'_id': session_token})
 
         if cached_token:
-            self.request.logger.debug('looked up cached token in %dms', ((datetime.datetime.utcnow() - timestamp).total_seconds() * 1000.))
 
             # Check if site has inactivity timeout
             try:


### PR DESCRIPTION
This is driving me a little batty and making the logs hard to read, so I fixed it.

Every `log.debug` that doesn't have some information attached to it has been removed, excepting some in `config.py` because... fine. Oh, and I removed the every-request line that benchmarks our database!

If one of these is important to you, please add it back with more information - and make it conditional.

When I decided to improve this, there were about ~40 calls to `log.debug`, many of them in code paths that tend to be called on many / most / all requests. Now there are about 14. I also got rid of one `log.info`, the rest seemed fine.