### PR TITLE
Revise delete permissions

### DIFF
--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -3,6 +3,8 @@ Purpose of this module is to define all the permissions checker decorators for t
 """
 
 from . import _get_access, INTEGER_PERMISSIONS
+from ..web.errors import APIPermissionException
+from .. import config
 
 
 def default_container(handler, container=None, target_parent_container=None):
@@ -35,8 +37,9 @@ def default_container(handler, container=None, target_parent_container=None):
                 user_perms = _get_access(handler.uid, container)
                 has_access = user_perms >= INTEGER_PERMISSIONS[required_perm]
 
-                if not has_access and has_original_data and user_perms == INTEGER_PERMISSIONS['rw']:
+                if not has_access and container.get('has_original_data', False) and user_perms == INTEGER_PERMISSIONS['rw']:
                     # The user was not granted access because the container had original data
+
                     errors = {'reason': 'original_data_present'}
                 else:
                     errors = {'reason': 'permission_denied'}

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -26,9 +26,12 @@ def default_container(handler, container=None, target_parent_container=None):
                     required_perm = 'admin'
                 has_access = _get_access(handler.uid, target_parent_container) >= INTEGER_PERMISSIONS[required_perm]
             elif method == 'DELETE':
-                # Container deletion always requires admin
-                required_perm = 'admin'
-                has_access = _get_access(handler.uid, target_parent_container) >= INTEGER_PERMISSIONS[required_perm]
+                # Project delete requires admin, others require rw
+                if container['cont_name'] == 'project' or container.get('has_original_data', False):
+                    required_perm = 'admin'
+                else:
+                    required_perm = 'rw'
+                has_access = _get_access(handler.uid, container) >= INTEGER_PERMISSIONS[required_perm]
             elif method == 'PUT' and target_parent_container is not None:
                 has_access = (
                     _get_access(handler.uid, container) >= INTEGER_PERMISSIONS['admin'] and

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -4,7 +4,6 @@ Purpose of this module is to define all the permissions checker decorators for t
 
 from . import _get_access, INTEGER_PERMISSIONS
 from ..web.errors import APIPermissionException
-from .. import config
 
 
 def default_container(handler, container=None, target_parent_container=None):
@@ -39,7 +38,6 @@ def default_container(handler, container=None, target_parent_container=None):
 
                 if not has_access and container.get('has_original_data', False) and user_perms == INTEGER_PERMISSIONS['rw']:
                     # The user was not granted access because the container had original data
-
                     errors = {'reason': 'original_data_present'}
                 else:
                     errors = {'reason': 'permission_denied'}

--- a/api/auth/listauth.py
+++ b/api/auth/listauth.py
@@ -47,9 +47,8 @@ def files_sublist(handler, container):
     def g(exec_op):
         def f(method, _id, query_params=None, payload=None, exclude_params=None):
             errors = None
-            if method == 'GET' and container.get('public', False):
-                min_access = -1
-            elif method == 'GET':
+            min_access = sys.maxint
+            if method == 'GET':
                 min_access = INTEGER_PERMISSIONS['ro']
             elif method in ['POST', 'PUT']:
                 min_access = INTEGER_PERMISSIONS['rw']
@@ -66,10 +65,6 @@ def files_sublist(handler, container):
                 else:
                     errors = {'reason': 'permission_denied'}
 
-            else:
-                min_access = sys.maxint
-
-            log.warning('the user access is {} and the min access is {}'.format(access, min_access))
 
             if access >= min_access:
                 return exec_op(method, _id, query_params, payload, exclude_params)

--- a/api/auth/listauth.py
+++ b/api/auth/listauth.py
@@ -6,6 +6,7 @@ Purpose of this module is to define all the permissions checker decorators for t
 import sys
 
 from .. import config
+from ..types import Origin
 from . import _get_access, INTEGER_PERMISSIONS
 
 log = config.log
@@ -26,6 +27,34 @@ def default_sublist(handler, container):
                 min_access = INTEGER_PERMISSIONS['ro']
             elif method in ['POST', 'PUT', 'DELETE']:
                 min_access = INTEGER_PERMISSIONS['rw']
+            else:
+                min_access = sys.maxint
+
+            if access >= min_access:
+                return exec_op(method, _id, query_params, payload, exclude_params)
+            else:
+                handler.abort(403, 'user not authorized to perform a {} operation on the list'.format(method))
+        return f
+    return g
+
+def files_sublist(handler, container):
+    """
+    Files have slightly modified permissions centered around origin.
+    Admin is required to remove files with an origin type other than engine or user.
+    """
+    access = _get_access(handler.uid, container)
+    def g(exec_op):
+        def f(method, _id, query_params=None, payload=None, exclude_params=None):
+            if method == 'GET' and container.get('public', False):
+                min_access = -1
+            elif method == 'GET':
+                min_access = INTEGER_PERMISSIONS['ro']
+            elif method in ['POST', 'PUT']:
+                min_access = INTEGER_PERMISSIONS['rw']
+            elif method =='DELETE':
+                min_access = INTEGER_PERMISSIONS['admin']
+                if container.get('origin',{}).get('type') in [str(Origin.user), str(Origin.job)]:
+                    min_access = INTEGER_PERMISSIONS['rw']
             else:
                 min_access = sys.maxint
 

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -3,6 +3,7 @@ import copy
 
 from .. import config
 from ..auth import has_access
+from ..types import Origin
 
 from ..web.errors import APINotFoundException, APIPermissionException
 
@@ -161,6 +162,24 @@ def get_referring_analyses(cont_name, cont_id, filename=None):
     analysis_ids = [bson.ObjectId(job['destination']['id']) for job in jobs]
     analyses = config.db.analyses.find({'_id': {'$in': analysis_ids}, 'deleted': {'$exists': False}})
     return list(analyses)
+
+
+def container_has_original_data(container, child_cont_name=None):
+    """
+    Given a container, creates a list of all origin types
+    for all files in the container and it's children, if provided.
+    If the set only includes user and job uploaded files, the container
+    is not considered to have "original data".
+    """
+    origin_types = set()
+
+    for f in container.get('files', []):
+        origin_types.add(f['origin']['type'])
+    if child_cont_name:
+        for c in container.get(child_cont_name, []):
+            for f in c.get('files', []):
+                origin_types.add(f['origin']['type'])
+    return origin_types.issubset(set(str(Origin.user, Origin.job)))
 
 
 class ContainerReference(object):

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -171,15 +171,16 @@ def container_has_original_data(container, child_cont_name=None):
     If the set only includes user and job uploaded files, the container
     is not considered to have "original data".
     """
