### PR TITLE
Fix missing origin on download

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -103,7 +103,7 @@ class Download(base.RequestHandler):
 
         if len(targets) > 0:
             filename = arc_prefix + '_ '+datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S') + '.tar'
-            ticket = util.download_ticket(self.request.client_addr, 'batch', targets, filename, total_size)
+            ticket = util.download_ticket(self.request.client_addr, self.origin, 'batch', targets, filename, total_size)
             config.db.downloads.insert_one(ticket)
             return {'ticket': ticket['_id'], 'file_cnt': file_cnt, 'size': total_size}
         else:
@@ -225,7 +225,7 @@ class Download(base.RequestHandler):
         if len(targets) > 0:
             if not filename:
                 filename = arc_prefix + '_' + datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S') + '.tar'
-            ticket = util.download_ticket(self.request.client_addr, 'batch', targets, filename, total_size)
+            ticket = util.download_ticket(self.request.client_addr, self.origin, 'batch', targets, filename, total_size)
             config.db.downloads.insert_one(ticket)
             return {'ticket': ticket['_id'], 'file_cnt': file_cnt, 'size': total_size, 'filename': filename}
         else:
@@ -285,7 +285,7 @@ class Download(base.RequestHandler):
                         yield chunk
                     if len(chunk) % BLOCKSIZE != 0:
                         yield (BLOCKSIZE - (len(chunk) % BLOCKSIZE)) * b'\0'
-                self.log_user_access(AccessType.download_file, cont_name=cont_name, cont_id=cont_id, multifile=True) # log download
+                self.log_user_access(AccessType.download_file, cont_name=cont_name, cont_id=cont_id, multifile=True, origin_override=ticket['origin']) # log download
         yield stream.getvalue() # get tar stream trailer
         stream.close()
 
@@ -295,7 +295,7 @@ class Download(base.RequestHandler):
             t.type = tarfile.SYMTYPE
             t.linkname = os.path.relpath(filepath, data_path)
             yield t.tobuf()
-            self.log_user_access(AccessType.download_file, cont_name=cont_name, cont_id=cont_id, multifile=True) # log download
+            self.log_user_access(AccessType.download_file, cont_name=cont_name, cont_id=cont_id, multifile=True, origin_override=ticket['origin']) # log download
         stream = cStringIO.StringIO()
         with tarfile.open(mode='w|', fileobj=stream) as _:
             pass
@@ -317,9 +317,8 @@ class Download(base.RequestHandler):
                 self.response.app_iter = self.archivestream(ticket)
             self.response.headers['Content-Type'] = 'application/octet-stream'
             self.response.headers['Content-Disposition'] = 'attachment; filename=' + str(ticket['filename'])
-            for project_id in ticket['projects']:
-                config.db.projects.update_one({'_id': project_id}, {'$inc': {'counter': 1}})
         else:
+
             req_spec = self.request.json_body
 
             if self.is_true('bulk'):

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -450,7 +450,7 @@ class FileListHandler(ListHandler):
 
         # Request for download ticket
         if self.get_param('ticket') == '':
-            ticket = util.download_ticket(self.request.client_addr, 'file', _id, filename, fileinfo['size'], origin=self.origin)
+            ticket = util.download_ticket(self.request.client_addr, self.origin, 'file', _id, filename, fileinfo['size'])
             return {'ticket': config.db.downloads.insert_one(ticket).inserted_id}
 
         # Request for info about zipfile

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -327,12 +327,12 @@ class AnalysesHandler(RefererHandler):
             if filename:
                 total_size = fileinfo[0]['size']
                 file_cnt = 1
-                ticket = util.download_ticket(self.request.client_addr, 'file', cid, filename, total_size, origin=self.origin)
+                ticket = util.download_ticket(self.request.client_addr, self.origin, 'file', cid, filename, total_size)
             else:
                 targets, total_size, file_cnt = self._prepare_batch(fileinfo, analysis)
                 label = util.sanitize_string_to_filename(self.storage.get_container(_id).get('label', 'No Label'))
                 filename = 'analysis_' + label + '.tar'
