### PR TITLE
Swagger changes for code generation

### DIFF
--- a/swagger/Gruntfile.js
+++ b/swagger/Gruntfile.js
@@ -86,6 +86,16 @@ module.exports = function(grunt) {
 		},
 
 		/**
+		 * Simplify swagger for codegen
+		 */
+		simplifySwagger: {
+			core: {
+				src: 'build/swagger-ui.json',
+				dst: 'build/swagger-codegen.json'
+			}
+		},
+
+		/**
 		 * Validate swagger
 		 */
 		validateSwagger: {
@@ -152,7 +162,8 @@ module.exports = function(grunt) {
 		'createBuildDir',
 		'flattenSwagger',
 		'schemasToDefs',
-		'validateSwagger'
+		'validateSwagger',
+		'simplifySwagger'
 	]);
 
 	/**

--- a/swagger/paths/collections.yaml
+++ b/swagger/paths/collections.yaml
@@ -20,12 +20,13 @@ $template_arguments:
             $ref: examples/output/collection-list.json
   post:
     summary: Create a collection
-    operationId: create_collection
+    operationId: add_collection
     tags: 
     - collections
     parameters:
-      - in: body
-        name: body
+      - name: body
+        in: body
+        required: true
         schema:
           $ref: schemas/input/collection.json
     responses:
@@ -79,8 +80,9 @@ $template_arguments:
     tags: 
     - collections
     parameters:
-      - in: body
-        name: body
+      - name: body
+        in: body
+        required: true
         schema:
           $ref: schemas/input/collection-update.json
     responses:

--- a/swagger/paths/dataexplorer.yaml
+++ b/swagger/paths/dataexplorer.yaml
@@ -6,9 +6,11 @@
       - name: simple
         in: query
         type: boolean
+        x-sdk-default: 'true'
       - name: limit
         in: query
         type: integer
+        x-sdk-default: 100
       - name: body
         in: body
         required: true

--- a/swagger/paths/groups.yaml
+++ b/swagger/paths/groups.yaml
@@ -25,6 +25,7 @@ $template_arguments:
     parameters:
       - name: body
         in: body 
+        required: true
         schema:
           $ref: schemas/input/group-new.json
     responses:
@@ -34,6 +35,7 @@ $template_arguments:
           $ref: schemas/output/group-new.json
       '400':
         $ref: '#/responses/400:invalid-body-json'
+        
 /groups/{GroupId}:
   parameters:
     - required: true
@@ -61,6 +63,7 @@ $template_arguments:
     parameters:
       - in: body
         name: body
+        required: true
         schema:
           $ref: schemas/input/group-update.json
     responses:

--- a/swagger/paths/login.yaml
+++ b/swagger/paths/login.yaml
@@ -7,8 +7,7 @@
       '200':
         description: ''
         schema:
-          example:
-            success: true
+          $ref: schemas/output/login-output.json
 /logout:
   post:
     summary: Log Out
@@ -18,5 +17,4 @@
       '200':
         description: ''
         schema:
-          example:
-            auth_tokens_removed: 2
+          $ref: schemas/output/logout-output.json

--- a/swagger/paths/users.yaml
+++ b/swagger/paths/users.yaml
@@ -17,6 +17,7 @@
     parameters:
       - name: body
         in: body
+        required: true
         schema:
           $ref: schemas/input/user-new.json
     responses:
@@ -79,6 +80,7 @@
     parameters:
       - name: body
         in: body
+        required: true
         schema: 
           $ref: schemas/input/user-update.json
         description: >

--- a/swagger/schemas/definitions/acquisition.json
+++ b/swagger/schemas/definitions/acquisition.json
@@ -2,17 +2,18 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions":{
         "acquisition-input":{
-            "type": "object",
-            "properties": {
-                "public":       {"$ref":"container.json#/definitions/public"},
-                "label":        {"$ref":"common.json#/definitions/label"},
-                "info":         {"$ref":"container.json#/definitions/info"},
-                "session":      {"$ref":"common.json#/definitions/objectid"},
-                "uid":          {"$ref":"container.json#/definitions/uid"},
-                "timestamp":    {"$ref":"container.json#/definitions/timestamp"},
-                "timezone":     {"$ref":"container.json#/definitions/timezone"}
-            },
-            "additionalProperties":false
+          "type": "object",
+          "properties": {
+              "public":       {"$ref":"container.json#/definitions/public"},
+              "label":        {"$ref":"common.json#/definitions/label"},
+              "info":         {"$ref":"container.json#/definitions/info"},
+              "session":      {"$ref":"common.json#/definitions/objectid"},
+              "uid":          {"$ref":"container.json#/definitions/uid"},
+              "timestamp":    {"$ref":"container.json#/definitions/timestamp"},
+              "timezone":     {"$ref":"container.json#/definitions/timezone"}
+          },
+          "additionalProperties":false,
+          "x-sdk-model": "acquisition"
         },
         "acquisition-metadata-input": {
             "type": "object",
@@ -55,7 +56,7 @@
               "timezone":     {"$ref":"container.json#/definitions/timezone"},
               "created":      {"$ref":"created-modified.json#/definitions/created"},
               "modified":     {"$ref":"created-modified.json#/definitions/modified"},
-              "info_exists":  {"type": "boolean", "default": false},
+              "info_exists":  {"type": "boolean"},
               "permissions":{
                   "type":"array",
                   "items":{"$ref":"permission.json#/definitions/permission-output-default-required"}
@@ -67,7 +68,8 @@
                   "items":{"$ref":"analysis.json#/definitions/analysis-output"}
               }
           },
-          "additionalProperties":false
+          "additionalProperties":false,
+          "x-sdk-model": "acquisition"
         }
     }
 }

--- a/swagger/schemas/definitions/acquisition.json
+++ b/swagger/schemas/definitions/acquisition.json
@@ -55,7 +55,7 @@
               "timezone":     {"$ref":"container.json#/definitions/timezone"},
               "created":      {"$ref":"created-modified.json#/definitions/created"},
               "modified":     {"$ref":"created-modified.json#/definitions/modified"},
-              "info_exists":  {"type": "boolean"},
+              "info_exists":  {"type": "boolean", "default": false},
               "permissions":{
                   "type":"array",
                   "items":{"$ref":"permission.json#/definitions/permission-output-default-required"}

--- a/swagger/schemas/definitions/analysis.json
+++ b/swagger/schemas/definitions/analysis.json
@@ -85,7 +85,7 @@
 				"_id":{"$ref":"common.json#/definitions/objectid"},
 				"files":{
 					"type":"array",
-					"items":{"$ref":"file.json#/definitions/file"}
+					"items":{"$ref":"file.json#/definitions/file-entry"}
 				},
 				"job":         {"$ref":"common.json#/definitions/objectid"},
 				"notes":       {"$ref":"note.json#/definitions/notes-list-output"},

--- a/swagger/schemas/definitions/analysis.json
+++ b/swagger/schemas/definitions/analysis.json
@@ -63,7 +63,7 @@
 				},
 				"files":{
 					"type":"array",
-					"items": {"$ref":"file.json#/definitions/file"}
+					"items":{"$ref":"file.json#/definitions/file-entry"}
 				},
 				"job":{
 					"oneOf":[

--- a/swagger/schemas/definitions/analysis.json
+++ b/swagger/schemas/definitions/analysis.json
@@ -12,7 +12,8 @@
 				"description": {"$ref":"common.json#/definitions/description"},
 				"label":       {"$ref":"common.json#/definitions/label"}
 			},
-		    "additionalProperties": false
+		    "additionalProperties": false,
+		    "x-sdk-model": "analysis-input"
 		},
 		"analysis-input-job":{
 			"type":"object",
@@ -22,7 +23,8 @@
 				"description": {"$ref":"common.json#/definitions/description"},
 				"label":       {"$ref":"common.json#/definitions/label"}
 			},
-		    "additionalProperties": false
+		    "additionalProperties": false,
+		    "x-sdk-model": "analysis-input"
 		},
 		"analysis-input-legacy":{
 			"type":"object",
@@ -41,11 +43,14 @@
 			},
 		    "additionalProperties": false
 		},
-		"analysis-input": {"anyOf": [
-			{"$ref":"#/definitions/analysis-input-adhoc"},
-			{"$ref":"#/definitions/analysis-input-job"},
-			{"$ref":"#/definitions/analysis-input-legacy"}
-		]},
+		"analysis-input-any": {
+			"anyOf": [
+				{"$ref":"#/definitions/analysis-input-adhoc"},
+				{"$ref":"#/definitions/analysis-input-job"},
+				{"$ref":"#/definitions/analysis-input-legacy"}
+			],
+			"x-sdk-schema": {"$ref":"#/definitions/analysis-input-adhoc"}
+		},
 		"analysis-update":{
 			"type":"object",
 			"properties":{
@@ -59,7 +64,7 @@
 				"_id":{"$ref":"common.json#/definitions/objectid"},
 				"inputs":{
 					"type":"array",
-					"items": {"$ref":"file.json#/definitions/file"}
+					"items": {"$ref":"file.json#/definitions/file-entry"}
 				},
 				"files":{
 					"type":"array",
@@ -80,12 +85,16 @@
 				"created":     {"$ref":"created-modified.json#/definitions/created"},
 				"modified":    {"$ref":"created-modified.json#/definitions/modified"}
 			},
-			"required":["_id", "files", "label", "created", "modified"]
+			"required":["_id", "label", "created", "modified"]
 		},
 		"analysis-list-entry":{
 			"type":"object",
 			"properties":{
 				"_id":{"$ref":"common.json#/definitions/objectid"},
+				"inputs":{
+					"type":"array",
+					"items": {"$ref":"file.json#/definitions/file-entry"}
+				},
 				"files":{
 					"type":"array",
 					"items":{"$ref":"file.json#/definitions/file-entry"}
@@ -97,22 +106,8 @@
 				"created":     {"$ref":"created-modified.json#/definitions/created"},
 				"modified":    {"$ref":"created-modified.json#/definitions/modified"}
 			},
-			"required":["_id", "files", "label", "created", "modified"]
+			"required":["_id", "label", "created", "modified"]
 		},		
-		"analysis-job": {
-			"type": "object",
-			"properties":{
-				"analysis":{
-					"type":"object",
-					"allOf":[{"$ref":"#/definitions/analysis-input"}],
-					"required":["label"]
-				},
-				"job":{
-					"type":"object",
-					"allOf":[{"$ref":"job.json#/definitions/job-input"}]
-				}
-			}
-		},
 		"analysis-files-create-ticket-output": {
 			"type":"object",
 			"properties":{

--- a/swagger/schemas/definitions/analysis.json
+++ b/swagger/schemas/definitions/analysis.json
@@ -69,7 +69,10 @@
 					"oneOf":[
 						{"$ref":"common.json#/definitions/objectid"},
 						{"$ref": "job.json#/definitions/job-output"}
-					]
+					],
+					"x-sdk-schema": { 
+						"$ref": "job.json#/definitions/job-output"
+					}
 				},
 				"notes":       {"$ref":"note.json#/definitions/notes-list-output"},
 				"description": {"$ref":"common.json#/definitions/description"},

--- a/swagger/schemas/definitions/auth.json
+++ b/swagger/schemas/definitions/auth.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  	"login-output": {
+  		"type": "object",
+  		"properties": {
+  			"token": {"type": "string"}
+  		},
+  		"required": ["token"]
+  	},
+  	"logout-output": {
+  		"type": "object",
+  		"properties": {
+  			"tokens_removed": {"type": "integer"}
+  		},
+  		"required": ["tokens_removed"]
+  	}
+  }
+}

--- a/swagger/schemas/definitions/batch.json
+++ b/swagger/schemas/definitions/batch.json
@@ -8,7 +8,7 @@
     "batch-proposal-detail": {
       "type": "object",
       "properties": {
-        "analysis": {"$ref": "analysis.json#/definitions/analysis-input"},
+        "analysis": {"$ref": "analysis.json#/definitions/analysis-input-job"},
         "tags": {"$ref":"tag.json#/definitions/tag-list"}
       },
       "additionalProperties": false
@@ -60,7 +60,7 @@
         "gear_id": {"$ref":"job.json#/definitions/gear_id"},
         "config": {"$ref":"job.json#/definitions/config"},
         "tags": {"$ref":"tag.json#/definitions/tag-list"},
-        "analysis": {"$ref": "analysis.json#/definitions/analysis-input"},
+        "analysis": {"$ref": "analysis.json#/definitions/analysis-input-job"},
         "targets": {
           "type": "array",
           "items": {"$ref":"container.json#/definitions/container-reference"}

--- a/swagger/schemas/definitions/collection.json
+++ b/swagger/schemas/definitions/collection.json
@@ -34,6 +34,7 @@
                 "info":         {"$ref": "container.json#/definitions/info"},
                 "description":  {"$ref": "common.json#/definitions/description"}
             },
+            "x-sdk-model": "collection",
             "additionalProperties": false
         },
         "collection-input-with-contents":{
@@ -45,6 +46,7 @@
                 "description":  {"$ref": "common.json#/definitions/description"},
                 "contents":     {"$ref": "#/definitions/collection-operation"}
             },
+            "x-sdk-model": "collection",
             "additionalProperties": false
         },
         "collection-new-output": {
@@ -82,6 +84,7 @@
                     "items":{"$ref":"analysis.json#/definitions/analysis-output"}
                 }
             },
+            "x-sdk-model": "collection",
             "additionalProperties":false
         }
     }

--- a/swagger/schemas/definitions/collection.json
+++ b/swagger/schemas/definitions/collection.json
@@ -27,7 +27,8 @@
           "properties": {
             "_id": {"$ref":"common.json#/definitions/objectid"}
           },
-          "required": ["_id"]
+          "required": ["_id"],
+          "x-sdk-return": "_id"
         },
         "collection-output":{
             "type": "object",

--- a/swagger/schemas/definitions/collection.json
+++ b/swagger/schemas/definitions/collection.json
@@ -1,6 +1,31 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions":{
+        "collection-node": {
+            "type": "object",
+            "properties": {
+                "level": { 
+                    "type": "string", 
+                    "enum": ["project", "session", "acquisition"]
+                },
+                "_id": { "$ref": "common.json#/definitions/objectid" }
+            },
+            "additionalProperties": false
+        },
+        "collection-operation": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["add", "remove"]
+                },
+                "nodes": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/collection-node" }
+                }
+            },
+            "additionalProperties": false
+        },
         "collection-input":{
             "type": "object",
             "properties": {
@@ -18,7 +43,7 @@
                 "label":        {"$ref": "common.json#/definitions/label"},
                 "info":         {"$ref": "container.json#/definitions/info"},
                 "description":  {"$ref": "common.json#/definitions/description"},
-                "contents":     { "type": "object" }
+                "contents":     {"$ref": "#/definitions/collection-operation"}
             },
             "additionalProperties": false
         },

--- a/swagger/schemas/definitions/common.json
+++ b/swagger/schemas/definitions/common.json
@@ -52,7 +52,8 @@
                 "_id": {
                     "type": "string"
                 }
-            }
+            },
+            "x-sdk-return": "_id"
         }
     }
 }

--- a/swagger/schemas/definitions/container.json
+++ b/swagger/schemas/definitions/container.json
@@ -4,7 +4,7 @@
         "_id":          {"type": "string"},
         "public":       {"type": "boolean"},
         "info":         {"$ref": "common.json#/definitions/info"},
-        "info_exists":  {"type": "boolean"},
+        "info_exists":  {"type": "boolean", "default": false},
         "uid":          {"type": "string"},
         "timestamp":    {"type": ["string", "null"], "format": "date-time"},
         "timezone":     {"type": "string"},

--- a/swagger/schemas/definitions/container.json
+++ b/swagger/schemas/definitions/container.json
@@ -19,7 +19,8 @@
           "properties": {
             "_id": {"$ref":"#/definitions/_id"}
           },
-          "required": ["_id"]
+          "required": ["_id"],
+          "x-sdk-return": "_id"
         },
         "container-reference": {
           "type": "object",

--- a/swagger/schemas/definitions/container.json
+++ b/swagger/schemas/definitions/container.json
@@ -4,7 +4,7 @@
         "_id":          {"type": "string"},
         "public":       {"type": "boolean"},
         "info":         {"$ref": "common.json#/definitions/info"},
-        "info_exists":  {"type": "boolean", "default": false},
+        "info_exists":  {"type": "boolean"},
         "uid":          {"type": "string"},
         "timestamp":    {"type": ["string", "null"], "format": "date-time"},
         "timezone":     {"type": "string"},

--- a/swagger/schemas/definitions/created-modified.json
+++ b/swagger/schemas/definitions/created-modified.json
@@ -2,10 +2,12 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions":{
     "created": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "modified": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     }
   }
 }

--- a/swagger/schemas/definitions/device.json
+++ b/swagger/schemas/definitions/device.json
@@ -12,6 +12,16 @@
       "type": "string",
       "enum": ["ok", "missing", "error", "unknown"]
     },
+    "device-status-entry": {
+      "type": "object",
+      "properties":{
+        "errors":    {"$ref":"#/definitions/errors"},
+        "last_seen": {"$ref":"common.json#/definitions/timestamp"},
+        "status":    {"$ref":"#/definitions/status-value"}
+      },
+      "additionalProperties":false,
+      "required": ["last_seen", "status"]      
+    },
     "device": {
       "type": "object",
       "properties": {
@@ -43,13 +53,7 @@
       "type":"object",
       "patternProperties": {
         "^[0-9a-z.@_-]*$":{
-          "properties":{
-            "errors":    {"$ref":"#/definitions/errors"},
-            "last_seen": {"$ref":"common.json#/definitions/timestamp"},
-            "status":    {"$ref":"#/definitions/status-value"}
-          },
-          "additionalProperties":false,
-          "required": ["last_seen", "status"]
+          "$ref": "#/definitions/device-status-entry"
         }      
       }
     }

--- a/swagger/schemas/definitions/device.json
+++ b/swagger/schemas/definitions/device.json
@@ -33,21 +33,24 @@
         "interval":  {"$ref":"#/definitions/interval"},
         "last_seen": {"$ref":"common.json#/definitions/timestamp"}
       },
+      "x-sdk-model": "device",
       "additionalProperties": false
     },
     "device-input":{
-        "type": "object",
-        "properties": {
-          "interval":       {"$ref":"#/definitions/interval"},
-          "errors":         {"$ref":"#/definitions/errors"},
-          "info":           {"$ref":"common.json#/definitions/info"}
-        },
-        "additionalProperties": false
+      "type": "object",
+      "properties": {
+        "interval":       {"$ref":"#/definitions/interval"},
+        "errors":         {"$ref":"#/definitions/errors"},
+        "info":           {"$ref":"common.json#/definitions/info"}
+      },
+      "x-sdk-model": "device",
+      "additionalProperties": false
     },
     "device-output": {
       "type": "object",
       "allOf": [{"$ref":"#/definitions/device"}],
-      "required": ["_id", "name", "method", "last_seen"]
+      "required": ["_id", "name", "method", "last_seen"],
+      "x-sdk-model": "device"
     },
     "device-status": {
       "type":"object",

--- a/swagger/schemas/definitions/download.json
+++ b/swagger/schemas/definitions/download.json
@@ -9,6 +9,7 @@
                 "-": {"$ref": "#/definitions/filter-items"},
                 "minus": {"$ref": "#/definitions/filter-items"}
             },
+            "x-sdk-ignore-properties": ["+", "-"],
             "additionalProperties": false
         },
         "filter-items": {            

--- a/swagger/schemas/definitions/file.json
+++ b/swagger/schemas/definitions/file.json
@@ -61,9 +61,10 @@
             "created":     {"$ref":"created-modified.json#/definitions/created"},
             "modified":    {"$ref":"created-modified.json#/definitions/modified"},
             "size":        {"$ref":"#/definitions/size"},
-            "info_exists": {"type": "boolean", "default": false}
+            "info_exists": {"type": "boolean"}
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "x-sdk-model": "file-entry"
         },
         "file-input":{
             "type": "object",
@@ -76,7 +77,8 @@
               "tags":           {"$ref":"#/definitions/tags"},
               "info":           {"$ref":"common.json#/definitions/info"}
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "x-sdk-model": "file-entry"
         },
         "file-update":{
             "type": "object",
@@ -85,12 +87,14 @@
               "modality":       {"$ref":"#/definitions/modality"},
               "measurements":   {"$ref":"#/definitions/measurements"}
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "x-sdk-model": "file-entry"
         },
         "file-output":{
           "type": "object",
           "allOf": [{"$ref":"#/definitions/file-entry"}],
-          "required":["modified", "size"]
+          "required":["modified", "size"],
+          "x-sdk-model": "file-entry"
         },
         "file-reference": {
           "type": "object",

--- a/swagger/schemas/definitions/file.json
+++ b/swagger/schemas/definitions/file.json
@@ -41,7 +41,7 @@
           "maxLength":106
         },
         "size":{"type":"integer"},
-        "file": {
+        "file-entry": {
           "type": "object",
           "properties": {
             "name":           {"$ref":"#/definitions/name"},
@@ -89,7 +89,7 @@
         },
         "file-output":{
           "type": "object",
-          "allOf": [{"$ref":"#/definitions/file"}],
+          "allOf": [{"$ref":"#/definitions/file-entry"}],
           "required":["modified", "size"]
         },
         "file-reference": {

--- a/swagger/schemas/definitions/file.json
+++ b/swagger/schemas/definitions/file.json
@@ -61,7 +61,7 @@
             "created":     {"$ref":"created-modified.json#/definitions/created"},
             "modified":    {"$ref":"created-modified.json#/definitions/modified"},
             "size":        {"$ref":"#/definitions/size"},
-            "info_exists": {"type": "boolean"}
+            "info_exists": {"type": "boolean", "default": false}
           },
           "additionalProperties": false
         },

--- a/swagger/schemas/definitions/gear.json
+++ b/swagger/schemas/definitions/gear.json
@@ -159,6 +159,7 @@
                 "url",
                 "version"
             ],
+            "x-sdk-include-empty": [ "config", "inputs" ],
             "additionalProperties": false
         },
         "gear-category": {

--- a/swagger/schemas/definitions/gear.json
+++ b/swagger/schemas/definitions/gear.json
@@ -164,7 +164,6 @@
         },
         "gear-category": {
             "type": "string",
-            "enum": [ "utility", "analysis", "converter", "qa" ],
             "description": "The gear category"
         },
         "gear-doc": {

--- a/swagger/schemas/definitions/group.json
+++ b/swagger/schemas/definitions/group.json
@@ -23,7 +23,8 @@
               }
             }
           },
-          "additionalProperties":false
+          "additionalProperties":false,
+          "x-sdk-model": "group"
         },
         "group-input":{
           "type": "object",
@@ -31,7 +32,8 @@
             "_id":{"$ref":"common.json#/definitions/string-id"},
             "label": {"$ref": "#/definitions/label"}
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "x-sdk-model": "group"
         },
         "group-metadata-input": {
           "type": "object",
@@ -43,7 +45,8 @@
         "group-output":{
           "type": "object",
           "allOf": [{"$ref":"#/definitions/group"}],
-          "required": ["permissions", "created","modified","_id"]
+          "required": ["permissions", "created","modified","_id"],
+          "x-sdk-model": "group"
         },
         "group-new-output": {
           "type": "object",
@@ -60,7 +63,8 @@
         "project-group-output":{
           "type": "object",
           "allOf": [{"$ref":"#/definitions/group"}],
-          "required": ["_id"]
+          "required": ["_id"],
+          "x-sdk-model": "group"
         },
         "project-group-output-list":{
             "type":"array",

--- a/swagger/schemas/definitions/group.json
+++ b/swagger/schemas/definitions/group.json
@@ -15,7 +15,13 @@
             "label": {"$ref": "#/definitions/label"},
             "permissions": {"$ref": "permission.json#/definitions/permission-output-list"},
             "created": {"$ref":"created-modified.json#/definitions/created"},
-            "modified": {"$ref":"created-modified.json#/definitions/modified"}
+            "modified": {"$ref":"created-modified.json#/definitions/modified"},
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
           "additionalProperties":false
         },
@@ -44,7 +50,8 @@
           "properties": {
             "_id": {"$ref":"common.json#/definitions/string-id"}
           },
-          "required": ["_id"]
+          "required": ["_id"],
+          "x-sdk-return": "_id"
         },
         "group-output-list":{
             "type":"array",

--- a/swagger/schemas/definitions/info.json
+++ b/swagger/schemas/definitions/info.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions": {
         "info-add-remove": {
+            "type": "object",
             "properties": {
                 "set":      {"type": "object", "minProperties": 1},
                 "delete":   {
@@ -16,6 +17,7 @@
             "additionalProperties": false            
         },
         "info-replace": {
+            "type": "object",
             "properties": {
                 "replace": {"type": "object"}
             },

--- a/swagger/schemas/definitions/job.json
+++ b/swagger/schemas/definitions/job.json
@@ -8,7 +8,10 @@
     "inputs-item": {
       "type":"object",
       "properties":{
-        "type":{"enum":["http", "scitran"]},
+        "type":{
+          "type": "string",
+          "enum":["http", "scitran"]
+        },
         "uri":{"type":"string"},
         "location":{"type":"string"},
         "vu":{"type":"string"}

--- a/swagger/schemas/definitions/job.json
+++ b/swagger/schemas/definitions/job.json
@@ -152,7 +152,8 @@
         "saved_files":{"$ref":"#/definitions/saved_files"},
         "produced_metadata":{"$ref":"#/definitions/produced-metadata"}
       },
-      "additionalProperties":false
+      "additionalProperties":false,
+      "x-sdk-model":"job"
     },
     "job-input": {
       "type":"object",
@@ -164,7 +165,8 @@
         "config":{"$ref":"#/definitions/config"}
       },
       "required": ["gear_id"],
-      "additionalProperties":false
+      "additionalProperties":false,
+      "x-sdk-model":"job"
     },
     "job-output": {
       "type": "object",
@@ -172,7 +174,8 @@
       "required": [
         "id", "gear_id", "inputs", "config",
         "destination", "tags", "state", "attempt"
-      ]
+      ],
+      "x-sdk-model":"job"
     }
   }
 }

--- a/swagger/schemas/definitions/note.json
+++ b/swagger/schemas/definitions/note.json
@@ -10,7 +10,8 @@
       "properties":{
         "text":{"$ref":"#/definitions/text"}
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "x-sdk-model": "note"
     },
     "notes-list-input": {
       "type": "array",
@@ -26,7 +27,8 @@
         "user":{"$ref":"common.json#/definitions/user-id"}
       },
       "additionalProperties": false,
-      "required":["_id", "text", "created", "modified", "user"]
+      "required":["_id", "text", "created", "modified", "user"],
+      "x-sdk-model": "note"
     },
     "notes-list-output":{
       "type":"array",

--- a/swagger/schemas/definitions/note.json
+++ b/swagger/schemas/definitions/note.json
@@ -1,7 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
-    "text":             {"type": "string"},
+    "text": {
+      "type": "string",
+      "x-sdk-positional": true
+    },
     "note-input":{
       "type":"object",
       "properties":{

--- a/swagger/schemas/definitions/packfile.json
+++ b/swagger/schemas/definitions/packfile.json
@@ -47,7 +47,8 @@
                 "packfile":    {"$ref":"#/definitions/packfile-packfile-input"}
             },
             "required": ["project", "session", "acquisition", "packfile"],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "packfile"
         },
         "packfile-start": {
             "type":"object",

--- a/swagger/schemas/definitions/packfile.json
+++ b/swagger/schemas/definitions/packfile.json
@@ -52,8 +52,9 @@
         "packfile-start": {
             "type":"object",
             "properties":{
-                "token":{"$ref":"common.json#/definitions/objectid"}
-            }            
+                "token":{"type": "string"}
+            },
+            "x-sdk-return": "token"
         }
     }
 }

--- a/swagger/schemas/definitions/permission.json
+++ b/swagger/schemas/definitions/permission.json
@@ -11,11 +11,13 @@
         "_id":{"$ref":"common.json#/definitions/user-id"},
         "access":{"$ref":"#/definitions/access"}
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "x-sdk-model": "permission"
     },
     "permission-output-default-required":{
       "allOf":[{"$ref":"#/definitions/permission"}],
-      "required":["_id", "access"]
+      "required":["_id", "access"],
+      "x-sdk-model": "permission"
     },
     "permission-output-list": {
       "type": "array",

--- a/swagger/schemas/definitions/permission.json
+++ b/swagger/schemas/definitions/permission.json
@@ -1,7 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
-    "access":         { "enum": ["ro", "rw", "admin"] },
+    "access": { 
+      "type": "string",
+      "enum": ["ro", "rw", "admin"] 
+    },
     "permission":{
       "type":"object",
       "properties":{

--- a/swagger/schemas/definitions/project.json
+++ b/swagger/schemas/definitions/project.json
@@ -10,7 +10,8 @@
                 "description":  {"$ref":"common.json#/definitions/description"},
                 "group":        {"$ref":"common.json#/definitions/string-id"}
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "project"
         },
         "project-metadata-input": {
             "type": "object",
@@ -52,7 +53,8 @@
                     "items":{"$ref":"analysis.json#/definitions/analysis-output"}
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "project"
         }
     }
 }

--- a/swagger/schemas/definitions/rule.json
+++ b/swagger/schemas/definitions/rule.json
@@ -35,7 +35,8 @@
                 "all":        { "$ref": "#/definitions/rule-items" },
                 "disabled":   { "type": "boolean" }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "rule"
         },
 
         "rule-output": {
@@ -47,7 +48,8 @@
                 "any":      { "$ref": "#/definitions/rule-items" },
                 "all":      { "$ref": "#/definitions/rule-items" },
                 "disabled": { "type": "boolean" }
-            }
+            },
+            "x-sdk-model": "rule"
         }
     }
 }

--- a/swagger/schemas/definitions/session.json
+++ b/swagger/schemas/definitions/session.json
@@ -18,7 +18,8 @@
                 "timezone":     {"$ref":"container.json#/definitions/timezone"},
                 "subject":      {"$ref": "subject.json#/definitions/subject-input"}
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "session"
         },
         "session-metadata-input": {
             "type": "object",
@@ -69,7 +70,8 @@
                     "items":{"$ref":"analysis.json#/definitions/analysis-output"}
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "session"
         },
         "session-jobs-output": {
             "type": "object",

--- a/swagger/schemas/definitions/session.json
+++ b/swagger/schemas/definitions/session.json
@@ -79,6 +79,7 @@
                     "items":{"$ref": "job.json#/definitions/job-output"}
                 },
                 "containers":{
+                    "type": "object",
                     "patternProperties": {
                         "^[a-fA-F0-9]{24}$":{
                             "type": "object"

--- a/swagger/schemas/definitions/subject.json
+++ b/swagger/schemas/definitions/subject.json
@@ -5,10 +5,24 @@
         "firstname":        { "type": "string", "maxLength": 64 },
         "lastname":         { "type": "string", "maxLength": 64 },
         "age":              { "type": ["integer", "null"] },
-        "sex":              { "type": "string", "enum": ["male", "female", "other", "unknown", null] },
-        "race":             { "type": "string", "enum": ["American Indian or Alaska Native", "Asian", "Native Hawaiian or Other Pacific Islander", "Black or African American", "White", "More Than One Race", "Unknown or Not Reported", null] },
-        "ethnicity":        { "type": "string", "enum": ["Not Hispanic or Latino", "Hispanic or Latino", "Unknown or Not Reported", null] },
-
+        "sex": { 
+            "oneOf": [
+                            { "type": "null"},
+                            { "type": "string", "enum": ["male", "female", "other", "unknown"] }
+            ]
+        },
+        "race": {
+            "oneOf": [
+                            { "type": "null"},
+                            { "type": "string", "enum": ["American Indian or Alaska Native", "Asian", "Native Hawaiian or Other Pacific Islander", "Black or African American", "White", "More Than One Race", "Unknown or Not Reported"] }
+            ]
+        },
+        "ethnicity": {
+            "oneOf": [
+                            { "type": "null"},
+                            { "type": "string", "enum": ["Not Hispanic or Latino", "Hispanic or Latino", "Unknown or Not Reported"] }
+            ]
+        },
         "code":             { "type": "string", "maxLength": 64 },
         "tags":             { "type": "array", "items": {"type": "string"} },
         "subject-input":{

--- a/swagger/schemas/definitions/subject.json
+++ b/swagger/schemas/definitions/subject.json
@@ -45,7 +45,8 @@
                   "items":{"$ref":"file.json#/definitions/file-input"}
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "subject"
         },
         "subject-output":{
             "type": "object",
@@ -68,11 +69,13 @@
                   "items":{"$ref":"file.json#/definitions/file-output"}
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "x-sdk-model": "subject"
         },
         "subject-output-default-required":{
             "allOf":[{"$ref":"#/definitions/subject-output"}],
-            "required":["_id"]
+            "required":["_id"],
+            "x-sdk-model": "subject"
         }
     }
 }

--- a/swagger/schemas/definitions/subject.json
+++ b/swagger/schemas/definitions/subject.json
@@ -5,9 +5,9 @@
         "firstname":        { "type": "string", "maxLength": 64 },
         "lastname":         { "type": "string", "maxLength": 64 },
         "age":              { "type": ["integer", "null"] },
-        "sex":              { "enum": ["male", "female", "other", "unknown", null] },
-        "race":             { "enum": ["American Indian or Alaska Native", "Asian", "Native Hawaiian or Other Pacific Islander", "Black or African American", "White", "More Than One Race", "Unknown or Not Reported", null] },
-        "ethnicity":        { "enum": ["Not Hispanic or Latino", "Hispanic or Latino", "Unknown or Not Reported", null] },
+        "sex":              { "type": "string", "enum": ["male", "female", "other", "unknown", null] },
+        "race":             { "type": "string", "enum": ["American Indian or Alaska Native", "Asian", "Native Hawaiian or Other Pacific Islander", "Black or African American", "White", "More Than One Race", "Unknown or Not Reported", null] },
+        "ethnicity":        { "type": "string", "enum": ["Not Hispanic or Latino", "Hispanic or Latino", "Unknown or Not Reported", null] },
 
         "code":             { "type": "string", "maxLength": 64 },
         "tags":             { "type": "array", "items": {"type": "string"} },

--- a/swagger/schemas/definitions/tag.json
+++ b/swagger/schemas/definitions/tag.json
@@ -3,6 +3,7 @@
   "definitions": {
     "value":             {"type": "string", "minLength": 1, "maxLength": 32},
     "tag":{
+      "type": "object",
       "properties":{
         "value":{"$ref":"#/definitions/value"}
       },

--- a/swagger/schemas/definitions/tag.json
+++ b/swagger/schemas/definitions/tag.json
@@ -1,7 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
-    "value":             {"type": "string", "minLength": 1, "maxLength": 32},
+    "value": {
+      "type": "string", 
+      "minLength": 1, 
+      "maxLength": 32,
+      "x-sdk-positional": true
+    },
     "tag":{
       "type": "object",
       "properties":{
@@ -13,7 +18,7 @@
     "tag-list":{
       "type":"array",
       "items":{
-        "allOf":[{"$ref":"#/definitions/tag"}]
+        "allOf":[{"type":"string"}]
       }
     }
   }

--- a/swagger/schemas/definitions/user.json
+++ b/swagger/schemas/definitions/user.json
@@ -37,7 +37,7 @@
       "properties":{
         "key":            {"type": "string"},
         "created":        {"$ref":"created-modified.json#/definitions/created"},
-        "last_used":      {}
+        "last_used":      {"$ref":"common.json#/definitions/timestamp"}
       },
       "additionalProperties":false
     },

--- a/swagger/schemas/definitions/user.json
+++ b/swagger/schemas/definitions/user.json
@@ -57,7 +57,8 @@
         "firstlogin":{"$ref":"#/definitions/firstlogin"},
         "lastlogin":{"$ref":"#/definitions/lastlogin"}
       },
-      "additionalProperties":false
+      "additionalProperties":false,
+      "x-sdk-model": "user"
     },
     "user-output":{
       "type":"object",
@@ -77,7 +78,8 @@
         "created":{"$ref":"created-modified.json#/definitions/created"},
         "modified":{"$ref":"created-modified.json#/definitions/modified"}
       },
-      "additionalProperties":false
+      "additionalProperties":false,
+      "x-sdk-model": "user"
     },
     "user-output-api-key": {
       "type":"object",
@@ -102,7 +104,8 @@
       "required":[
          "_id", "firstname", "lastname",
          "root", "email", "created", "modified"
-      ]      
+      ],
+      "x-sdk-model": "user"      
     }
   }
 }

--- a/swagger/schemas/input/analysis.json
+++ b/swagger/schemas/input/analysis.json
@@ -2,6 +2,6 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Analysis",
     "type": "object",
-	"allOf":[{"$ref":"../definitions/analysis.json#/definitions/analysis-input"}],
+	"allOf":[{"$ref":"../definitions/analysis.json#/definitions/analysis-input-any"}],
     "required": ["label"]
 }

--- a/swagger/schemas/output/login-output.json
+++ b/swagger/schemas/output/login-output.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf":[{"$ref":"../definitions/auth.json#/definitions/login-output"}],
+  "example": {
+  	"token": "MjeuawZcctfRdCOmx_C6oYXK4sLHd2Dhc_oZpkXPPkxHizhNgwFWcrrKGA49BEnK"
+  }
+}

--- a/swagger/schemas/output/logout-output.json
+++ b/swagger/schemas/output/logout-output.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf":[{"$ref":"../definitions/auth.json#/definitions/logout-output"}],
+  "example": {
+  	"tokens_removed": 1
+  }
+}

--- a/swagger/schemas/output/user-new.json
+++ b/swagger/schemas/output/user-new.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
-	"$ref": "../definitions/common.json#/definitions/object-created",
+	"allOf": [{"$ref": "../definitions/common.json#/definitions/object-created"}],
 	"example": {
 		"_id": "jane.doe@gmail.com"
 	}

--- a/swagger/schemas/output/user.json
+++ b/swagger/schemas/output/user.json
@@ -2,12 +2,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "allOf":[
-    {"$ref":"../definitions/user.json#/definitions/user-output"},
-    {
-      "required":[
-         "_id", "firstname", "lastname",
-         "root", "email", "created", "modified"
-         ]
-    }
+    {"$ref":"../definitions/user.json#/definitions/user-output"}
+  ],
+  "required":[
+    "_id", "firstname", "lastname",
+    "root", "email", "created", "modified"
   ]
 }

--- a/swagger/support/schema-transpiler.js
+++ b/swagger/support/schema-transpiler.js
@@ -74,11 +74,6 @@ SchemaTranspiler.prototype.draft4ToOpenApi2 = function(schema, defs, id) {
 		schema.type = this._selectTypeFromArray(schema.type, id);
 	}
 
-	if( schema.allOf && schema.allOf.length === 1 && !schema.required ) {
-		// Merge all of object with top-level object
-		schema = this._flattenAllOf(schema, id);
-	}
-
 	// Check for top-level $ref, allOf, anyOf, oneOf
 	if( schema.$ref && schema.example ) {
 		// Special case, if object has $ref and example, then

--- a/swagger/support/schema-transpiler.js
+++ b/swagger/support/schema-transpiler.js
@@ -97,7 +97,11 @@ SchemaTranspiler.prototype.draft4ToOpenApi2 = function(schema, defs, id) {
 	}
 
 	if( schema.patternProperties ) {
-		this.warn(id, '"patternProperties" is not supported in OpenApi 2');
+		var keys = _.keys(schema.patternProperties);
+		if( keys.length > 1 ) {
+			this.warn(id, 'Can only support one type in additionalProperties (from "patternProperties")');
+		}
+		schema.additionalProperties = this.draft4ToOpenApi2(schema.patternProperties[keys[0]], defs, id);
 		delete schema.patternProperties;
 	}
 

--- a/swagger/support/schemas.js
+++ b/swagger/support/schemas.js
@@ -15,8 +15,23 @@ var PRIMITIVE_TYPES = {
 	'null': true
 };
 
+var OBJECT_PROPERTIES = [ 'allOf', 'anyOf', 'oneOf', 'multipleOf', 'not', 
+	'if', 'then', 'else', 'properties', 'additionalProperties' ];
+
 function isPrimitiveType(type) {
 	return !!PRIMITIVE_TYPES[type];
+}
+
+function isEmptyObject(schema) {
+	if( schema.type && schema.type !== 'object' ) {
+		return false;
+	}
+	if( schema.$ref ) {
+		return false;
+	}
+	return !_.some(OBJECT_PROPERTIES, function(key) {
+		return !!schema[key];
+	});
 }
 
 function normalizeName(name) {
@@ -200,6 +215,7 @@ Schemas.prototype.isPrimitiveDef = function(name) {
 };
 
 Schemas.isPrimitiveType = isPrimitiveType;
+Schemas.isEmptyObject = isEmptyObject;
 
 Schemas.prototype.getComplexDefinitions = function() {
 	return _.pickBy(this.definitions, function(value) {

--- a/swagger/support/schemas.js
+++ b/swagger/support/schemas.js
@@ -199,6 +199,7 @@ Schemas.prototype.isPrimitiveDef = function(name) {
 	return false;
 };
 
+Schemas.isPrimitiveType = isPrimitiveType;
 
 Schemas.prototype.getComplexDefinitions = function() {
 	return _.pickBy(this.definitions, function(value) {

--- a/swagger/support/spec/schema-transpiler-spec.js
+++ b/swagger/support/spec/schema-transpiler-spec.js
@@ -72,13 +72,15 @@ describe('SchemaTranspiler draft4ToOpenApi2', function() {
 		});
 	});
 
-	it('should flatten allOf with one element', function() {
+	it('should not flatten allOf with one element', function() {
 		var schema = {
 			allOf: [{$ref:'#/definitions/Foo'}]
 		};
 
 		var result = transpiler.toOpenApi2(schema);
-		expect(result).toEqual({$ref:'#/definitions/Foo'});
+		expect(result).toEqual({
+			allOf: [{$ref:'#/definitions/Foo'}]
+		});
 	});
 
 	it('should merge properties for anyOf', function() {
@@ -122,28 +124,16 @@ describe('SchemaTranspiler draft4ToOpenApi2', function() {
 		expect(result).toEqual({});
 	});
 
-	it('should flatten array elements', function() {
-		var defs = {
-				Foo: {
-					type: 'object',
-					properties: {
-						updated: {type: 'boolean'}
-					},
-					required: ['updated']
-				}
-			},
-			schema = {
+	it('should not flatten array elements', function() {
+		var schema = {
 				type: 'array',
 				items: {
 					allOf: [{$ref:'#/definitions/Foo'}]
 				}
 			};
 		
-		var result = transpiler.toOpenApi2(schema, defs);
-		expect(result).toEqual({
-			type: 'array',
-			items: {$ref:'#/definitions/Foo'}
-		});
+		var result = transpiler.toOpenApi2(schema);
+		expect(result).toEqual(schema);
 	});
 
 	it('should recurse into properties', function() {
@@ -160,7 +150,7 @@ describe('SchemaTranspiler draft4ToOpenApi2', function() {
 			type: 'object',
 			properties: {
 				bar: {type: 'string'},
-				foo: {$ref: '#/definitions/Foo'}
+				foo: {allOf: [{$ref: '#/definitions/Foo'}]}
 			}
 		});
 	});

--- a/swagger/support/tasks/simplify-swagger.js
+++ b/swagger/support/tasks/simplify-swagger.js
@@ -158,7 +158,17 @@ module.exports = function(grunt) {
 					grunt.log.writeln('WARNING Cannot simplify "allOf" definition at: ' + formatPath(path));
 				}
 			} else {
-				grunt.log.writeln('WARNING Cannot simplify "allOf" definition at: ' + formatPath(path));
+				// Still replace aliases
+				for( var i = 0; i < schema.allOf.length; i++ ) {
+					var alias = context.aliases[schema.allOf[i].$ref];
+					if( alias ) {
+						schema.allOf[i] = _.cloneDeep(alias);
+					}
+				}
+				// It's not an error to not simplify polymorphic types
+				if( !schema['x-discriminator-value'] ) {
+					grunt.log.writeln('WARNING Cannot simplify "allOf" definition at: ' + formatPath(path));
+				}
 			}
 		} else if( schema.$ref ) {
 			// Replace alias for $ref fields

--- a/swagger/support/tasks/simplify-swagger.js
+++ b/swagger/support/tasks/simplify-swagger.js
@@ -106,6 +106,10 @@ module.exports = function(grunt) {
 				} else {
 					grunt.log.writeln('ERROR '.red + 'Cannot find alias for: ' + path + ' (' + schema.allOf[0].$ref + ')');
 				}
+			} else if( schema.$ref ) {
+				// Replace pure references
+				context.aliases[path] = schema;
+				delete defs[k];
 			} else if( Schemas.isPrimitiveType(schema.type) ) {
 				// For simple types in definitions, alias them
 				context.aliases[path] = schema;

--- a/swagger/support/tasks/simplify-swagger.js
+++ b/swagger/support/tasks/simplify-swagger.js
@@ -1,0 +1,92 @@
+'use strict';
+
+module.exports = function(grunt) {
+	var path = require('path');
+	var fs = require('fs');
+	var _ = require('lodash');
+	var yaml = require('js-yaml');
+	var walk = require('../walk');
+	var Schemas = require('../schemas');
+
+	/**
+	 * This task simplifies models in a swagger file.
+	 * @param {object} data Task data
+	 * @param {string} data.src The input file (root level swagger file)
+	 * @param {string} data.dst The output file
+	 */
+	grunt.registerMultiTask('simplifySwagger', 'Simplify models in swagger API file', function() {
+		var srcFile = this.data.src||'swagger.yaml';
+		var dstFile = this.data.dst;
+		
+		if(!fs.existsSync(srcFile)) {
+			grunt.log.error('Could not find:', srcFile);
+			return false;
+		}
+
+		var root = yaml.safeLoad(fs.readFileSync(srcFile).toString());
+
+		// walk through all schemas
+		// That's every definition and every response and body schema
+		root = walk(root, function(obj, path) {
+			if( isSchema(path) ) {
+				return simplifySchema(obj, path);
+			}
+			return obj;
+		});
+
+		var data = JSON.stringify(root, null, 2);
+		fs.writeFileSync(dstFile, data);
+	});
+
+	function formatPath(path) {
+		path = _.map(path, function(el) {
+			return el.replace(/\//g, '~1');
+		});
+		return '#/' + path.join('/');
+	}
+
+	function isSchema(path) {
+		if( path.length === 2 && path[0] === 'definitions' ) {
+			return true;
+		}
+		if( path.length === 4 && path[0] === 'definitions' && path[2] === 'properties' ) {
+			return true;
+		}
+		if( path.length > 1 && path[path.length-1] === 'schema' ) {
+			return true;
+		}
+		return false;
+	}
+
+	function isValidSchema(schema) {
+		return( schema.type || schema.$ref || 
+			schema.allOf || schema.oneOf || schema.anyOf || schema.not );
+	}
+
+	// Performs all of the simplifying steps, and
+	// returns a simplified version of schema
+	function simplifySchema(schema, path) {
+		schema = _.cloneDeep(schema);
+		if( !isValidSchema(schema) ) {
+			grunt.log.writeln('WARNING '.red + 'Invalid schema (no object type specified) at: ' + formatPath(path));
+			schema.type = 'object';
+		} else if( schema.type === 'array' && schema.items ) {
+			path = _.concat(path, 'items');
+			schema.items = simplifySchema(schema.items, path);				
+		} else if( schema.allOf ) {
+			if( schema.allOf.length === 1 ) {
+				if( schema.allOf[0].$ref || Schemas.isPrimitiveType(schema.allOf[0].type) ) {
+					schema = schema.allOf[0];
+				} else {
+					grunt.log.writeln('WARNING: Cannot simplify "allOf" definition at: ' + formatPath(path));
+				}
+			} else {
+				grunt.log.writeln('WARNING: Cannot simplify "allOf" definition at: ' + formatPath(path));
+			}
+		}
+		return schema;
+	}
+
+};
+
+	