-    origin_types = set()
 
     for f in container.get('files', []):
-        origin_types.add(f['origin']['type'])
+        if f['origin']['type'] not in [str(Origin.user), str(Origin.job)]:
+            return True
     if child_cont_name:
         for c in container.get(child_cont_name, []):
             for f in c.get('files', []):
-                origin_types.add(f['origin']['type'])
-    return origin_types.issubset(set(str(Origin.user, Origin.job)))
+                if f['origin']['type'] not in [str(Origin.user), str(Origin.job)]:
+                    return True
+    return False
 
 
 class ContainerReference(object):

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -531,14 +531,11 @@ class ContainerHandler(base.RequestHandler):
         _id = kwargs.pop('cid')
         self.config = self.container_handler_configurations[cont_name]
         self.storage = self.config['storage']
-        container = self._get_container(_id)
-        if self.config.get('children_cont'):
-            container['has_children'] = bool(self.storage.get_children(_id))
-        else:
-            container['has_children'] = False
-        if container.get('files') or container.get('analyses'):
-            container['has_children'] = True
+        container = self._get_container(_id, get_children=True)
+        container['cont_name'] = containerutil.singularize(cont_name)
 
+        if cont_name in ['sessions', 'acquisitions']:
+            container['has_original_data'] = containerutil.container_origin_types(container, child_cont_name=self.config.get('children_cont'))
         if cont_name == 'acquisitions':
             analyses = containerutil.get_referring_analyses(cont_name, _id)
             if analyses:

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -13,7 +13,7 @@ from ..jobs.jobs import Job
 from ..jobs.queue import Queue
 from ..types import Origin
 from ..web import base