-                ticket = util.download_ticket(self.request.client_addr, 'batch', targets, filename, total_size, origin=self.origin)
+                ticket = util.download_ticket(self.request.client_addr, self.origin, 'batch', targets, filename, total_size)
             return {
                 'ticket': config.db.downloads.insert_one(ticket).inserted_id,
                 'size': total_size,

--- a/api/util.py
+++ b/api/util.py
@@ -144,7 +144,7 @@ def container_fileinfo(container, filename): # pragma: no cover
     return None
 
 
-def download_ticket(ip, type_, target, filename, size, projects = None, origin=None):
+def download_ticket(ip, origin, type_, target, filename, size, projects = None):
     return {
         '_id': str(uuid.uuid4()),
         'timestamp': datetime.datetime.utcnow(),

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -379,7 +379,7 @@ class RequestHandler(webapp2.RequestHandler):
 
         util.send_json_http_exception(self.response, message, code, request_id, custom=custom_errors)
 
-    def log_user_access(self, access_type, cont_name=None, cont_id=None, multifile=False):
+    def log_user_access(self, access_type, cont_name=None, cont_id=None, multifile=False, origin_override=None):
 
         if not config.get_item('core', 'access_log_enabled'):
             return
@@ -391,7 +391,7 @@ class RequestHandler(webapp2.RequestHandler):
             'access_type':      access_type.value,
             'request_method':   self.request.method,
             'request_path':     self.request.path,
-            'origin':           self.origin,
+            'origin':           origin_override if origin_override is not None else self.origin,
             'timestamp':        datetime.datetime.utcnow()
         }
 

--- a/tests/integration_tests/python/test_access_log.py
+++ b/tests/integration_tests/python/test_access_log.py
@@ -175,8 +175,14 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     file_count = r.json()['file_cnt']
     r = as_admin.get('/download', params={'ticket':ticket_id})
     assert r.ok
+
     log_records_count_after = log_db.access_log.count({})
     assert log_records_count_before + file_count == log_records_count_after
+
+    most_recent_logs = log_db.access_log.find({}).sort([('_id', -1)]).limit(file_count)
+    for l in most_recent_logs:
+        assert l['access_type'] == AccessType.download_file.value
+        assert l['origin']['id'] == 'admin@user.com'
 
     ###
     # Test search bulk download
@@ -191,8 +197,14 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     file_count = r.json()['file_cnt']
     r = as_admin.get('/download', params={'ticket':ticket_id})
     assert r.ok
+
     log_records_count_after = log_db.access_log.count({})
     assert log_records_count_before + file_count == log_records_count_after
+
+    most_recent_logs = log_db.access_log.find({}).sort([('_id', -1)]).limit(file_count)
+    for l in most_recent_logs:
+        assert l['access_type'] == AccessType.download_file.value
+        assert l['origin']['id'] == 'admin@user.com'
 
 
     ###

--- a/tests/integration_tests/python/test_access_log.py
+++ b/tests/integration_tests/python/test_access_log.py
@@ -30,6 +30,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     most_recent_log = log_db.access_log.find({}).sort([('_id', -1)]).limit(1)[0]
     assert most_recent_log['access_type'] == AccessType.user_login.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
     ###
@@ -46,6 +47,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     most_recent_log = log_db.access_log.find({}).sort([('_id', -1)]).limit(1)[0]
     assert most_recent_log['access_type'] == AccessType.user_logout.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
     ###
@@ -64,6 +66,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['session']['id'] == str(session)
     assert most_recent_log['access_type'] == AccessType.view_container.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
     ###
@@ -94,6 +97,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['session']['id'] == session
     assert most_recent_log['context']['subject']['label'] == subject_code
     assert most_recent_log['access_type'] == AccessType.view_subject.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
     # Upload files
@@ -122,6 +126,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['project']['id'] == project
     assert most_recent_log['access_type'] == AccessType.download_file.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
     ###
@@ -149,6 +154,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['project']['id'] == str(project)
     assert most_recent_log['context']['ticket_id'] == ticket_id
     assert most_recent_log['access_type'] == AccessType.download_file.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
     # Upload another file
@@ -206,6 +212,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['project']['id'] == str(project)
     assert most_recent_log['access_type'] == AccessType.view_file.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
     ###
@@ -224,6 +231,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['project']['id'] == str(project)
     assert most_recent_log['access_type'] == AccessType.delete_file.value
+    assert most_recent_log['origin']['id'] == 'admin@user.com'
 
 
 def test_access_log_fails(data_builder, as_admin, log_db):


### PR DESCRIPTION
Ticketed downloads do not use auth channels (other than the ticket itself and verifying matching ip), leaving origin blank. This change requires origin on all download tickets and uses the set origin in the ticket to log access. Tests have been updated to look for proper origin on all access logs. 