--- a/swagger/support/tasks/simplify-swagger.js
+++ b/swagger/support/tasks/simplify-swagger.js
@@ -122,6 +122,11 @@ module.exports = function(grunt) {
 	// returns a simplified version of schema
 	function simplifySchema(schema, path, context) {
 		schema = _.cloneDeep(schema);
+		// If an x-sdk-schema is specified, use that
+		if( schema['x-sdk-schema'] ) {
+			schema = schema['x-sdk-schema'];
+		}
+
 		if( !isValidSchema(schema) ) {
 			grunt.log.writeln('WARNING '.red + 'Invalid schema (no object type specified) at: ' + formatPath(path));
 			schema.type = 'object';

--- a/swagger/support/tasks/simplify-swagger.js
+++ b/swagger/support/tasks/simplify-swagger.js
@@ -25,11 +25,18 @@ module.exports = function(grunt) {
 
 		var root = yaml.safeLoad(fs.readFileSync(srcFile).toString());
 
+		var context = {
+			aliases: {}
+		};
+
+		// Walk through definitions, simplifying models where we can
+		simplifyDefinitions(root, context);
+
 		// walk through all schemas
 		// That's every definition and every response and body schema
 		root = walk(root, function(obj, path) {
 			if( isSchema(path) ) {
-				return simplifySchema(obj, path);
+				return simplifySchema(obj, path, context);
 			}
 			return obj;
 		});
@@ -43,6 +50,17 @@ module.exports = function(grunt) {
 			return el.replace(/\//g, '~1');
 		});
 		return '#/' + path.join('/');
+	}
+
+	function unformatPath(path) {
+		if( !path.substr ) {
+			grunt.log.writeln('Invalid path: ' + JSON.stringify(path));
+			return path;
+		}
+		var parts = path.substr(2).split('/');
+		return _.map(parts, function(el) {
+			return el.replace(/~1/g, '/');
+		});
 	}
 
 	function isSchema(path) {
@@ -63,30 +81,81 @@ module.exports = function(grunt) {
 			schema.allOf || schema.oneOf || schema.anyOf || schema.not );
 	}
 
+	function isDefinition(path) {
+		return ( path.length === 2 &&  path[0] === 'definitions' );
+	}
+
+	function simplifyDefinitions(root, context) {
+		var defs = root.definitions||{};
+		var keys = _.keys(defs);
+
+		_.each(keys, function(k) {
+			var schema = defs[k];
+			var path = formatPath(['definitions', k]);
+
+			if( schema.type === 'array' ) {
+				// Setup an alias for array objects (don't generate a model)
+				context.aliases[path] = simplifySchema(schema, ['definitions', k], context);
+				delete defs[k];
+			} else if( schema.allOf && schema.allOf.length === 1 && schema.allOf[0].$ref ) {
+				// For objects that are just aliases for other objects, copy all of the properties
+				var target = unformatPath(schema.allOf[0].$ref);
+				var targetObj = resolvePathObj(root, target);
+				if( targetObj ) {
+					defs[k] = targetObj;
+				} else {
+					grunt.log.writeln('ERROR '.red + 'Cannot find alias for: ' + path + ' (' + schema.allOf[0].$ref + ')');
+				}
+			}
+		});
+	}
+
 	// Performs all of the simplifying steps, and
 	// returns a simplified version of schema
-	function simplifySchema(schema, path) {
+	function simplifySchema(schema, path, context) {
 		schema = _.cloneDeep(schema);
 		if( !isValidSchema(schema) ) {
 			grunt.log.writeln('WARNING '.red + 'Invalid schema (no object type specified) at: ' + formatPath(path));
 			schema.type = 'object';
 		} else if( schema.type === 'array' && schema.items ) {
 			path = _.concat(path, 'items');
-			schema.items = simplifySchema(schema.items, path);				
+			schema.items = simplifySchema(schema.items, path, context);
 		} else if( schema.allOf ) {
 			if( schema.allOf.length === 1 ) {
-				if( schema.allOf[0].$ref || Schemas.isPrimitiveType(schema.allOf[0].type) ) {
+				if( schema.allOf[0].$ref ) {
+					var alias = context.aliases[schema.allOf[0].$ref];
+					// Replace alias for allOf fields
+					if( alias ) {
+						schema = _.cloneDeep(alias); 
+					} else {
+						schema = schema.allOf[0];
+					}
+				} else if( Schemas.isPrimitiveType(schema.allOf[0].type) ) {
 					schema = schema.allOf[0];
 				} else {
-					grunt.log.writeln('WARNING: Cannot simplify "allOf" definition at: ' + formatPath(path));
+					grunt.log.writeln('WARNING Cannot simplify "allOf" definition at: ' + formatPath(path));
 				}
 			} else {
-				grunt.log.writeln('WARNING: Cannot simplify "allOf" definition at: ' + formatPath(path));
+				grunt.log.writeln('WARNING Cannot simplify "allOf" definition at: ' + formatPath(path));
+			}
+		} else if( schema.$ref ) {
+			// Replace alias for $ref fields
+			var alias = context.aliases[schema.$ref];
+			if( alias ) {
+				schema = _.cloneDeep(alias); 
 			}
 		}
 		return schema;
 	}
 
+	function resolvePathObj(root, path) {
+		var current = root;
+		path = path.slice();
+		while( current && path.length ) {
+			current = current[path.shift()];
+		}
+		return current;
+	}
 };
 
 	

--- a/swagger/support/tasks/simplify-swagger.js
+++ b/swagger/support/tasks/simplify-swagger.js
@@ -106,6 +106,10 @@ module.exports = function(grunt) {
 				} else {
 					grunt.log.writeln('ERROR '.red + 'Cannot find alias for: ' + path + ' (' + schema.allOf[0].$ref + ')');
 				}
+			} else if( Schemas.isPrimitiveType(schema.type) ) {
+				// For simple types in definitions, alias them
+				context.aliases[path] = schema;
+				delete defs[k];
 			}
 		});
 	}

