### PR TITLE
Fix db upgrade 42 for containers with archived=false

### DIFF
--- a/bin/database.py
+++ b/bin/database.py
@@ -1344,12 +1344,11 @@ def upgrade_to_41():
 
 def upgrade_to_42_closure(cont, cont_name):
     archived = cont.pop('archived')
+    update = {'$unset': {'archived': True}}
     if archived:
         cont['tags'] = cont.get('tags', []) + ['hidden']
-    config.db[cont_name].update_one({'_id': cont['_id']}, {
-                                        '$set': {'tags': cont['tags']},
-                                        '$unset': {'archived': True}
-                                    })
+        update['$set'] = {'tags': cont['tags']}
+    config.db[cont_name].update_one({'_id': cont['_id']}, update)
     return True
 
 def upgrade_to_42():

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -16,13 +16,19 @@ def database(mocker):
 def test_42(data_builder, api_db, as_admin, database):
     # Mimic old-style archived flag
     session = data_builder.create_session()
+    session2 = data_builder.create_session()
     api_db.sessions.update_one({'_id': bson.ObjectId(session)}, {'$set': {'archived': True}})
+    api_db.sessions.update_one({'_id': bson.ObjectId(session2)}, {'$set': {'archived': False}})
 
     # Verfiy archived session is not hidden anymore
-    assert session in [s['_id'] for s in as_admin.get('/sessions').json()]
+    assert session  in [s['_id'] for s in as_admin.get('/sessions').json()]
 
     # Verify upgrade creates new-style hidden tag
     database.upgrade_to_42()
     session_data = as_admin.get('/sessions/' + session).json()
     assert 'archived' not in session_data
     assert 'hidden' in session_data['tags']
+
+    # Verify archived was removed when false as well
+    session_data = as_admin.get('/sessions/' + session2).json()
+    assert 'archived' not in session_data


### PR DESCRIPTION
If archived is false an the container does not have any existing tags, the update would fail attempting to access the missing tags. Added additional tests.


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
