### PR TITLE
get_all analyses

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -192,8 +192,6 @@ endpoints = [
 
             route('/<cid:{gid}>/<list_name:tags>',                           TagsListHandler, m=['POST']),
             route('/<cid:{gid}>/<list_name:tags>/<value:{tag}>',             TagsListHandler, m=['GET', 'PUT', 'DELETE']),
-
-            route( '/<cid:{gid}>/analyses',                                     AnalysesHandler, h='get_all',       m=['GET']),
         ]),
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -192,6 +192,7 @@ endpoints = [
 
             route('/<cid:{gid}>/<list_name:tags>',                           TagsListHandler, m=['POST']),
             route('/<cid:{gid}>/<list_name:tags>/<value:{tag}>',             TagsListHandler, m=['GET', 'PUT', 'DELETE']),
+            route('/<cid:{gid}>/<sub_cont_name:{cname}|all>/analyses',       AnalysesHandler, h='get_all',       m=['GET']),
         ]),
 
 
@@ -270,6 +271,7 @@ endpoints = [
                 route('/<list_name:files>/<name:{fname}>/info', FileListHandler, h='get_info',       m=['GET']),
                 route('/<list_name:files>/<name:{fname}>/info', FileListHandler, h='modify_info',    m=['POST']),
 
+                route( '/<sub_cont_name:{cname}|all>/analyses',         AnalysesHandler, h='get_all',       m=['GET']),
                 route( '/analyses',                                     AnalysesHandler, h='get_all',       m=['GET']),
                 route( '/analyses',                                     AnalysesHandler,                    m=['POST']),
                 prefix('/analyses', [

--- a/api/api.py
+++ b/api/api.py
@@ -192,6 +192,8 @@ endpoints = [
 
             route('/<cid:{gid}>/<list_name:tags>',                           TagsListHandler, m=['POST']),
             route('/<cid:{gid}>/<list_name:tags>/<value:{tag}>',             TagsListHandler, m=['GET', 'PUT', 'DELETE']),
+
+            route( '/<cid:{gid}>/analyses',                                     AnalysesHandler, h='get_all',       m=['GET']),
         ]),
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -270,6 +270,7 @@ endpoints = [
                 route('/<list_name:files>/<name:{fname}>/info', FileListHandler, h='get_info',       m=['GET']),
                 route('/<list_name:files>/<name:{fname}>/info', FileListHandler, h='modify_info',    m=['POST']),
 
+                route( '/analyses',                                     AnalysesHandler, h='get_all',       m=['GET']),
                 route( '/analyses',                                     AnalysesHandler,                    m=['POST']),
                 prefix('/analyses', [
                     route('/<_id:{cid}>',                               AnalysesHandler,                    m=['GET', 'PUT', 'DELETE']),

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -211,20 +211,29 @@ def test_get_all_containers(data_builder, as_admin, as_user, as_public, file_for
 
     # Test get_all analyses
     project_3 = data_builder.create_project(public=False)
-    session_2 = data_builder.create_session(project=project_3)
+    session_2 = data_builder.create_session(project=project_3, public=False)
 
     analysis_1 = as_admin.post('/sessions/' + session_2 + '/analyses', files=file_form(
         'analysis.csv', meta={'label': 'no-job', 'inputs': [{'name': 'analysis.csv'}]})).json()["_id"]
+
     session_3 = data_builder.create_session(project=project_3)
     acquisition = data_builder.create_acquisition(session=session_3)
     analysis_2 = as_admin.post('/acquisitions/' + acquisition + '/analyses', files=file_form(
         'analysis.csv', meta={'label': 'no-job', 'inputs': [{'name': 'analysis.csv'}]})).json()["_id"]
 
-    r = as_admin.get('/projects/' + project_3 + '/analyses')
+    r = as_admin.get('/projects/' + project_3 + '/analyses', params={'children':True})
     assert r.ok
     assert len(r.json()) == 2
 
-    r = as_user.get('/projects/' + project_3 + '/analyses')
+    r = as_user.get('/projects/' + project_3 + '/analyses', params={'children':True})
+    assert r.status_code == 403
+
+
+    r = as_admin.get('/sessions/' + session_2 + '/analyses', params={'children':False})
+    assert r.ok
+    assert len(r.json()) == 1
+
+    r = as_user.get('/sessions/' + session_2 + '/analyses', params={'children':False})
     assert r.status_code == 403
 
 

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -175,6 +175,7 @@ def test_project_template(data_builder, file_form, as_admin):
 
 
 def test_get_all_containers(data_builder, as_admin, as_user, as_public, file_form):
+    group = data_builder.create_group()
     project_1 = data_builder.create_project()
     project_2 = data_builder.create_project()
     session = data_builder.create_session(project=project_1)
@@ -210,7 +211,7 @@ def test_get_all_containers(data_builder, as_admin, as_user, as_public, file_for
     assert r.ok
 
     # Test get_all analyses
-    project_3 = data_builder.create_project(public=False)
+    project_3 = data_builder.create_project(group=group, public=False)
     session_2 = data_builder.create_session(project=project_3, public=False)
 
     analysis_1 = as_admin.post('/sessions/' + session_2 + '/analyses', files=file_form(
@@ -221,19 +222,28 @@ def test_get_all_containers(data_builder, as_admin, as_user, as_public, file_for
     analysis_2 = as_admin.post('/acquisitions/' + acquisition + '/analyses', files=file_form(
         'analysis.csv', meta={'label': 'no-job', 'inputs': [{'name': 'analysis.csv'}]})).json()["_id"]
 
-    r = as_admin.get('/projects/' + project_3 + '/analyses', params={'children':True})
-    assert r.ok
-    assert len(r.json()) == 2
 
-    r = as_user.get('/projects/' + project_3 + '/analyses', params={'children':True})
-    assert r.status_code == 403
-
-
-    r = as_admin.get('/sessions/' + session_2 + '/analyses', params={'children':False})
+    r = as_admin.get('/groups/' + group + '/sessions/analyses')
     assert r.ok
     assert len(r.json()) == 1
 
-    r = as_user.get('/sessions/' + session_2 + '/analyses', params={'children':False})
+    r = as_admin.get('/projects/' + project_3 + '/sessions/analyses')
+    assert r.ok
+    assert len(r.json()) == 1
+
+    r = as_admin.get('/projects/' + project_3 + '/all/analyses')
+    assert r.ok
+    assert len(r.json()) == 2
+
+    r = as_user.get('/projects/' + project_3 + '/all/analyses')
+    assert r.status_code == 403
+
+
+    r = as_admin.get('/sessions/' + session_2 + '/analyses')
+    assert r.ok
+    assert len(r.json()) == 1
+
+    r = as_user.get('/sessions/' + session_2 + '/analyses')
     assert r.status_code == 403
 
 

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -222,6 +222,8 @@ def test_get_all_containers(data_builder, as_admin, as_user, as_public, file_for
     analysis_2 = as_admin.post('/acquisitions/' + acquisition + '/analyses', files=file_form(
         'analysis.csv', meta={'label': 'no-job', 'inputs': [{'name': 'analysis.csv'}]})).json()["_id"]
 
+    r = as_admin.get('/sessions/' + session_2 + '/projects/analyses')
+    assert r.status_code == 400
 
     r = as_admin.get('/groups/' + group + '/sessions/analyses')
     assert r.ok


### PR DESCRIPTION
Fixes #1024 
- Returns all analyses given a group/project/session/acquisition
- 3 types of calls
  - `/{cont_name}/{cid}/analyses`
    - It will return all analyses of the container
    - example, `/Project/{ProjectId}/analyses` will return any analyses that have that project as a parent 
  - `/{cont_name}/{cid}/{sub_cont_name}/analyses`
    - This will return any analyses that have any of the sub_containers under the container as a parent
    -  example, `projects/{ProjectId}/acquisitions/analyses` will return any analyses that have an acquisition that is under that project as a parent
  - `/{cont_name}/{cid}/all/analyses`
    - This will return any analyses that have a parent which is a container under the container in the url
    - example, `projects/{ProjectId}/all/analyses` will return any analyses that have any session or acquisition or the project itself as a parent
- Must have permission to the top level container and (only applies when making calls at the group level) will only return analyses for which the user has permission to its parent
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