--- a/swagger/templates/analyses-list.yaml
+++ b/swagger/templates/analyses-list.yaml
@@ -52,6 +52,7 @@ template: |
         in: query
         type: boolean
         description: Return job as an object instead of an id
+        x-sdk-default: 'true'
     responses:
       '200':
         description: Returns the id of the analysis that was created.

--- a/swagger/templates/analysis-item.yaml
+++ b/swagger/templates/analysis-item.yaml
@@ -36,6 +36,7 @@ template: |
           in: query
           type: boolean
           description: Return job as an object instead of an id
+          x-sdk-default: 'true'
       responses:
         '200':
           description: ''

--- a/swagger/templates/container-item.yaml
+++ b/swagger/templates/container-item.yaml
@@ -40,6 +40,7 @@ template: |
     parameters:
       - in: body
         name: body
+        required: true
         schema:
           $ref: {{{update-input-schema}}}
     responses:

--- a/swagger/templates/container.yaml
+++ b/swagger/templates/container.yaml
@@ -24,12 +24,13 @@ template: |
           $ref: {{{list-output-schema}}}
   post:
     summary: Create a new {{resource}}
-    operationId: create_{{resource}}
+    operationId: add_{{resource}}
     tags:
       - '{{tag}}'
     parameters:
       - in: body
         name: body
