### PR TITLE
Pin the mongodb version to 3.2 in run-tests-docker.sh

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -26,11 +26,14 @@ Build scitran-core image and run automated tests in a docker container:
 * To skip building the image, use `--no-build` (`-B`)
 * To pass any arguments to `run-tests-ubuntu.sh`, use `-- TEST_ARGS`
 
+
 #### Example
 Without rebuilding the image, run only integration tests matching `foo`, use the highest verbosity level for test output and jump into a python debugger session in case an assertion fails:
 ```
 ./tests/bin/run-tests-docker.sh -B -- -i -- -k foo -vvv --pdb
 ```
+
+**NOTE:** The mongodb version is pinned via the `MONGO_VERSION` variable in `tests/bin/run-tests-docker.sh`.
 
 ### Tools
 - [abao](https://github.com/cybertk/abao/)

--- a/tests/bin/run-tests-docker.sh
+++ b/tests/bin/run-tests-docker.sh
@@ -23,6 +23,7 @@ EOF
 function main() {
     local DOCKER_BUILD=true
     local TEST_ARGS=
+    local MONGO_VERSION=3.2
 
     while [[ "$#" > 0 ]]; do
         case "$1" in
@@ -47,7 +48,7 @@ function main() {
     docker run -d \
         --name scitran-core-test-mongo \
         --network scitran-core-test-network \
-        mongo
+        mongo:${MONGO_VERSION}
 
     # Execute tests
     docker run -it \


### PR DESCRIPTION
Integration tests were failing due to aggregation framework changes in mongo 3.6 (which is what docker pulled down by default on my system)

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
