### PR TITLE
Fix missing projection in get_all

### DIFF
--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -223,10 +223,14 @@ class ContainerStorage(object):
             projection.pop('subject.info', None)
             projection.pop('files.info', None)
             projection.pop('info', None)
+
+            # Replace with None if empty (empty projections only return ids)
+            if not projection:
+                projection = None
         else:
             replace_info_with_bool = False
 
-        results = list(self.dbc.find(query))
+        results = list(self.dbc.find(query, projection))
         for cont in results:
             self._from_mongo(cont)
             if fill_defaults:


### PR DESCRIPTION
Fixes #1044 

#1039 Added a bug that removed the projection variable from a call to mongo's `find()`. It has been replaced.

Tests were added to check for sensitive fields in list endpoints. PHI work will supercede these tests so minimal effort was applied. 

### Breaking Changes
None

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