+        required: true
         schema:
           $ref: {{{create-input-schema}}}
     responses:

--- a/swagger/templates/file-item.yaml
+++ b/swagger/templates/file-item.yaml
@@ -28,7 +28,7 @@ template: |
         - Make another request with the received ticket id in the "ticket" parameter. A valid "Authorization" header is no longer required.
 
       When "view" is true, [RFC7233](https://tools.ietf.org/html/rfc7233) range request headers are supported.
-    operationId: download_{{resource}}_file
+    operationId: download_file_from_{{resource}}
     tags:
     - '{{tag}}'
     produces:
@@ -55,7 +55,7 @@ template: |
         in: query
         type: string
         description: The filename of a zipfile member to download rather than the entire file
-
+    x-sdk-download-ticket: get_{{resource}}_download_ticket
     responses:
       '200':
         description: ''

--- a/swagger/templates/file-item.yaml
+++ b/swagger/templates/file-item.yaml
@@ -85,7 +85,7 @@ template: |
       - '{{tag}}'
     responses:
       '200':
-        $ref: '#/responses/200:deleted-with-count'
+        $ref: '#/responses/200:modified-with-count'
   put:
     summary: Modify a file's attributes
     operationId: modify_{{resource}}_file

--- a/swagger/templates/file-list-upload.yaml
+++ b/swagger/templates/file-list-upload.yaml
@@ -17,7 +17,7 @@ template: |
       
   post:
     summary: Upload a file to {{resource}}.
-    operationId: upload_{{resource}}_file
+    operationId: upload_file_to_{{resource}}
     tags: 
     - '{{tag}}'
     consumes:

--- a/swagger/templates/notes-note.yaml
+++ b/swagger/templates/notes-note.yaml
@@ -39,6 +39,7 @@ template: |
     parameters:
       - in: body
         name: body
+        required: true
         schema:
           $ref: schemas/input/note.json
     responses:

--- a/swagger/templates/notes.yaml
+++ b/swagger/templates/notes.yaml
@@ -22,6 +22,7 @@ template: |
     parameters:
       - name: body
         in: body
+        required: true
         schema:
           $ref: schemas/input/note.json
     responses:

--- a/swagger/templates/tags.yaml
+++ b/swagger/templates/tags.yaml
@@ -23,6 +23,7 @@ template: |
     parameters:
       - name: body
         in: body
+        required: true
         schema:
           $ref: schemas/input/tag.json
     responses:

--- a/tests/unit_tests/python/test_validators.py
+++ b/tests/unit_tests/python/test_validators.py
@@ -62,7 +62,7 @@ def test_payload():
 
 def test_file_output_valid():
     payload = [{
-        'modified': 'yesterday',
+        'modified': '2018-02-07T17:27:21+00:00',
         'size': 10
     }]
     schema_uri = validators.schema_uri("output", "file-list.json")
@@ -71,13 +71,22 @@ def test_file_output_valid():
 
 def test_file_output_invalid():
     payload = [{
-        'modified': 'yesterday'
+        'modified': '2018-02-07T17:27:21+00:00'
     }]
     schema_uri = validators.schema_uri("output", "file-list.json")
     schema, resolver = validators._resolve_schema(schema_uri)
     with pytest.raises(jsonschema.exceptions.ValidationError):
         validators._validate_json(payload, schema, resolver)
     
+def test_jsonschema_validate_enum_with_null():
+    schema = { 
+        'oneOf': [
+            { 'type': 'null' },
+            { 'type': 'string', 'enum': ['true', 'false'] }
+        ]
+    }
+    jsonschema.validate('true', schema)
+    jsonschema.validate(None, schema)
 
 # ===== Automated Tests =====
 


### PR DESCRIPTION
Generates an additional swagger.json file specifically for codegen. (Note, we don't use the normal output because the simplification step merges input and output models - for example `group-input` and `group-output` become `group`)

This PR also includes some additional docs and doc fixes.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
