### PR TITLE
Add to job log if job is orphaned

### DIFF
--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -8,7 +8,7 @@ import pymongo
 import datetime
 
 from .. import config
-from .jobs import Job
+from .jobs import Job, Logs
 from .gears import get_gear, validate_gear_config, fill_gear_default_values
 from ..validators import InputValidationException
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
@@ -411,6 +411,7 @@ class Queue(object):
             else:
                 orphaned += 1
                 j = Job.load(doc)
-                Queue.retry(j)
-
+                Logs.add(j.id_, [{"msg":"The job did not report in for a long time and was canceled.", "fd":-1}])
+                new_id = Queue.retry(j)
+                Logs.add(j.id_, [{"msg": "Retried job as " + str(new_id) if new_id else "Job retries exceeded maximum allowed", "fd":-1}])
         return orphaned

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -325,7 +325,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     assert r.json().get('orphaned') == 1
     r = as_admin.get('/jobs/'+str(job_instance['_id'])+'/logs')
     assert r.ok
-    assert "The job did not report in for a long time and was canceled." in [log["msg"] for log in r.json().get('logs',[])]
+    assert "The job did not report in for a long time and was canceled." in [log["msg"] for log in r.json()['logs']]
     api_db.jobs.delete_one({"_id": bson.ObjectId("5a007cdb0f352600d94c845f")})
 
 


### PR DESCRIPTION
Fixes #860 
### Todo
- [x] Add Tests

### Changes
- When a job is orphaned, a message is added saying such and if it is successfully retried, another message is added giving the new job id
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
