### PR TITLE
Create list of formalized top-level info keys that will always be returned

### DIFF
--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -1,3 +1,4 @@
+import copy
 import bson
 import datetime
 import pymongo.errors
@@ -217,6 +218,7 @@ class ContainerStorage(object):
 
         # if projection includes files.info, add new key `info_exists` and allow reserved info keys through
         if projection and ('info' in projection or 'files.info' in projection or 'subject.info' in projection):
+            projection = copy.deepcopy(projection)
             replace_info_with_bool = True
             projection.pop('subject.info', None)
             projection.pop('files.info', None)
@@ -236,7 +238,7 @@ class ContainerStorage(object):
                 cont['info'] = containerutil.sanitize_info(info)
 
                 if cont.get('subject'):
-                    s_info = cont['subject'].pop('info')
+                    s_info = cont['subject'].pop('info', {})
                     cont['subject']['info_exists'] = bool(s_info)
                     cont['subject']['info'] = containerutil.sanitize_info(s_info)
 

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -216,8 +216,9 @@ class ContainerStorage(object):
                 query['permissions'] = {'$elemMatch': user}
 
         # if projection includes files.info, add new key `info_exists` and allow reserved info keys through
-        if projection and ('info' in projection or 'files.info' in projection):
+        if projection and ('info' in projection or 'files.info' in projection or 'subject.info' in projection):
             replace_info_with_bool = True
+            projection.pop('subject.info', None)
             projection.pop('files.info', None)
             projection.pop('info', None)
         else:
@@ -233,6 +234,11 @@ class ContainerStorage(object):
                 info = cont.pop('info', {})
                 cont['info_exists'] = bool(info)
                 cont['info'] = containerutil.sanitize_info(info)
+
+                if cont.get('subject'):
+                    s_info = cont['subject'].pop('info')
+                    cont['subject']['info_exists'] = bool(s_info)
+                    cont['subject']['info'] = containerutil.sanitize_info(s_info)
 
                 for f in cont.get('files', []):
                     f_info = f.pop('info', {})

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -29,13 +29,14 @@ BASE_DEFAULTS = {
 }
 
 # All containers that inherit from 'container' in the DM
-CONTAINER_DEFAULTS = {
+CONTAINER_DEFAULTS = BASE_DEFAULTS.copy()
+CONTAINER_DEFAULTS.update({
     'permissions':  [],
     'files':        [],
     'notes':        [],
     'tags':         [],
     'info':         {}
-}
+})
 
 
 class ContainerStorage(object):
@@ -91,10 +92,10 @@ class ContainerStorage(object):
         if cont:
             defaults = BASE_DEFAULTS.copy()
             if self.cont_name not in ['groups', 'users']:
-                defaults.update(CONTAINER_DEFAULTS)
-            defaults.update(cont)
-            cont = defaults
-        return cont
+                defaults = CONTAINER_DEFAULTS.copy()
+            for k,v in defaults.iteritems():
+                cont.setdefault(k, v)
+
 
     def get_container(self, _id, projection=None, get_children=False):
         cont = self.get_el(_id, projection=projection)
@@ -122,10 +123,10 @@ class ContainerStorage(object):
         return ContainerStorage.factory(child_name).get_all_el(query, None, projection)
 
     def _from_mongo(self, cont):
-        return cont
+        pass
 
     def _to_mongo(self, payload):
