### PR TITLE
Remove direct access of potentially missing keys in job enqueue 

### DIFF
--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -232,7 +232,7 @@ class Queue(object):
 
                 # Whitelist file fields passed to gear to those that are scientific-relevant
                 whitelisted_keys = ['info', 'tags', 'measurements', 'mimetype', 'type', 'modality', 'size']
-                obj_projection = { key: obj[key] for key in whitelisted_keys }
+                obj_projection = { key: obj.get(key) for key in whitelisted_keys }
 
                 config_['inputs'][x] = {
                     'base': 'file',


### PR DESCRIPTION
Fixes #1042

Updates files that might have missing keys* as well, but code should not be written expecting these keys to exist. 

\* A null version of these keys are always added to new files via `upload.py`. Files from old version of scitran or that were manually entered into the system might be missing these keys. 

### Breaking Changes
None

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md

  