### PR TITLE
'plus' and 'minus' download filters 

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -17,8 +17,8 @@ log = config.log
 BYTES_IN_MEGABYTE = float(1<<20)
 
 def _filter_check(property_filter, property_values):
-    minus = set(property_filter.get('-', []))
-    plus = set(property_filter.get('+', []))
+    minus = set(property_filter.get('-', []) + property_filter.get('minus', []))
+    plus = set(property_filter.get('+', []) + property_filter.get('plus', []))
     if "null" in plus and not property_values:
         return True
     if "null" in minus and property_values:

--- a/raml/examples/create_download_incomplete_and_dicom.json
+++ b/raml/examples/create_download_incomplete_and_dicom.json
@@ -3,6 +3,6 @@
   "nodes": [{"level":"project", "_id":"57abe1589e512c513d42cb83"}],
   "filters":[{
       "tags":{"+":["incomplete"]},
-      "types":{"+":["dicom"]}
+      "types":{"plus":["dicom"]}
   }]
 }

--- a/raml/schemas/input/download.json
+++ b/raml/schemas/input/download.json
@@ -5,7 +5,9 @@
             "type": "object",
             "properties": {
                 "+": {"$ref": "#/definitions/filterItems"},
-                "-": {"$ref": "#/definitions/filterItems"}
+                "plus": {"$ref": "#definitions/filterItems"},
+                "-": {"$ref": "#/definitions/filterItems"},
+                "minus": {"$ref": "#definitions/filterItems"}
             },
             "additionalProperties": false
         },

--- a/tests/integration_tests/python/test_download.py
+++ b/tests/integration_tests/python/test_download.py
@@ -463,6 +463,20 @@ def test_filters(data_builder, file_form, as_admin):
     assert r.ok
     assert r.json()['file_cnt'] == 2
 
+    # Use filter aliases
+    r = as_admin.post('/download', json={
+        'optional': False,
+        'filters': [
+            {'tags': {'plus':['red']}}
+        ],
+        'nodes': [
+            {'level': 'session', '_id': session},
+        ]
+    })
+    assert r.ok
+    # 'plus' is same as using '+'
+    assert r.json()['file_cnt'] == 2
+
     # Filter by type
     as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
         "test", meta={'name': "test", 'tags': ['red', 'blue']}))


### PR DESCRIPTION
Fixes #1045 
### Changes
- '+' filters are now a union of filters under '+' and 'plus'
- Same thing with '-' and 'minus'

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