-        return payload
+        pass
 
     def exec_op(self, action, _id=None, payload=None, query=None, user=None,
                 public=False, projection=None, recursive=False, r_payload=None,  # pylint: disable=unused-argument
@@ -150,7 +151,7 @@ class ContainerStorage(object):
         raise ValueError('action should be one of GET, POST, PUT, DELETE')
 
     def create_el(self, payload):
-        payload = self._to_mongo(payload)
+        self._to_mongo(payload)
         try:
             result = self.dbc.insert_one(payload)
         except pymongo.errors.DuplicateKeyError:
@@ -169,7 +170,7 @@ class ContainerStorage(object):
         update = {}
 
         if payload is not None:
-            payload = self._to_mongo(payload)
+            self._to_mongo(payload)
             update['$set'] = util.mongo_dict(payload)
 
         if unset_payload is not None:
@@ -201,9 +202,10 @@ class ContainerStorage(object):
                 _id = bson.ObjectId(_id)
             except bson.errors.InvalidId as e:
                 raise APIStorageException(e.message)
-        cont = self._from_mongo(self.dbc.find_one(_id, projection))
+        cont = self.dbc.find_one(_id, projection)
+        self._from_mongo(cont)
         if fill_defaults:
-            cont =  self._fill_default_values(cont)
+            self._fill_default_values(cont)
         return cont
 
     def get_all_el(self, query, user, projection, fill_defaults=False):
@@ -213,21 +215,33 @@ class ContainerStorage(object):
             else:
                 query['permissions'] = {'$elemMatch': user}
 
-        # if projection includes files.info, add new key `info_exists`
-        if projection and 'files.info' in projection:
+        # if projection includes files.info, add new key `info_exists` and allow reserved info keys through
+        if projection and ('info' in projection or 'files.info' in projection):
             replace_info_with_bool = True
-            projection.pop('files.info')
+            projection.pop('files.info', None)
+            projection.pop('info', None)
+            if not projection:
+                # if we've removed everything, set it as None otherwise only the _id is returned
+                project = None
         else:
             replace_info_with_bool = False
 
-        results = list(self.dbc.find(query, projection))
+        results = list(self.dbc.find(query))
         for cont in results:
-            cont = self._from_mongo(cont)
+            self._from_mongo(cont)
             if fill_defaults:
-                cont =  self._fill_default_values(cont)
+                self._fill_default_values(cont)
+
             if replace_info_with_bool:
+                info = cont.pop('info', {})
+                cont['info_exists'] = bool(info)
+                cont['info'] = containerutil.sanitize_info(info)
+
                 for f in cont.get('files', []):
-                    f['info_exists'] = bool(f.pop('info', False))
+                    f_info = f.pop('info', {})
+                    f['info_exists'] = bool(f_info)
+                    f['info'] = containerutil.sanitize_info(f_info)
+
         return results
 
     def modify_info(self, _id, payload, modify_subject=False):

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -220,9 +220,6 @@ class ContainerStorage(object):
             replace_info_with_bool = True
             projection.pop('files.info', None)
             projection.pop('info', None)
-            if not projection:
-                # if we've removed everything, set it as None otherwise only the _id is returned
-                project = None
         else:
             replace_info_with_bool = False
 

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -146,6 +146,17 @@ def get_stats(cont, cont_type):
 
     return cont
 
+def sanitize_info(info):
+    """
+    Modifies an info key to only include known top-level keys
+    """
+    formalized_keys = ['BIDS']
+    sanitized_info = {}
+    for k in formalized_keys:
+        if k in info:
+            sanitized_info[k] = info[k]
+    return sanitized_info
+
 
 class ContainerReference(object):
     # pylint: disable=redefined-builtin

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -57,7 +57,7 @@ class ContainerHandler(base.RequestHandler):
             'parent_storage': containerstorage.GroupStorage(),
             'storage_schema_file': 'project.json',
             'payload_schema_file': 'project.json',
-            'list_projection': {'info': 0},
+            'list_projection': {'info': 0, 'files.info': 0},
             'propagated_properties': ['archived', 'public'],
             'children_cont': 'sessions'
         },
@@ -313,8 +313,7 @@ class ContainerHandler(base.RequestHandler):
         self.storage = self.config['storage']
 
         projection = self.config['list_projection'].copy()
-        if self.is_true('info'):
-            projection.pop('info')
+
         if self.is_true('permissions'):
             if not projection:
                 projection = None

