### PR TITLE
Menagerie of job handler improvements

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -246,7 +246,7 @@ def initialize_db():
     create_or_recreate_ttl_index('authtokens', 'timestamp', 2592000)
     create_or_recreate_ttl_index('uploads', 'timestamp', 60)
     create_or_recreate_ttl_index('downloads', 'timestamp', 60)
-    create_or_recreate_ttl_index('job_tickets', 'timestamp', 300)
+    create_or_recreate_ttl_index('job_tickets', 'timestamp', 3600) # IMPORTANT: this controls job orphan logic. Ref queue.py
 
     now = datetime.datetime.utcnow()
     db.groups.update_one({'_id': 'unknown'}, {'$setOnInsert': { 'created': now, 'modified': now, 'label': 'Unknown', 'permissions': []}}, upsert=True)

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -276,7 +276,7 @@ class JobsHandler(base.RequestHandler):
         job = Queue.start_job(tags=tags)
 
         if job is None:
-            self.abort(400, 'No jobs to process')
+            raise InputValidationException('No jobs to process')
         else:
             return job
 

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -370,6 +370,32 @@ class Job(object):
         self.request = r
         return self.request
 
+class JobTicket(object):
+    """
+    A JobTicket represents an attempt to complete a job.
+    """
+
+    @staticmethod
+    def get(_id):
+        return config.db.job_tickets.find_one({'_id': bson.ObjectId(_id)})
+
+    @staticmethod
+    def create(job_id, success):
+        j = Job.get(job_id)
+
+        result = config.db.job_tickets.insert_one({
+            'job': j.id_,
+            'success': success,
+        })
+
+        return result.inserted_id
+
+    @staticmethod
+    def find(job_id):
+        """Find any tickets with job ID"""
+        return list(config.db.job_tickets.find({'job': job_id}))
+
+
 class Logs(object):
 
     @staticmethod
@@ -422,6 +448,11 @@ class Logs(object):
 
     @staticmethod
     def add(_id, doc):
+
+        # Silently ignore adding no logs
+        if len(doc) <= 0:
+            return
+
         log = config.db.job_logs.find_one({'_id': _id})
 
         if log is None: # Race

--- a/api/placer.py
+++ b/api/placer.py
@@ -15,7 +15,7 @@ from . import validators
 from .dao.containerstorage import SessionStorage, AcquisitionStorage
 from .dao import containerutil, hierarchy
 from .jobs import rules
-from .jobs.jobs import Job
+from .jobs.jobs import Job, JobTicket
 from .types import Origin
 from .web import encoder
 from .web.errors import FileFormException
@@ -245,7 +245,7 @@ class EnginePlacer(Placer):
     """
     A placer that can accept files and/or metadata sent to it from the engine
 
-    It uses update_container_hierarchy to update the container and it's parents' fields from the metadata
+    It uses update_container_hierarchy to update the container and its parents' fields from the metadata
     """
 
     def check(self):
@@ -288,9 +288,9 @@ class EnginePlacer(Placer):
                     break
 
         if self.context.get('job_ticket_id'):
-            job_ticket_id = bson.ObjectId(self.context.get('job_ticket_id'))
-            job_ticket = config.db.job_tickets.find_one({'_id': job_ticket_id})
-            if not job_ticket.get('success'):
+            job_ticket = JobTicket.get(self.context.get('job_ticket_id'))
+
+            if not job_ticket['success']:
                 file_attrs['from_failed_job'] = True
 
         self.save_file(field, file_attrs)
@@ -312,9 +312,9 @@ class EnginePlacer(Placer):
                 self.metadata[k].pop('files', {})
 
             if self.context.get('job_ticket_id'):
-                job_ticket_id = bson.ObjectId(self.context.get('job_ticket_id'))
-                job_ticket = config.db.job_tickets.find_one({'_id': job_ticket_id})
-                if job_ticket.get('success'):
+                job_ticket = JobTicket.get(self.context.get('job_ticket_id'))
+
+                if job_ticket['success']:
                     hierarchy.update_container_hierarchy(self.metadata, bid, self.container_type)
             else:
                 hierarchy.update_container_hierarchy(self.metadata, bid, self.container_type)

--- a/api/tempdir.py
+++ b/api/tempdir.py
@@ -61,7 +61,7 @@ class TemporaryDirectory(object):
 
     def __del__(self):
         # Issue a Warning if implicit cleanup needed
-        self.cleanup(_warn=True)
+        self.cleanup()
 
     # The following code attempts to make
     # this class tolerant of the module nulling out process

--- a/api/util.py
+++ b/api/util.py
@@ -187,7 +187,7 @@ def humanize_validation_error(val_err):
         key = val_err.relative_path[0]
     message = val_err.message.replace("u'", "'")
 
-    return 'Gear manifest does not match schema on key ' + key + ': ' + message
+    return 'Object does not match schema on key ' + key + ': ' + message
 
 def obj_from_map(_map):
     """

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -335,7 +335,6 @@ class RequestHandler(webapp2.RequestHandler):
             code = exception.code
         elif isinstance(exception, errors.InputValidationException):
             code = 400
-            self.request.logger.warning(str(exception))
         elif isinstance(exception, errors.APIAuthProviderException):
             code = 401
         elif isinstance(exception, errors.APIRefreshTokenException):

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -418,6 +418,8 @@ def test_failed_job_output(data_builder, default_payload, as_user, as_admin, as_
         }
     }
 
+    api_db.jobs.update_one({'_id': bson.ObjectId(job)}, {'$set':{'state': 'running'}})
+
     r = as_drone.post('/engine',
         params={'level': 'acquisition', 'id': acquisition, 'job': job, 'job_ticket': job_ticket['_id']},
         files=file_form('result.txt', meta=metadata)
@@ -440,16 +442,6 @@ def test_failed_job_output(data_builder, default_payload, as_user, as_admin, as_
     # try to accept failed output - user has no access to destination
     r = as_user.post('/jobs/' + job + '/accept-failed-output')
     assert r.status_code == 403
-
-    # try to accept failed output - job is not in failed state yet
-    r = as_admin.post('/jobs/' + job + '/accept-failed-output')
-    assert r.status_code == 400
-
-    # set job state to failed
-    r = as_drone.put('/jobs/' + job, json={'state': 'running'})
-    assert r.ok
-    r = as_drone.put('/jobs/' + job, json={'state': 'failed'})
-    assert r.ok
 
     # accept failed output
     r = as_admin.post('/jobs/' + job + '/accept-failed-output')


### PR DESCRIPTION
1. Adding logs to a job will now unconditionally heartbeat that job first. A job consumer now has half the requests over time required when a job is running.
1. Creating a job-completion ticket will prevent that job from being orphaned. A job consumer no longer has to keep heartbeating while an upload is in progress.
1. For this reason, tickets now last an hour instead of 5 minutes.
1. Job tickets are now their own class in `jobs.py`.
1. A bunch of handlers were not using `@directives` or had ineffective `return` statements. Corrected.
1. Moved some repetitive download logic to `util.set_for_download`.
1. Moved some dumb humanizing logic to `util.humanize_validation_error`.
1. Harmonized some, but not all, uses of `self.response.json` variable naming.
1. Slightly reduced the log spam when jobs-next has nothing to return.
1. Fixed a bug in the new job-ticket handler that was not marking jobs as complete / failed.
1. Removed meaningless tempdir warnings. Congrats, CI is 288 lines shorter :tada: 