### PR TITLE
Remove unnecessary analysis input file update

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -404,22 +404,9 @@ class AnalysisStorage(ContainerStorage):
             if next_job is None:
                 break
             job = Job.load(next_job)
-        if job.id_ != str(analysis['job']):
+        if job.id_ != analysis['job']:
             # Update analysis if job has changed
-            # Remove old inputs and replace with new job inputs
-            # (In practice these should never change)
-            files = analysis.get('files', [])
-            files[:] = [x for x in files if x.get('output')]
-
-            for i in getattr(job, 'inputs',{}):
-                fileref = job.inputs[i]
-                contref = containerutil.create_containerreference_from_filereference(job.inputs[i])
-                file_ = contref.find_file(fileref.name)
-                if file_:
-                    file_['input'] = True
-                    files.append(file_)
-
-            self.update_el(analysis['_id'], {'job': job.id_, 'files': files})
+            self.update_el(analysis['_id'], {'job': job.id_})
 
         analysis['job'] = job
         return analysis


### PR DESCRIPTION
If a job fails and is respawned, an analysis will attempt to update the job id to the most recently spawned job. If that update is required, old code would also update the analysis's input files to match the new job's inputs. Code prevents a change in inputs from one job attempt to the next, so this is unnecessary. It was causing issues in situations where inputs did not exist for a job, so it easier to just remove it. 


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