--- a/raml/schemas/definitions/acquisition.json
+++ b/raml/schemas/definitions/acquisition.json
@@ -37,6 +37,7 @@
               "timezone":     {"$ref":"../definitions/container.json#/definitions/timezone"},
               "created":{"$ref":"../definitions/created-modified.json#/definitions/created"},
               "modified":{"$ref":"../definitions/created-modified.json#/definitions/modified"},
+              "info_exists": {"type": "boolean"},
               "permissions":{
                   "type":"array",
                   "items":{"$ref":"../definitions/permission.json#/definitions/permission-output-default-required"}

--- a/raml/schemas/definitions/collection.json
+++ b/raml/schemas/definitions/collection.json
@@ -32,6 +32,7 @@
                 "label": {"$ref": "../definitions/container.json#/definitions/label"},
                 "description": {"$ref": "../definitions/collection.json#/definitions/description"},
                 "info": {"$ref": "../definitions/container.json#/definitions/info"},
+                "info_exists":  {"$ref": "../definitions/container.json#/definitions/info_exists"},
                 "curator": {"$ref":"#/definitions/curator"},
                 "created":{"$ref":"../definitions/created-modified.json#/definitions/created"},
                 "modified":{"$ref":"../definitions/created-modified.json#/definitions/modified"},

--- a/raml/schemas/definitions/container.json
+++ b/raml/schemas/definitions/container.json
@@ -7,6 +7,7 @@
         "archived":     {"type": "boolean"},
         "label":        {"type": "string", "minLength": 1, "maxLength": 256},
         "info":         {"type": "object"},
+        "info_exists":  {"type": "boolean"},
         "uid":          {"type":"string"},
         "timestamp":    {"type": ["string", "null"], "format": "date-time"},
         "timezone":     {"type": "string"}

--- a/raml/schemas/definitions/project.json
+++ b/raml/schemas/definitions/project.json
@@ -21,6 +21,7 @@
                 "public": {"$ref": "../definitions/container.json#/definitions/public"},
                 "label": {"$ref": "../definitions/container.json#/definitions/label"},
                 "info": {"$ref": "../definitions/container.json#/definitions/info"},
+                "info_exists":  {"$ref": "../definitions/container.json#/definitions/info_exists"},
                 "description": {"$ref": "../definitions/project.json#/definitions/description"},
                 "group":{"$ref":"../definitions/group.json#/definitions/_id"},
                 "created":{"$ref":"../definitions/created-modified.json#/definitions/created"},

--- a/raml/schemas/definitions/session.json
+++ b/raml/schemas/definitions/session.json
@@ -30,6 +30,7 @@
                 "public":       {"$ref": "../definitions/container.json#/definitions/public"},
                 "label":        {"$ref": "../definitions/container.json#/definitions/label"},
                 "info":         {"$ref": "../definitions/container.json#/definitions/info"},
+                "info_exists":  {"$ref": "../definitions/container.json#/definitions/info_exists"},
                 "archived":     {"$ref":"../definitions/container.json#/definitions/archived"},
                 "operator":     {"$ref": "#/definitions/operator"},
                 "project":      {"$ref":"#/definitions/project"},

--- a/raml/schemas/definitions/subject.json
+++ b/raml/schemas/definitions/subject.json
@@ -51,6 +51,7 @@
               "code":             {"$ref":"#/definitions/code"},
               "tags":             {"$ref":"#/definitions/tags"},
               "info":             {"$ref":"#/definitions/info"},
+              "info_exists":      {"$ref": "../definitions/container.json#/definitions/info_exists"},
               "files":{
                   "type":"array",
                   "items":{

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -1031,6 +1031,29 @@ def test_edit_subject_info(data_builder, as_admin, as_user):
     assert r.json()['info'] == subject_info
 
 
+    # Test info is not returned on list endpoints
+    r = as_admin.get('/sessions')
+    assert r.ok
+    sessions = r.json()
+    assert len(sessions) == 1
+    assert not sessions[0]['subject'].get('info')
+    assert sessions[0]['subject']['info_exists']
+
+    # Add reserved key and ensure it is returned
+    BIDS_map = {'BIDS':{'subject_label': 'TEST'}}
+    r = as_admin.post('/sessions/' + session + '/subject/info', json={
+        'set': BIDS_map
+    })
+    assert r.ok
+
+    r = as_admin.get('/sessions')
+    assert r.ok
+    sessions = r.json()
+    assert len(sessions) == 1
+    assert sessions[0]['subject']['info'] == BIDS_map
+    assert sessions[0]['subject']['info_exists']
+
+
     # Use 'replace' to set file info to {}
     r = as_admin.post('/sessions/' + session + '/subject/info', json={
         'replace': {}

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -180,10 +180,6 @@ def test_get_all_containers(data_builder, as_admin, as_user, as_public, file_for
     project_2 = data_builder.create_project()
     session = data_builder.create_session(project=project_1)
 
-    # get all projects w/ info=true
-    r = as_public.get('/projects', params={'info': 'true'})
-    assert r.ok
-
     # get all projects w/ counts=true
     r = as_public.get('/projects', params={'counts': 'true'})
     assert r.ok
@@ -762,6 +758,28 @@ def test_edit_container_info(data_builder, as_admin, as_user):
     assert r.ok
     assert r.json()['info'] == project_info
 
+    # Test info is not returned on list endpoints
+    r = as_admin.get('/projects')
+    assert r.ok
+    projects = r.json()
+    assert len(projects) == 1
+    assert not projects[0].get('info')
+    assert projects[0]['info_exists']
+
+    # Add reserved key and ensure it is returned
+    BIDS_map = {'BIDS':{'project_label': 'TEST'}}
+    r = as_admin.post('/projects/' + project + '/info', json={
+        'set': BIDS_map
+    })
+    assert r.ok
+
+    r = as_admin.get('/projects')
+    assert r.ok
+    projects = r.json()
+    assert len(projects) == 1
+    assert projects[0]['info'] == BIDS_map
+    assert projects[0]['info_exists']
+
 
     # Use 'replace' to set file info to {}
     r = as_admin.post('/projects/' + project + '/info', json={
@@ -772,6 +790,7 @@ def test_edit_container_info(data_builder, as_admin, as_user):
     r = as_admin.get('/projects/' + project)
     assert r.ok
     assert r.json()['info'] == {}
+
 
 def test_edit_file_info(data_builder, as_admin, file_form):
     project = data_builder.create_project()
@@ -870,6 +889,28 @@ def test_edit_file_info(data_builder, as_admin, file_form):
     r = as_admin.get('/projects/' + project + '/files/' + file_name + '/info')
     assert r.ok
     assert r.json()['info'] == file_info
+
+    # Test file info is not returned on list endpoints
+    r = as_admin.get('/projects')
+    assert r.ok
+    projects = r.json()
+    assert len(projects) == 1 and projects[0]['_id'] == project
+    assert not projects[0]['files'][0].get('info')
+    assert projects[0]['files'][0]['info_exists']
+
+    # Add reserved key and ensure it is returned
+    BIDS_map = {'BIDS':{'project_label': 'TEST'}}
+    r = as_admin.post('/projects/' + project + '/files/' + file_name + '/info', json={
+        'set': BIDS_map
+    })
+    assert r.ok
+
+    r = as_admin.get('/projects')
+    assert r.ok
+    projects = r.json()
+    assert len(projects) == 1 and projects[0]['_id'] == project
+    assert projects[0]['files'][0]['info'] == BIDS_map
+    assert projects[0]['files'][0]['info_exists']
 
 
     # Use 'replace' to set file info to {}


### PR DESCRIPTION
Some top-level keys have special meaning in the info dictionary on objects and files. This PR allows a static list of info keys through on list endpoints. Kept simple until more nuance (project/site level options) is necessary. 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
