### PR TITLE
Mark failed job output

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -141,6 +141,8 @@ endpoints = [
             route('/<:[^/]+>/logs/text',   JobHandler,  h='get_logs_text', m=['GET']),
             route('/<:[^/]+>/logs/html',   JobHandler,  h='get_logs_html', m=['GET']),
             route('/<:[^/]+>/logs',        JobHandler,  h='add_logs',      m=['POST']),
+            route('/<:[^/]+>/prepare-complete',     JobHandler,  h='prepare_complete',     m=['POST']),
+            route('/<:[^/]+>/accept-failed-output', JobHandler,  h='accept_failed_output', m=['POST']),
         ]),
         route('/gears',                                  GearsHandler),
         route('/gears/check',                            GearsHandler, h='check', m=['POST']),

--- a/api/config.py
+++ b/api/config.py
@@ -248,6 +248,7 @@ def initialize_db():
     create_or_recreate_ttl_index('authtokens', 'timestamp', 2592000)
     create_or_recreate_ttl_index('uploads', 'timestamp', 60)
     create_or_recreate_ttl_index('downloads', 'timestamp', 60)
+    create_or_recreate_ttl_index('job_tickets', 'timestamp', 300)
 
     now = datetime.datetime.utcnow()
     db.groups.update_one({'_id': 'unknown'}, {'$setOnInsert': { 'created': now, 'modified': now, 'label': 'Unknown', 'permissions': []}}, upsert=True)

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -4,7 +4,7 @@ import copy
 from .. import config
 from ..auth import has_access
 
-from ..web.errors import APIPermissionException
+from ..web.errors import APINotFoundException, APIPermissionException
 
 CONT_TYPES = ['acquisition', 'analysis', 'collection', 'group', 'project', 'session']
 SINGULAR_TO_PLURAL = {
@@ -189,12 +189,12 @@ class ContainerReference(object):
         collection = pluralize(self.type)
         result = config.db[collection].find_one({'_id': bson.ObjectId(self.id)})
         if result is None:
-            raise Exception('No such {} {} in database'.format(self.type, self.id))
+            raise APINotFoundException('No such {} {} in database'.format(self.type, self.id))
         if 'parent' in result:
             parent_collection = pluralize(result['parent']['type'])
             parent = config.db[parent_collection].find_one({'_id': bson.ObjectId(result['parent']['id'])})
             if parent is None:
-                raise Exception('Cannot find parent {} {} of {} {}'.format(
+                raise APINotFoundException('Cannot find parent {} {} of {} {}'.format(
                     result['parent']['type'], result['parent']['id'], self.type, self.id))
             result['permissions'] = parent['permissions']
         return result
@@ -251,7 +251,7 @@ class FileReference(ContainerReference):
             if file['name'] == self.name:
                 return file
 
-        raise Exception('No such file {} on {} {} in database'.format(self.name, self.type, self.id))
+        raise APINotFoundException('No such file {} on {} {} in database'.format(self.name, self.type, self.id))
 
 
 def create_filereference_from_dictionary(d):

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -483,26 +483,18 @@ class JobHandler(base.RequestHandler):
 
     @require_drone
     def prepare_complete(self, _id):
-        try:
-            j = Job.get(_id)
-        except Exception: # pylint: disable=broad-except
-            # TBD maybe raise APINotFound from Job.get?
-            raise APINotFoundException('Job not found')
+        j = Job.get(_id)
         payload = self.request.json
         ticket = {
             'job': j.id_,
             'success': payload.get('success', False),
         }
-        # TBD why not store success on the job itself?
         return {'ticket': config.db.job_tickets.insert_one(ticket).inserted_id}
 
 
     @require_login
     def accept_failed_output(self, _id):
-        try:
-            j = Job.get(_id)
-        except Exception: # pylint: disable=broad-except
-            raise APINotFoundException('Job not found')
+        j = Job.get(_id)
 
         # Permission check
         if not self.superuser_request:
@@ -510,9 +502,6 @@ class JobHandler(base.RequestHandler):
 
         if j.state != 'failed':
             self.abort(400, 'Can only accept failed output of a job that failed')
-
-        # TBD recording user/timestamp? logging?
-        # TBD ticket cleanup/purging?
 
         # Remove flag from files
         container = j.destination.get()

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -17,6 +17,7 @@ from ..dao.containerutil import ContainerReference, pluralize
 from ..web import base
 from ..web.encoder import pseudo_consistent_json_encode
 from ..web.errors import APIPermissionException, APINotFoundException, InputValidationException
+from ..web.request import AccessType
 from .. import config
 from . import batch
 from ..validators import validate_data, verify_payload_exists
@@ -524,6 +525,8 @@ class JobHandler(base.RequestHandler):
 
         # Create any automatic jobs for the accepted files
         create_jobs(config.db, container_before, container, cont_name)
+
+        self.log_user_access(AccessType.accept_failed_output, cont_name=j.destination.type, cont_id=j.destination.id, multifile=True)
 
 
 class BatchHandler(base.RequestHandler):

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -19,7 +19,8 @@ class Job(object):
                  attempt=1, previous_job_id=None, created=None,
                  modified=None, state='pending', request=None,
                  id_=None, config_=None, now=False, origin=None,
-                 saved_files=None, produced_metadata=None, batch=None):
+                 saved_files=None, produced_metadata=None, batch=None,
+                 failed_output_accepted=False):
         """
         Creates a job.
 
@@ -48,6 +49,8 @@ class Job(object):
             The database identifier for this job.
         config: map (optional)
             The gear configuration for this job.
+        failed_output_accepted: bool (optional)
+            Flag indicating whether output was accepted for a failed job.
         """
 
         # TODO: validate inputs against the manifest
@@ -101,6 +104,7 @@ class Job(object):
         self.saved_files        = saved_files
         self.produced_metadata  = produced_metadata
         self.batch              = batch
+        self.failed_output_accepted = failed_output_accepted
 
 
     def intention_equals(self, other_job):
@@ -159,7 +163,8 @@ class Job(object):
             origin=d.get('origin'),
             saved_files=d.get('saved_files'),
             produced_metadata=d.get('produced_metadata'),
-            batch=d.get('batch'))
+            batch=d.get('batch'),
+            failed_output_accepted=d.get('failed_output_accepted', False))
 
     @classmethod
     def get(cls, _id):