-from ..web.errors import APIStorageException
+from ..web.errors import APIStorageException, APIPermissionException
 from ..web.request import log_access, AccessType
 
 log = config.log
@@ -531,20 +531,29 @@ class ContainerHandler(base.RequestHandler):
         _id = kwargs.pop('cid')
         self.config = self.container_handler_configurations[cont_name]
         self.storage = self.config['storage']
-        container = self._get_container(_id, get_children=True)
+
+        if cont_name != 'acquisitions':
+            get_children = True
+        else:
+            get_children = False
+        container = self._get_container(_id, get_children=get_children)
         container['cont_name'] = containerutil.singularize(cont_name)
 
         if cont_name in ['sessions', 'acquisitions']:
-            container['has_original_data'] = containerutil.container_origin_types(container, child_cont_name=self.config.get('children_cont'))
+            container['has_original_data'] = containerutil.container_has_original_data(container, child_cont_name=self.config.get('children_cont'))
         if cont_name == 'acquisitions':
             analyses = containerutil.get_referring_analyses(cont_name, _id)
             if analyses:
                 analysis_ids = [str(a['_id']) for a in analyses]
-                self.abort(400, 'Cannot delete acquisition {} referenced by analyses {}'.format(_id, analysis_ids))
+                errors = {'reason': 'analysis_conflict'}
+                raise APIPermissionException('Cannot delete acquisition {} referenced by analyses {}'.format(_id, analysis_ids), errors=errors)
 
         target_parent_container, _ = self._get_parent_container(container)
         permchecker = self._get_permchecker(container, target_parent_container)
         permchecker(noop)('DELETE', _id)
+        if self.is_true('check'):
+            # User only wanted to check permissions, respond with 200
+            return
 
         try:
             # This line exec the actual delete checking permissions using the decorator permchecker

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -544,9 +544,11 @@ class ContainerHandler(base.RequestHandler):
 
         target_parent_container, _ = self._get_parent_container(container)
         permchecker = self._get_permchecker(container, target_parent_container)
+        permchecker(noop)('DELETE', _id)
+
         try:
             # This line exec the actual delete checking permissions using the decorator permchecker
-            result = permchecker(self.storage.exec_op)('DELETE', _id)
+            result = self.storage.exec_op('DELETE', _id)
         except APIStorageException as e:
             self.abort(400, e.message)
         if result.modified_count == 1:

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -3,7 +3,7 @@ import datetime
 from ..web import base
 from .. import util
 from .. import validators
-from ..auth import groupauth
+from ..auth import groupauth, require_admin
 from ..dao import containerstorage
 from .containerhandler import ContainerHandler
 
@@ -24,6 +24,7 @@ class GroupHandler(base.RequestHandler):
             ContainerHandler.join_user_info([result])
         return result
 
