### PR TITLE
Filter list of groups on GET endpoint when user is site admin

### DIFF
--- a/api/auth/groupauth.py
+++ b/api/auth/groupauth.py
@@ -36,13 +36,10 @@ def list_permission_checker(handler, uid=None):
                 projection = projection or {}
                 projection['permissions.$'] = 1
             else:
-                if not handler.superuser_request and not handler.user_is_admin:
+                if not handler.superuser_request:
                     query = query or {}
                     projection = projection or {}
-                    if handler.is_true('admin'):
-                        query['permissions'] = {'$elemMatch': {'_id': handler.uid, 'access': 'admin'}}
-                    else:
-                        query['permissions._id'] = handler.uid
+                    query['permissions._id'] = handler.uid
 
             return exec_op(method, query=query, projection=projection)
         return f

--- a/tests/integration_tests/python/test_groups.py
+++ b/tests/integration_tests/python/test_groups.py
@@ -128,4 +128,4 @@ def test_groups(as_user, as_admin, data_builder):
     project = data_builder.create_project()
     r = as_admin.get('/groups', params={'join': 'projects'})
     assert r.ok
-    assert r.json()[1].get('projects')[0].get('_id') == project
+    assert r.json()[0].get('projects')[0].get('_id') == project


### PR DESCRIPTION
At one point there was a change to the get_all filter that would return all groups to users that were site admins without invoking `root=true`. Functionality has been returned to the original behavior of only returning all groups (including those the user does not have permission to) when specifically requested through the use of the root flag. 


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
