### PR TITLE
Properly 404 on missing file

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -502,8 +502,10 @@ class FileListHandler(ListHandler):
     def get_info(self, cont_name, list_name, **kwargs):
         _id = kwargs['cid']
         filename = kwargs['name']
+        result = super(FileListHandler,self).get(cont_name, list_name, **kwargs)
         self.log_user_access(AccessType.view_file, cont_name=cont_name, cont_id=_id, filename=filename)
-        return super(FileListHandler,self).get(cont_name, list_name, **kwargs)
+        return result
+
 
     def modify_info(self, cont_name, list_name, **kwargs):
         _id = kwargs.pop('cid')

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -789,6 +789,13 @@ def test_edit_file_info(data_builder, as_admin, file_form):
     project = data_builder.create_project()
     file_name = 'test_file.txt'
 
+
+    # Assert getting file info 404s properly
+    r = as_admin.get('/projects/' + project + '/files/' + 'not_real.txt' + '/info')
+    assert r.status_code == 404
+    r = as_admin.get('/projects/' + '000000000000000000000000' + '/files/' + 'not_real.txt' + '/info')
+    assert r.status_code == 404
+
     r = as_admin.post('/projects/' + project + '/files', files=file_form(file_name))
     assert r.ok
 


### PR DESCRIPTION
Fixes #1063

Rearranged the order of operations for `GET /api/cont_name/cont_id/files/filename/info` so logging happens after the file info has been loaded. Endpoint will now properly 404 on unknown files and containers. 


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