+    @require_admin
     def delete(self, _id):
         if _id == 'unknown':
             self.abort(400, 'The group "unknown" can\'t be deleted as it is integral within the API')

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -38,7 +38,7 @@ def initialize_list_configurations():
         },
         'files': {
             'storage': liststorage.FileStorage,
-            'permchecker': listauth.default_sublist,
+            'permchecker': listauth.files_sublist,
             'use_object_id': True,
             'storage_schema_file': 'file.json',
             'input_schema_file': 'file.json'
@@ -380,44 +380,6 @@ class FileListHandler(ListHandler):
             return info
 
     def get(self, cont_name, list_name, **kwargs):
-        """
-        .. http:get:: /api/(cont_name)/(cid)/files/(file_name)
-
-            Gets the ticket used to download the file when the ticket is not provided.
-
-            Downloads the file when the ticket is provided.
-
-            :query ticket: should be empty
-
-            :param cont_name: one of ``projects``, ``sessions``, ``acquisitions``, ``collections``
-            :type cont_name: string
-
-            :param cid: Container ID
-            :type cid: string
-
-            :statuscode 200: no error
-            :statuscode 400: explain...
-            :statuscode 409: explain...
-
-            **Example request**:
-
-            .. sourcecode:: http
-
-                GET /api/acquisitions/57081d06b386a6dc79ca383c/files/fMRI%20Loc%20Word%20Face%20Obj.zip?ticket= HTTP/1.1
-                Host: demo.flywheel.io
-                Accept: */*
-
-
-            **Example response**:
-
-            .. sourcecode:: http
-
-                HTTP/1.1 200 OK
-                Vary: Accept-Encoding
-                Content-Type: application/json; charset=utf-8
-                {"ticket": "1e975e3d-21e9-41f4-bb97-261f03d35ba1"}
-
-        """
         _id = kwargs.pop('cid')
         permchecker, storage, _, _, keycheck = self._initialize_request(cont_name, list_name, _id)
         list_name = storage.list_name

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -345,6 +345,7 @@ class RequestHandler(webapp2.RequestHandler):
         elif isinstance(exception, errors.APIConsistencyException):
             code = 400
         elif isinstance(exception, errors.APIPermissionException):
+            custom_errors = exception.errors
             code = 403
         elif isinstance(exception, errors.APINotFoundException):
             code = 404

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -15,7 +15,10 @@ class APINotFoundException(Exception):
     pass
 
 class APIPermissionException(Exception):
-    pass
+    def __init__(self, msg, errors=None):
+
+        super(APIPermissionException, self).__init__(msg)
+        self.errors = errors
 
 class APIRefreshTokenException(Exception):
     # Specifically alert a client when the user's refresh token expires

--- a/swagger/paths/acquisitions.yaml
+++ b/swagger/paths/acquisitions.yaml
@@ -14,6 +14,8 @@ $template_arguments:
   arguments:
     update-input-schema: schemas/input/acquisition-update.json
     get-output-schema: schemas/output/acquisition.json
+    delete-description: Read-write project permissions are required to delete an acquisition. </br>Admin project permissions are required if the acquisition contains data uploaded by sources other than users and jobs.
+
 
 # ===== Tags =====
 /acquisitions/{AcquisitionId}/tags:

--- a/swagger/paths/projects.yaml
+++ b/swagger/paths/projects.yaml
@@ -14,6 +14,7 @@ $template_arguments:
   arguments:
     update-input-schema: schemas/input/project-update.json
     get-output-schema: schemas/output/project.json
+    delete-description: Only site admins and users with "admin" project permissions may delete a project
 
 /projects/groups:
   get:
@@ -112,8 +113,8 @@ $template_arguments:
       - in: body
         name: body
         schema:
-          $ref: schemas/input/rule-update.json        
-        
+          $ref: schemas/input/rule-update.json
+
 
 '/projects/{ProjectId}/template':
   parameters:

--- a/swagger/paths/sessions.yaml
+++ b/swagger/paths/sessions.yaml
@@ -14,8 +14,9 @@ $template_arguments:
   arguments:
     update-input-schema: schemas/input/session.json
     get-output-schema: schemas/output/session.json
+    delete-description: Read-write project permissions are required to delete a session. </br>Admin project permissions are required if the session or it's acquisitions contain data uploaded by sources other than users and jobs.
 
-'/sessions/{SessionId}/jobs':
+/sessions/{SessionId}/jobs:
   parameters:
     - in: path
       type: string
@@ -104,7 +105,7 @@ $template_arguments:
     parameters:
       - in: body
         name: body
-        schema: 
+        schema:
           $ref: schemas/input/analysis-job.json
       - in: query
         type: boolean

--- a/swagger/templates/container-item.yaml
+++ b/swagger/templates/container-item.yaml
@@ -9,6 +9,8 @@ parameters:
     type: string
   - name: get-output-schema
     type: string
+  - name: delete-description
+    type: string
 template: |
   parameters:
     - in: path
@@ -43,6 +45,9 @@ template: |
   delete:
     summary: Delete a {{resource}}
     operationId: delete_{{resource}}
+    {{#delete-description}}
+    description: {{{.}}}
+    {{/delete-description}}
     tags:
       - '{{tag}}'
     responses:

--- a/swagger/templates/file-item.yaml
+++ b/swagger/templates/file-item.yaml
@@ -35,7 +35,7 @@ template: |
       - name: ticket
         in: query
         type: string
-        description: The generated ticket id for the download, or present but empty to generate a ticket id.
+        description: The generated ticket id for the download, or present but empty to generate a ticket id
       - name: view
         in: query
         type: boolean
@@ -69,4 +69,18 @@ template: |
     responses:
       default:
         description: ''
+  delete:
+    summary: Delete a file
+    description: |
+      A user with read-write or higher permissions on the container may delete files
+      that were uploaded by users or were the output of jobs. (Specifically, files
+      whose `origin.type` is either `job` or `user`.)
+      <br/>
+      A user with admin permissions on the container may delete any file.
+    operationId: delete_{{resource}}_file
+    tags:
+      - '{{tag}}'
+    responses:
+      '200':
+        $ref: '#/responses/200:deleted-with-count'
 

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -1235,7 +1235,8 @@ def test_fields_list_requests(data_builder, file_form, as_admin):
     assert not a['files'][0].get('info')
 
 
-def test_container_delete_tag(data_builder, default_payload, as_root, as_admin, as_user, file_form, api_db):
+
+def test_container_delete_tag(data_builder, default_payload, as_root, as_admin, as_user, as_drone, file_form, api_db):
     gear_doc = default_payload['gear']['gear']
     gear_doc['inputs'] = {'csv': {'base': 'file'}}
     gear = data_builder.create_gear(gear=gear_doc)
@@ -1245,15 +1246,8 @@ def test_container_delete_tag(data_builder, default_payload, as_root, as_admin, 
     acquisition = data_builder.create_acquisition()
     collection = data_builder.create_collection()
     assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.csv')).ok
-    r = as_admin.post('/sessions/' + session + '/analyses', params={'job': 'true'}, json={
-        'analysis': {'label': 'with-job'},
-        'job': {
-            'gear_id': gear,
-            'inputs': {'csv': {'type': 'acquisition', 'id': acquisition, 'name': 'test.csv'}}
-        }
-    })
-    assert r.ok
-    analysis = r.json()['_id']
+    assert as_drone.post('/acquisitions/' + acquisition + '/files', files=file_form('test2.csv')).ok
+
     r = as_admin.put('/collections/' + collection, json={
         'contents': {'operation': 'add', 'nodes': [{'level': 'session', '_id': session}]}
     })
@@ -1263,13 +1257,62 @@ def test_container_delete_tag(data_builder, default_payload, as_root, as_admin, 
     r = as_root.delete('/groups/' + group)
     assert r.status_code == 400
 
+    # try to delete project without perms
+    r = as_user.delete('/projects/' + project)
+    assert r.status_code == 403
+    assert r.json()['reason'] == 'permission_denied'
+
+    # try to delete session without perms
+    r = as_user.delete('/sessions/' + session)
+    assert r.status_code == 403
+    assert r.json()['reason'] == 'permission_denied'
+
+    # try to delete acquisition with perms
+    r = as_user.delete('/acquisitions/' + acquisition)
+    assert r.status_code == 403
+    assert r.json()['reason'] == 'permission_denied'
+
+    # Add user as rw
+    r = as_user.get('/users/self')
+    assert r.ok
+    uid = r.json()['_id']
+
+    r = as_admin.post('/projects/' + project + '/permissions', json={
+        '_id': uid,
+        'access': 'rw'
+    })
+    assert r.ok
+
     # try to delete project without admin perms
     r = as_user.delete('/projects/' + project)
     assert r.status_code == 403
+    assert r.json()['reason'] == 'permission_denied'
+
+    # try to delete a session with "original data" without admin perms
+    r = as_user.delete('/sessions/' + session)
+    assert r.status_code == 403
+    assert r.json()['reason'] == 'original_data_present'
+
+    # try to delete an acquisition with "original data" without admin perms
+    r = as_user.delete('/acquisitions/' + acquisition)
+    assert r.status_code == 403
+    assert r.json()['reason'] == 'original_data_present'
+
+    # Add session level analysis
+    r = as_admin.post('/sessions/' + session + '/analyses', params={'job': 'true'}, json={
+        'analysis': {'label': 'with-job'},
+        'job': {
+            'gear_id': gear,
+            'inputs': {'csv': {'type': 'acquisition', 'id': acquisition, 'name': 'test.csv'}}
+        }
+    })
+    assert r.ok
+    analysis = r.json()['_id']
 
     # try to delete acquisition referenced by analysis
     r = as_admin.delete('/acquisitions/' + acquisition)
     assert r.status_code == 403
+    assert r.json()['reason'] == 'analysis_conflict'
 
     # try to delete acquisition file referenced by analysis
     r = as_admin.delete('/acquisitions/' + acquisition + '/files/test.csv')

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -1269,7 +1269,7 @@ def test_container_delete_tag(data_builder, default_payload, as_root, as_admin, 
 
     # try to delete acquisition referenced by analysis
     r = as_admin.delete('/acquisitions/' + acquisition)
-    assert r.status_code == 400
+    assert r.status_code == 403
 
     # try to delete acquisition file referenced by analysis
     r = as_admin.delete('/acquisitions/' + acquisition + '/files/test.csv')


### PR DESCRIPTION
Changes/things made clear in this PR:

*Note:* all permissions mentioned are those set at the project level

Project deletion:
  - users with `admin` can delete the project even if it has data (original or not)
  - other users cannot delete a project (even if it is empty)

Session/Acquisition deletion:
  - users with `rw` can delete a session or acquisition if it is empty or only contains data uploaded by a job or user (not necessarily themselves)
  - users with `admin` can delete a session or acquisition in any situation
  - if an acquisition's file was used as input for an analysis, the acquisition cannot be delete by anyone without deleting the analysis first

Individual File deletion:
  - users with `rw` can delete a file if it was uploaded by any user or a job
  - users with `admin` can delete a file in any situation

A new query param is offered on container `DELETE` endpoints: `check=true/false`
  - If a client would like to check user permissions before performing an action, they can pass the query param `check=true` (default `false`) to only preform a perm check - returning the expected 403/404 failure if the action would not be allowed or 200 with no response body if the action would be allowed

List of permission failure variants:

If the container has "original data" (data not uploaded by a user or job), the API will respond with `'original_data_present'` in the `reason` key:
```
DELETE api/container_name/container_id?check=true
{
  "status_code": 403,
  "message": "user not authorized to perform a DELETE operation on the container.",
  "reason": "original_data_present",
  "request_id": "fdbe14e5-1520003841"
}
```
If deleting this container would cause an analysis' input file to be removed without removing the analysis, the API will respond with `'analysis_conflict'` in the `reason` key:
```
DELETE api/container_name/container_id?check=true

{
  "status_code": 403,
  "message": "Cannot delete acquisition 5a908946123ade00147d00cb referenced by analyses ['5a996cf3cea75600b4f7fba3']",
  "reason": "analysis_conflict",
  "request_id": "8650511c-1520004700"
}
```

All other permission conflicts (`403`) will have `'{'reason': 'permission_denied'}` or will be a different error (`404`/`400`, etc)

Tests will be added after above proposal is agreed upon.
