### PR TITLE
Add endpoint for modifying container info fields

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -256,6 +256,9 @@ endpoints = [
         prefix('/<cont_name:{cname}>', [
             route( '/<cid:{cid}>',     ContainerHandler,                                m=['GET','PUT','DELETE']),
             prefix('/<cid:{cid}>', [
+
+                route( '/info',                                ContainerHandler, h='modify_info',    m=['POST']),
+
                 route('/<list_name:tags>',               TagsListHandler, m=['POST']),
                 route('/<list_name:tags>/<value:{tag}>', TagsListHandler, m=['GET', 'PUT', 'DELETE']),
 

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -508,6 +508,21 @@ class ContainerHandler(base.RequestHandler):
         else:
             self.abort(404, 'Element not updated in container {} {}'.format(self.storage.cont_name, _id))
 
+    def modify_info(self, cont_name, **kwargs):
+        _id = kwargs.pop('cid')
+        self.config = self.container_handler_configurations[cont_name]
+        self.storage = self.config['storage']
+        container = self._get_container(_id)
+        permchecker = self._get_permchecker(container)
+        payload = self.request.json_body
+
+        validators.validate_data(payload, 'info_update.json', 'input', 'POST')
+
+        permchecker(noop)('PUT', _id=_id)
+        self.storage.modify_info(_id, payload)
+
+        return
+
     def delete(self, cont_name, **kwargs):
         _id = kwargs.pop('cid')
         self.config = self.container_handler_configurations[cont_name]


### PR DESCRIPTION
Similar to #893, add endpoint to modify container info using set/delete/replace keywords.


### `POST /api/<container>/<container_id>/info`
  
Format of request:
```
# set or delete required, can have both
{
	"set": {}, 
	"delete": []
}
```
  - "set" is a non-empty map of `key` : `value` (values may be scalars or complex objects). All keys are added to the `info` key if they do not exist, or are replaced by the `value` if they do exist
  - "delete" is a non-empty list of top level keys to be deleted. If key does not exist, request is ignored.

OR

```
{
	"replace": {}
}
```
  - the value of the "replace" key will be set as the value of the `info` key for the file. It can be an empty map. 

**Example Requests**
```
POST /api/acquisitions/5984d10adf01e2001433dde8/info HTTP/1.1
Content-Type: application/json

{
	"set": {
		"top_level_key": 123,
		"complex_object_key": {
			"a": 1,
			"b": 2
		}
	},
	"delete": ["keys", "to", "be", "removed"]
}
```

```
POST /api/acquisitions/5984d10adf01e2001433dde8/info HTTP/1.1
Content-Type: application/json

{
	"replace": {
		"notice": "this is a full replace of the info field"
	}
}
```


### Breaking Changes
None

There will be a transition period where setting `info` through `PUT /container_name/container_id`will still be allowed. It is expected that eventually all changes in `info` should go through these new endpoints. 

@kofalt SDK related additive changes

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
