### PR TITLE
Allow subject info editing in new style

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -259,6 +259,7 @@ endpoints = [
             prefix('/<cid:{cid}>', [
 
                 route( '/info',                                ContainerHandler, h='modify_info',    m=['POST']),
+                route( '/<subject:subject>/info',               ContainerHandler, h='modify_info',    m=['POST']),
 
                 route('/<list_name:tags>',               TagsListHandler, m=['POST']),
                 route('/<list_name:tags>/<value:{tag}>', TagsListHandler, m=['GET', 'PUT', 'DELETE']),

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -510,6 +510,13 @@ class ContainerHandler(base.RequestHandler):
 
     def modify_info(self, cont_name, **kwargs):
         _id = kwargs.pop('cid')
+
+        # Support subject info modification in new style
+        # Will be removed when subject becomes stand-alone container
+        modify_subject = True if 'subject' in kwargs else False
+        if modify_subject and cont_name != 'sessions':
+            self.abort(400, 'Subject info modification only allowed via session.')
+
         self.config = self.container_handler_configurations[cont_name]
         self.storage = self.config['storage']
         container = self._get_container(_id)
@@ -519,7 +526,7 @@ class ContainerHandler(base.RequestHandler):
         validators.validate_data(payload, 'info_update.json', 'input', 'POST')
 
         permchecker(noop)('PUT', _id=_id)
-        self.storage.modify_info(_id, payload)
+        self.storage.modify_info(_id, payload, modify_subject=modify_subject)
 
         return
 


### PR DESCRIPTION
A lot of this logic can be removed when subject becomes its own container (this is also noted with inline comments). Old methods for modifying subject info are deprecated and will eventually no longer be supported. 

### Breaking Changes
None

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