@@ -198,6 +203,8 @@ class Job(object):
             d.pop('request')
         if d['now'] is False:
             d.pop('now')
+        if d['failed_output_accepted'] is False:
+            d.pop('failed_output_accepted')
 
         return d
 

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -12,6 +12,7 @@ from ..dao.containerutil import create_filereference_from_dictionary, create_con
 
 from .. import config
 from ..util import render_template
+from ..web.errors import APINotFoundException
 
 
 class Job(object):
@@ -170,7 +171,7 @@ class Job(object):
     def get(cls, _id):
         doc = config.db.jobs.find_one({'_id': bson.ObjectId(_id)})
         if doc is None:
-            raise Exception('Job not found')
+            raise APINotFoundException('Job not found')
 
         return cls.load(doc)
 

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -182,7 +182,7 @@ def create_potential_jobs(db, container, container_type, file_):
 
     for rule in rules:
 
-        if eval_rule(rule, file_, container):
+        if 'from_failed_job' not in file_ and eval_rule(rule, file_, container):
 
             alg_name = rule['alg']
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -186,7 +186,7 @@ class Upload(base.RequestHandler):
         elif strategy == 'reaper':
             strategy = Strategy.reaper
         else:
-            self.abort(500, 'stragegy {} not implemented'.format(strategy))
+            self.abort(500, 'strategy {} not implemented'.format(strategy))
         return process_upload(self.request, strategy, origin=self.origin, context=context)
 
     def engine(self):
@@ -204,7 +204,10 @@ class Upload(base.RequestHandler):
             self.abort(400, 'container id is required')
         else:
             cid = bson.ObjectId(cid)
-        context = {'job_id': self.get_param('job')}
+        context = {
+            'job_id': self.get_param('job'),
+            'job_ticket_id': self.get_param('job_ticket'),
+        }
         if level == 'analysis':
             return process_upload(self.request, Strategy.analysis_job, origin=self.origin, container_type=level, id_=cid, context=context)
         else:

--- a/api/web/request.py
+++ b/api/web/request.py
@@ -7,14 +7,15 @@ from .. import config
 from .. import util
 
 AccessType = util.Enum('AccessType', {
-    'view_container':   'view_container',
-    'view_subject':     'view_subject',
-    'view_file':        'view_file',
-    'download_file':    'download_file',
-    'delete_file':      'delete_file',
-    'delete_analysis':  'delete_analysis',
-    'user_login':       'user_login',
-    'user_logout':      'user_logout'
+    'accept_failed_output':     'accept_failed_output',
+    'view_container':           'view_container',
+    'view_subject':             'view_subject',
+    'view_file':                'view_file',
+    'download_file':            'download_file',
+    'delete_file':              'delete_file',
+    'delete_analysis':          'delete_analysis',
+    'user_login':               'user_login',
+    'user_logout':              'user_logout'
 })
 AccessTypeList = [type_name for type_name, member in AccessType.__members__.items()]
 

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -329,6 +329,116 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     api_db.jobs.delete_one({"_id": bson.ObjectId("5a007cdb0f352600d94c845f")})
 
 
+def test_failed_job_output(data_builder, default_payload, as_user, as_admin, as_drone, api_db, file_form):
+    # create gear
+    gear_doc = default_payload['gear']['gear']
+    gear_doc['inputs'] = {
+        'dicom': {
+            'base': 'file'
+        }
+    }
+    gear = data_builder.create_gear(gear=gear_doc)
+    session = data_builder.create_session()
+    acquisition = data_builder.create_acquisition()
+    assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.zip')).ok
+
+    # create job
+    r = as_admin.post('/jobs/add', json={
+        'gear_id': gear,
+        'inputs': {
+            'dicom': {
+                'type': 'acquisition',
+                'id': acquisition,
+                'name': 'test.zip'
+            }
+        },
+        'config': {},
+        'destination': {
+            'type': 'acquisition',
+            'id': acquisition
+        }
+    })
+    assert r.ok
+    job = r.json()['_id']
+
+    # prepare completion (send success status before engine upload)
+    r = as_drone.post('/jobs/' + job + '/prepare-complete', json={'success': False})
+    assert r.ok
+
+    # verify that job ticket has been created
+    job_ticket = api_db.job_tickets.find_one({'job': job})
+    assert job_ticket['success'] == False
+
+    # engine upload
+    metadata = {
+        'project':{
+            'label': 'engine project',
+            'info': {'test': 'p'}
+        },
+        'session':{
+            'label': 'engine session',
+            'subject': {'code': 'engine subject'},
+            'info': {'test': 's'}
+        },
+        'acquisition':{
+            'label': 'engine acquisition',
+            'timestamp': '2016-06-20T21:57:36+00:00',
+            'info': {'test': 'a'},
+            'files': [{
+                'name': 'result.txt',
+                'type': 'engine type 0',
+                'info': {'test': 'f0'}
+            }]
+        }
+    }
+
+    r = as_drone.post('/engine',
+        params={'level': 'acquisition', 'id': acquisition, 'job': job, 'job_ticket': job_ticket['_id']},
+        files=file_form('result.txt', meta=metadata)
+    )
+    assert r.ok
+
+    # verify metadata wasn't applied
+    acq = as_admin.get('/acquisitions/' + acquisition).json()
+    assert 'test' not in acq.get('info', {})
+
+    # verify uploaded file got marked w/ 'from_failed_job'
+    result_file = acq['files'][-1]
+    assert 'from_failed_job' in result_file
+    assert result_file['from_failed_job'] == True
+
+    # try to accept failed output - user has no access to destination
+    r = as_user.post('/jobs/' + job + '/accept-failed-output')
+    assert r.status_code == 403
+
+    # try to accept failed output - job is not in failed state yet
+    r = as_admin.post('/jobs/' + job + '/accept-failed-output')
+    assert r.status_code == 400
+
+    # set job state to failed
+    r = as_drone.put('/jobs/' + job, json={'state': 'running'})
+    assert r.ok
+    r = as_drone.put('/jobs/' + job, json={'state': 'failed'})
+    assert r.ok
+
+    # accept failed output
+    r = as_admin.post('/jobs/' + job + '/accept-failed-output')
+    assert r.ok
+
+    # verify job is marked w/ 'failed_output_accepted'
+    job_doc = as_admin.get('/jobs/' + job).json()
+    assert 'failed_output_accepted' in job_doc
+    assert job_doc['failed_output_accepted'] == True
+
+    # verify metadata was applied on hierarchy
+    acq = as_admin.get('/acquisitions/' + acquisition).json()
+    assert 'test' in acq.get('info', {})
+
+    # verify uploaded file isn't marked anymore
+    result_file = acq['files'][-1]
+    assert 'from_failed_job' not in result_file
+
+
 def test_analysis_job_creation_errors(data_builder, default_payload, as_admin, file_form):
     project = data_builder.create_project()
     session = data_builder.create_session()

--- a/tests/integration_tests/python/test_uploads.py
+++ b/tests/integration_tests/python/test_uploads.py
@@ -699,7 +699,7 @@ def test_acquisition_engine_upload(data_builder, file_form, as_root):
         params={'level': 'acquisition', 'id': acquisition, 'job': '000000000000000000000000'},
         files=file_form('one.csv', 'two.csv', meta=metadata)
     )
-    assert r.status_code == 500
+    assert r.status_code == 404
 
     # engine upload
     r = as_root.post('/engine',


### PR DESCRIPTION
Resolves #968 

Notes/TBDs:
* Didn't add `/jobs/x/complete` endpoint as discussed, added feature to existing `/upload/engine` endpoint in a backwards-compatible way instead. Opinions?
* Without further context it seems like success info might as well be stored on the job. What's the reasoning behind keeping it in a separate ticket?
* Job ticket purging/cleanup not implemented!

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
