### PR TITLE
Fix regex project match for reaper upload

### DIFF
--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -337,7 +337,8 @@ def _find_or_create_destination_project(group_id, project_label, timestamp, user
     if project_label == '':
         project_label = 'Unknown'
 
-    project = config.db.projects.find_one({'group': group['_id'], 'label': {'$regex': re.escape(project_label), '$options': 'i'}})
+    project_regex = '^'+re.escape(project_label)+'$'
+    project = config.db.projects.find_one({'group': group['_id'], 'label': {'$regex': project_regex, '$options': 'i'}})
 
     if project:
         # If the project already exists, check the user's access


### PR DESCRIPTION
A regex is required to do a case insensitive lookup of Mongo string fields. The existing regex did not use proper start-of-string and end-of-string tokens so it matched more generously than was expected. This change requires a case-insensitive exact match rather than the existence of the search string. 

FYI @gsfr 
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
